### PR TITLE
Fix build when the main folder contains `flame.html` or `tree.html` files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CONVERTER_JAR=lib/converter.jar
 
 CFLAGS=-O3 -fno-exceptions
 CXXFLAGS=-O3 -fno-exceptions -fno-omit-frame-pointer -fvisibility=hidden
-INCLUDES=-I$(JAVA_HOME)/include -Isrc/res -Isrc/helper
+INCLUDES=-I$(JAVA_HOME)/include -Isrc/helper
 LIBS=-ldl -lpthread
 MERGE=true
 

--- a/src/flameGraph.cpp
+++ b/src/flameGraph.cpp
@@ -26,8 +26,8 @@
 // Browsers refuse to draw on canvas larger than 32767 px
 const int MAX_CANVAS_HEIGHT = 32767;
 
-INCBIN(FLAMEGRAPH_TEMPLATE, "flame.html")
-INCBIN(TREE_TEMPLATE, "tree.html")
+INCBIN(FLAMEGRAPH_TEMPLATE, "src/res/flame.html")
+INCBIN(TREE_TEMPLATE, "src/res/tree.html")
 
 
 class StringUtils {


### PR DESCRIPTION
Tiny fix for the case that the current async-profiler folder contains `flame.html` or `tree.html` or files. The build script currently takes these files instead of the files from `src/res`, causing an error during the flame graph generation. This is problematic because `flame.html` is not an uncommon name for created flame graph files.