### PR TITLE
Support read JFR file chunk by chunk

### DIFF
--- a/src/converter/jfr2flame.java
+++ b/src/converter/jfr2flame.java
@@ -53,7 +53,7 @@ public class jfr2flame {
         long startTicks = args.from != 0 ? toTicks(args.from) : Long.MIN_VALUE;
         long endTicks = args.to != 0 ? toTicks(args.to) : Long.MAX_VALUE;
 
-        for (Event event; (event = jfr.readEvent(eventClass)) != null; ) {
+        for (Event event; (event = jfr.readEvent(eventClass).getEvent()) != null; ) {
             if (event.time >= startTicks && event.time <= endTicks) {
                 if (threadState < 0 || ((ExecutionSample) event).threadState == threadState) {
                     agg.collect(event);

--- a/src/converter/one/jfr/Chunk.java
+++ b/src/converter/one/jfr/Chunk.java
@@ -1,0 +1,53 @@
+package one.jfr;
+
+import one.jfr.event.Event;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+public class Chunk<E extends Event> implements Iterable<E> {
+    private final List<E> events;
+
+    final int nextChunkPos;
+
+    private Chunk(Builder<E> bld) {
+        this.events = bld.events;
+        this.nextChunkPos = bld.nextChunkPos;
+    }
+
+    public boolean isEmpty() {
+        return this.events == null || this.events.size() == 0;
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        return Collections.unmodifiableList(events).iterator();
+    }
+
+    public static <E extends Event> Builder<E> builder() {
+        return new Builder<>();
+    }
+
+    public static final class Builder<E extends Event> {
+        private int nextChunkPos = -1;
+        private List<E> events;
+
+        public Builder() {
+        }
+
+        Builder<E> events(List<E> events) {
+            this.events = events;
+            return this;
+        }
+
+        Builder<E> nextChunkPos(int pos) {
+            this.nextChunkPos = pos;
+            return this;
+        }
+
+        Chunk<E> build() {
+            return new Chunk<>(this);
+        }
+    }
+}

--- a/src/converter/one/jfr/Chunks.java
+++ b/src/converter/one/jfr/Chunks.java
@@ -1,0 +1,54 @@
+package one.jfr;
+
+import one.jfr.event.Event;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public class Chunks<E extends Event> implements Iterable<Chunk<E>> {
+    private final JfrReader reader;
+
+    private Chunk<E> c;
+
+    private final Class<E> cls;
+
+    public Chunks(JfrReader reader) {
+        this(reader, null);
+    }
+
+    public Chunks(JfrReader reader, Class<E> cls) {
+        this.reader = reader;
+        this.cls = cls;
+        this.c = null;
+    }
+
+    @Override
+    public Iterator<Chunk<E>> iterator() {
+        return new Iterator<Chunk<E>>() {
+            @Override
+            public boolean hasNext() {
+                try {
+                    if (c == null)
+                        return reader.ensureBytes(JfrReader.CHUNK_HEADER_SIZE);
+                    return c.nextChunkPos != -1;
+                } catch (IOException ioEx) {
+                    return false;
+                }
+            }
+
+            @Override
+            public Chunk<E> next() {
+                try {
+                    c = reader.nextChunk(c == null ? 0 : c.nextChunkPos, cls);
+                    if (c == null) {
+                        throw new NoSuchElementException("Incomplete JFR file");
+                    }
+                    return c;
+                } catch (IOException ioEx) {
+                    throw new NoSuchElementException("fail to read event");
+                }
+            }
+        };
+    }
+}

--- a/src/converter/one/jfr/JfrReader.java
+++ b/src/converter/one/jfr/JfrReader.java
@@ -78,19 +78,13 @@ public class JfrReader implements Closeable {
 
         buf.flip();
         ensureBytes(CHUNK_HEADER_SIZE);
-        if (!readChunk(0)) {
-            throw new IOException("Incomplete JFR file");
-        }
     }
 
-    public JfrReader(ByteBuffer buf) throws IOException {
+    public JfrReader(ByteBuffer buf) {
         this.ch = null;
         this.buf = buf;
 
         buf.order(ByteOrder.BIG_ENDIAN);
-        if (!readChunk(0)) {
-            throw new IOException("Incomplete JFR file");
-        }
     }
 
     @Override


### PR DESCRIPTION
If the JFR file is large, for example, `alloc` event is enabled, it may cost large heap space to process millions of events.

This PR intends to amortize memory consumption by allowing users to read a single chunk once.

API:

As is used by `readAllEvents` in the `JfrReader.java`,

```java
    public <E extends Event> List<E> readAllEvents(Class<E> cls) {
        Chunks<E> chunks = readChunks(cls);
        ArrayList<E> events = new ArrayList<>();
        for (final Chunk<E> chunk : chunks) {
            for (final E event : chunk) {
                events.add(event);
            }
        }
        Collections.sort(events);
        return events;
    }
```


Still questions: (Excuse for my poor understanding of the JFR spec)

In the current impl, I noticed only `types` and `typesByName` are cleared. However, according to [the file format](https://www.morling.dev/blog/jdk-flight-recorder-file-format/), `Chunk` should be self-contained. Does it mean that we can clear all intermediate states, e.g. classes, symbols, methods when we start to read a new Chunk?