### PR TITLE
Action "check": print "OK" result to file

### DIFF
--- a/src/arguments.h
+++ b/src/arguments.h
@@ -230,7 +230,7 @@ class Arguments {
 
     bool hasOutputFile() const {
         return _file != NULL &&
-            (_action == ACTION_STOP || _action == ACTION_DUMP ? _output != OUTPUT_JFR : _action >= ACTION_STATUS);
+            (_action == ACTION_STOP || _action == ACTION_DUMP ? _output != OUTPUT_JFR : _action >= ACTION_CHECK);
     }
 
     bool hasOption(JfrOption option) const {


### PR DESCRIPTION
When running `./profiler.sh` temporary output file is created for the agent.
All other actions write the result to this file both on success and on failure.
Before the fix:
```
./profiler.sh status jps
Profiler is not active

./profiler.sh check -e foo jps
[ERROR] PerfEvents are unsupported on macOS

./profiler.sh check -e cpu jps
# OK is printed to the target process's stdout
```
After the fix:
```
./profiler.sh status jps
Profiler is not active

./profiler.sh check -e foo jps
[ERROR] PerfEvents are unsupported on macOS

./profiler.sh check -e cpu jps
OK
```