### PR TITLE
Prune to most "important" stacks - FOR DISCUSSION

### DIFF
--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -163,6 +163,11 @@ Error Arguments::parse(const char* args) {
             CASE("collapsed")
                 _output = OUTPUT_COLLAPSED;
 
+            CASE("prune")
+                _output = OUTPUT_COLLAPSED;
+                if(value == NULL || (_pruned = atoi(value)) <= 0)
+                  msg = "Invalid pruning";
+
             CASE("flamegraph")
                 _output = OUTPUT_FLAMEGRAPH;
 

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -169,6 +169,7 @@ class Arguments {
     CStack _cstack;
     Clock _clock;
     Output _output;
+    int _pruned;
     long _chunk_size;
     long _chunk_time;
     const char* _jfr_sync;
@@ -216,6 +217,7 @@ class Arguments {
         _cstack(CSTACK_DEFAULT),
         _clock(CLK_DEFAULT),
         _output(OUTPUT_NONE),
+        _pruned(0),
         _chunk_size(100 * 1024 * 1024),
         _chunk_time(3600),
         _jfr_sync(NULL),

--- a/src/flameGraph.h
+++ b/src/flameGraph.h
@@ -31,13 +31,18 @@ class Trie {
     u64 _total;
     u64 _self;
     u64 _inlined, _c1_compiled, _interpreted;
+    mutable int _n;
+    mutable Trie* _parent;
 
-    Trie() : _children(), _total(0), _self(0), _inlined(0), _c1_compiled(0), _interpreted(0) {
+    Trie() : _children(), _total(0), _self(0), _inlined(0), _c1_compiled(0), _interpreted(0), _n(0), _parent(0) {
     }
 
     Trie* addChild(const std::string& key, u64 value) {
         _total += value;
-        return &_children[key];
+        _n = _children.size() + 1;
+        Trie *ret = &_children[key];
+        ret->_parent = this;
+        return ret;
     }
 
     void addLeaf(u64 value) {
@@ -100,6 +105,10 @@ class FlameGraph {
     }
 
     void dump(std::ostream& out, bool tree);
+
+    void dumpCollapsed(std::ostream& out);
+
+    void prune(int n);
 };
 
 #endif // _FLAMEGRAPH_H

--- a/src/launcher/main.cpp
+++ b/src/launcher/main.cpp
@@ -73,6 +73,7 @@ static const char USAGE_STRING[] =
     "\n"
     "  --loop time       run profiler in a loop\n"
     "  --alloc bytes     allocation profiling interval in bytes\n"
+    "  --prune num       prune to number of collapsed stacks\n"
     "  --live            build allocation profile from live objects only\n"
     "  --lock duration   lock profiling threshold in nanoseconds\n"
     "  --total           accumulate the total value (time, bytes, etc.)\n"
@@ -430,6 +431,9 @@ int main(int argc, const char** argv) {
         } else if (arg == "--alloc" || arg == "--lock" || arg == "--chunksize" || arg == "--chunktime" ||
                    arg == "--cstack" || arg == "--clock" || arg == "--begin" || arg == "--end") {
             params << "," << (arg.str() + 2) << "=" << args.next();
+
+        } else if (arg == "--prune") {
+            format << "," << (arg.str() + 2) << "=" << args.next();
 
         } else if (arg == "--ttsp") {
             params << ",begin=SafepointSynchronize::begin,end=RuntimeService::record_safepoint_synchronized";

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -21,7 +21,7 @@ fi
   JAVAPID=$!
 
   sleep 1     # allow the Java runtime to initialize
-  ../build/bin/asprof -f $FILENAME -o collapsed -d 5 $JAVAPID
+  ../build/bin/asprof -f $FILENAME -d 5 -o collapsed --prune 10 $JAVAPID
 
   kill $JAVAPID
 
@@ -30,6 +30,11 @@ fi
       exit 1
     fi
   }
+
+  if [ $(wc -l < $FILENAME) != 10 ]; then
+     echo "Wrong number of collapsed stacks in $FILENAME"
+     exit 1
+  fi
 
   assert_string "Target.main;Target.method1 "
   assert_string "Target.main;Target.method2 "


### PR DESCRIPTION
Adds a new `--prune NUM` option to be used with `collapsed` format.  Leaves will be pruned from the stack graph in order of increasing `_total` until only `NUM` remain; when all of a node's children have been pruned, it is added back to the queue.  With `--prune `5`, the `/tmp/java.trace` from the smoke test looks like:
```
Target.main;Target.method1 42
Target.main;Target.method2 46
Target.main;Target.method3;java/io/File.list;java/io/File.normalizedList;java/io/UnixFileSystem.list;Java_java_io_UnixFileSystem_list;JNU_CopyObjectArray;jni_DeleteLocalRef 17
Target.main;Target.method3;java/io/File.list;java/io/File.normalizedList;java/io/UnixFileSystem.list;Java_java_io_UnixFileSystem_list;JNU_CopyObjectArray;jni_GetObjectArrayElement 26
Target.main;Target.method3;java/io/File.list;java/io/File.normalizedList;java/io/UnixFileSystem.list;Java_java_io_UnixFileSystem_list;newSizedString8859_1;jni_NewString;java_lang_String::create_oop_from_unicode(unsigned short*, int, Thread*);java_lang_String::create_from_unicode(unsigned short*, int, Thread*);java_lang_String::basic_create(int, bool, Thread*) 25
```
Note, for example, that `java_lang_String::basic_create` would typically not show up in a list of most-sampled stacks, because the samples are fragmented over a dozen contributing child stacks.