### PR TITLE
Improve tree view display

### DIFF
--- a/src/res/tree.html
+++ b/src/res/tree.html
@@ -1,18 +1,25 @@
 <!DOCTYPE html>
 <html lang='en'>
 <head>
-<title>Tree view</title>
+<title>Tree View - Async Profiler</title>
 <meta charset='utf-8'/>
 <style>
-body {
-	font-family: Arial;
+body, input, button {
+	font-family: "Andale Mono", "Monaco", "Consolas", monospace;
+	font-weight: 600;
+}
+input, button {
+	padding: 0.5em 1em
 }
 ul.tree li {
 	list-style-type: none;
 	position: relative;
+	white-space: nowrap;
 }
-ul.tree ul {
-	margin-left: 20px; padding-left: 0;
+ul {
+	margin-left: 0.6em;
+	padding-left: 0.6em;
+	border-left: 1px dashed lightgray;
 }
 ul.tree li ul {
 	display: none;
@@ -22,12 +29,11 @@ ul.tree li.open > ul {
 }
 ul.tree li div:before {
 	height: 1em;
-	padding:0 .1em;
-	font-size: .8em;
+	font-weight: normal;
 	display: block;
 	position: absolute;
-	left: -1.3em;
-	top: .2em;
+	left: -0.9em;
+	color: darkblue;
 }
 ul.tree li > div {
 	display: inline;
@@ -36,10 +42,14 @@ ul.tree li > div {
 	text-decoration: none;
 }
 ul.tree li > div:not(:nth-last-child(2)):before {
-	content: '+';
+	content: '⊕';
+	padding: 0.15em;
+	margin-top: -0.15em;
+	margin-left: -0.15em;
+	background-color: white;
 }
 ul.tree li.open > div:not(:nth-last-child(2)):before {
-	content: '-';
+	content: '⊖';
 }
 .sc {
 	text-decoration: underline;
@@ -130,11 +140,16 @@ for(var i = 0; i < tree.length; i++){
 </script>
 </head>
 <body>
-<div style='padding-left: 25px;'>/*title:*/ view, total /*type:*/: /*count:*/ </div>
-<div style='padding-left: 25px;'><button type='button' onclick='treeView(0)'>++</button><button type='button' onclick='treeView(1)'>--</button>
-<input type='text' id='search' value='' size='35' onkeypress='if(event.keyCode == 13) document.getElementById('searchBtn').click()'>
-<button type='button' id='searchBtn' onclick='search()'>search</button></div>
-<ul class='tree'>
+<div style="margin-left: 0.5em">
+	<div style="margin-bottom: 4px">/*title:*/ view, total /*type:*/: /*count:*/ </div>
+	<div>
+		<button type="button" title="Expand All" onclick="treeView(0)" style="font-weight: normal"><span>⊕</span><span style="margin-left: 0.1em">⊕</span></button>
+		<button type="button" title="Collapse All" onclick="treeView(1)" style="font-weight: normal"><span>⊖</span><span style="margin-left: 0.1em">⊖</span></button>
+		<input type="text" aria-label="Search Text" id="search" value="" size="35" onkeypress="if(event.keyCode == 13) document.getElementById('searchBtn').click()">
+		<button type="button" id="searchBtn" onclick="search()"><span aria-hidden="true">🔎</span> search</button>
+	</div>
+</div>
+<ul class="tree">
 /*tree:*/
 <script>
 addClickActions();


### PR DESCRIPTION
- fix text wrapping for long traces when horizontal scroll is present
- add vertical line aligned on expland/collapse icon for clearer tree
view
- use ⊕ and ⊖ instead of + and - for better visibility
- use monospace font for better numerical alignment
- fix form search on enter key press
- header form small alignment improvements

**Wrapping**

Before:

<img width="1396" alt="image" src="https://user-images.githubusercontent.com/1011245/205391091-8eb49c91-36a1-4a38-b8b7-8f4f4b57cb50.png">

After:

<img width="1271" alt="image" src="https://user-images.githubusercontent.com/1011245/205390983-f04d78a3-15fd-4985-acad-281753943074.png">

**Form & Alignment**

Before:

<img width="1164" alt="image" src="https://user-images.githubusercontent.com/1011245/205391423-8d98bf99-bb5f-4e37-b6df-ea46ce1d0d33.png">

After:

<img width="1169" alt="image" src="https://user-images.githubusercontent.com/1011245/205391745-bb9ab520-9221-4d8a-bd9c-e4c46f67eb90.png">

