### PR TITLE
Basic RISC-V support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,22 +70,22 @@ else
     else
       ARCH_TAG=arm32
     endif
+  else ifeq ($(findstring aarch64,$(ARCH)),aarch64)
+    ARCH_TAG=arm64
+  else ifeq ($(ARCH),ppc64le)
+    ARCH_TAG=ppc64le
+  else ifeq ($(ARCH),riscv64)
+    ARCH_TAG=riscv64
   else
-    ifeq ($(findstring aarch64,$(ARCH)),aarch64)
-      ARCH_TAG=arm64
-    else
-      ifeq ($(ARCH),ppc64le)
-        ARCH_TAG=ppc64le
-      else
-        ARCH_TAG=x86
-      endif
-    endif
+    ARCH_TAG=x86
   endif
 endif
 
 ifneq ($(ARCH),ppc64le)
   ifneq ($(ARCH_TAG),arm32)
-    CXXFLAGS += -momit-leaf-frame-pointer
+    ifneq ($(ARCH_TAG),riscv64)
+      CXXFLAGS += -momit-leaf-frame-pointer
+    endif
   endif
 endif
 

--- a/src/arch.h
+++ b/src/arch.h
@@ -111,6 +111,28 @@ const int PERF_REG_PC = 32;  // PERF_REG_POWERPC_NIP
 #define rmb()             asm volatile ("sync" : : : "memory") // lwsync would do but better safe than sorry
 #define flushCache(addr)  __builtin___clear_cache((char*)(addr), (char*)(addr) + sizeof(instruction_t))
 
+#elif defined(__riscv) && (__riscv_xlen == 64)
+
+typedef unsigned int instruction_t;
+#if defined(__riscv_compressed)
+const instruction_t BREAKPOINT = 0x9002; // EBREAK (compressed form)
+#else
+const instruction_t BREAKPOINT = 0x00100073; // EBREAK
+#endif
+const int BREAKPOINT_OFFSET = 0;
+
+const int SYSCALL_SIZE = sizeof(instruction_t);
+const int FRAME_PC_SLOT = 1;    // return address is at -1 from FP
+const int ADJUST_RET = 0;       // No need for adjustments
+const int PROBE_SP_LIMIT = 0;
+const int PLT_HEADER_SIZE = 24; // Best guess from examining readelf
+const int PLT_ENTRY_SIZE = 24;  // ...same...
+const int PERF_REG_PC = 0;      // PERF_REG_RISCV_PC
+
+#define spinPause()       // No architecture support
+#define rmb()             asm volatile ("fence" : : : "memory")
+#define flushCache(addr)  __builtin___clear_cache((char*)(addr), (char*)(addr) + sizeof(instruction_t))
+
 #else
 
 #error "Compiling on unsupported arch"

--- a/src/stackFrame_riscv64.cpp
+++ b/src/stackFrame_riscv64.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 Andrei Pangin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors: Andrei Pangin and Aleksey Shipilev
+ */
+
+#if defined(__riscv) && (__riscv_xlen == 64)
+
+#include <errno.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include "stackFrame.h"
+
+#define REG(l)  _ucontext->uc_mcontext.__gregs[l]
+
+uintptr_t& StackFrame::pc() {
+    return (uintptr_t&)REG(REG_PC);
+}
+
+uintptr_t& StackFrame::sp() {
+    return (uintptr_t&)REG(REG_SP);
+}
+
+uintptr_t& StackFrame::fp() {
+    return (uintptr_t&)REG(REG_S0);
+}
+
+uintptr_t& StackFrame::retval() {
+    return (uintptr_t&)REG(REG_RA);
+}
+
+uintptr_t StackFrame::arg0() {
+    return (uintptr_t)REG(REG_A0);
+}
+
+uintptr_t StackFrame::arg1() {
+    return (uintptr_t)REG(REG_A0 + 1);
+}
+
+uintptr_t StackFrame::arg2() {
+    return (uintptr_t)REG(REG_A0 + 2);
+}
+
+uintptr_t StackFrame::arg3() {
+    return (uintptr_t)REG(REG_A0 + 3);
+}
+
+void StackFrame::ret() {
+    pc() = REG(REG_RA);
+}
+
+bool StackFrame::popStub(instruction_t* entry, const char* name) {
+    // Not implemented yet.
+    return false;
+}
+
+bool StackFrame::popMethod(instruction_t* entry) {
+    // Not implemented yet.
+    return false;
+}
+
+bool StackFrame::checkInterruptedSyscall() {
+    return retval() == (uintptr_t)-EINTR;
+}
+
+bool StackFrame::isSyscall(instruction_t* pc) {
+    // RISC-V ISA uses ECALL for doing both syscalls and debugger
+    // calls, so this might technically mismatch.
+    return (*pc) == 0x00000073;
+}
+
+#endif // riscv

--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -126,6 +126,10 @@ typedef Elf32_Dyn  ElfDyn;
 #  define R_GLOB_DAT R_AARCH64_GLOB_DAT
 #elif defined(__PPC64__)
 #  define R_GLOB_DAT R_PPC64_GLOB_DAT
+#elif defined(__riscv) && (__riscv_xlen == 64)
+// RISC-V does not have GLOB_DAT relocation, use something neutral,
+// like the impossible relocation number.
+#define R_GLOB_DAT -1
 #else
 #  error "Compiling on unsupported arch"
 #endif


### PR DESCRIPTION
This PR adds the support for building and running on riscv64 platforms. I have built and tested it on HiFive Unmatched board running Ubuntu 22.04, and ran async-profiler with JMH -prof async and bleeding edge mainline JDK 20 build. The flamegraphs seem to make sense: it resolves C2 native code well, resolves compiled code well, etc.

![riscv64-async](https://user-images.githubusercontent.com/1858943/188129298-782e58d3-14af-420b-a1ae-a66d014d44a4.png)

I tested with `-Xint`, `-XX:TieredStopAtLevel=1` (C1), default (C2).

I still call this support "basic", because it is not tested beyound toy examples, and some features (like stub pops) are stubbed out.