### PR TITLE
Compile with -std-c++2b without errors

### DIFF
--- a/src/dictionary.cpp
+++ b/src/dictionary.cpp
@@ -34,7 +34,7 @@ static inline bool keyEquals(const char* candidate, const char* key, size_t leng
 
 Dictionary::Dictionary() {
     _table = (DictTable*)calloc(1, sizeof(DictTable));
-    _table->base_index = _base_index = 1;
+    _base_index = _table->base_index = 1;
 }
 
 Dictionary::~Dictionary() {
@@ -45,7 +45,7 @@ Dictionary::~Dictionary() {
 void Dictionary::clear() {
     clear(_table);
     memset(_table, 0, sizeof(DictTable));
-    _table->base_index = _base_index = 1;
+    _base_index = _table->base_index = 1;
 }
 
 void Dictionary::clear(DictTable* table) {

--- a/src/safeAccess.h
+++ b/src/safeAccess.h
@@ -36,7 +36,7 @@ class SafeAccess {
     }
 
     static uintptr_t skipFaultInstruction(uintptr_t pc) {
-        if (pc - (uintptr_t)load < 16) {
+        if ((pc - (uintptr_t)load) < 16) {
 #if defined(__x86_64__)
             return *(u16*)pc == 0x8b48 ? 3 : 0;  // mov rax, [reg]
 #elif defined(__i386__)


### PR DESCRIPTION
Make codebase compile with `-std-c++2b`.