### PR TITLE
change default interval 100hz->~99hz to avoid lockstep sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ The following is a complete list of the command-line options accepted by
 * `-i N` - sets the profiling interval in nanoseconds or in other units,
   if N is followed by `ms` (for milliseconds), `us` (for microseconds),
   or `s` (for seconds). Only CPU active time is counted. No samples
-  are collected while CPU is idle. The default is 10000000 (10ms).  
+  are collected while CPU is idle. By default, the profiler samples ~99 times a second.
   Example: `./profiler.sh -i 500us 8983`
 
 * `--alloc N` - allocation profiling interval in bytes or in other units,

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -19,8 +19,9 @@
 
 #include <stddef.h>
 
-
-const long DEFAULT_INTERVAL = 10000000;      // 10 ms
+const long DEFAULT_FREQUENCY_HZ = 99;
+const long NS_IN_SEC = 1000000000;
+const long DEFAULT_INTERVAL = NS_IN_SEC / DEFAULT_FREQUENCY_HZ; // = 10101010[.101]ns
 const long DEFAULT_ALLOC_INTERVAL = 524287;  // 512 KiB
 const int DEFAULT_JSTACKDEPTH = 2048;
 


### PR DESCRIPTION
Common logic is more likely to execute periodically at 100hz rather than 99hz, thus lockstep sampling is less likely to occur.