### PR TITLE
Feat/add native stack depth max opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,8 +372,7 @@ The following is a complete list of the command-line options accepted by
   In lock profiling mode, record contended locks that the JVM has waited for
   longer than the specified duration.
 
-* `-j N` - sets the Java stack profiling depth. This option will be ignored if N is greater
-  than default 2048.  
+* `-j N` - sets the Java stack profiling depth. The default is 2048.  
   Example: `./profiler.sh -j 30 8983`
 
 * `-t` - profile threads separately. Each stack trace will end with a frame
@@ -447,6 +446,9 @@ The following is a complete list of the command-line options accepted by
 
   By default, C stack is shown in cpu, itimer, wall-clock and perf-events profiles.
   Java-level events like `alloc` and `lock` collect only Java stack.
+
+* `--cdepth DEPTH` - set native stack depth. The default is 128.
+  Example: `./profiler.sh --cdepth 64 8983`
 
 * `--clock SOURCE` - clock source for JFR timestamps: `tsc` (default)
   or `monotonic` (equivalent for `CLOCK_MONOTONIC`).

--- a/README.md
+++ b/README.md
@@ -456,8 +456,8 @@ The following is a complete list of the command-line options accepted by
   By default, C stack is shown in cpu, itimer, wall-clock and perf-events profiles.
   Java-level events like `alloc` and `lock` collect only Java stack.
 
-* `--cdepth DEPTH` - set native stack depth. The default is 128.
-  Example: `./profiler.sh --cdepth 64 8983`
+* `--cstackdepth DEPTH` - set native stack depth. The default is 128.
+  Example: `./profiler.sh --cstackdepth 64 8983`
 
 * `--signal NUM` - use alternative signal for cpu or wall clock profiling.
   To change both signals, specify two numbers separated by a slash: `--signal SIGCPU/SIGWALL`.

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -92,6 +92,7 @@ static const Multiplier UNIVERSAL[] = {{'n', 1}, {'u', 1000}, {'m', 1000000}, {'
 //     sched            - group threads by scheduling policy
 //     cstack=MODE      - how to collect C stack frames in addition to Java stack
 //                        MODE is 'fp' (Frame Pointer), 'dwarf', 'lbr' (Last Branch Record) or 'no'
+//     cdepth=DEPTH     - maximum native stack depth (default: 128)
 //     clock=SOURCE     - clock source for JFR timestamps: 'tsc' or 'monotonic'
 //     allkernel        - include only kernel-mode events
 //     alluser          - include only user-mode events
@@ -318,6 +319,11 @@ Error Arguments::parse(const char* args) {
                     } else {
                         _cstack = CSTACK_FP;
                     }
+                }
+
+            CASE("cdepth")
+                if (value == NULL || (_cdepth = atoi(value)) <= 0) {
+                    msg = "cdepth must be > 0";
                 }
 
             CASE("clock")

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -94,7 +94,7 @@ static const Multiplier UNIVERSAL[] = {{'n', 1}, {'u', 1000}, {'m', 1000000}, {'
 //     sched            - group threads by scheduling policy
 //     cstack=MODE      - how to collect C stack frames in addition to Java stack
 //                        MODE is 'fp' (Frame Pointer), 'dwarf', 'lbr' (Last Branch Record) or 'no'
-//     cdepth=DEPTH     - maximum native stack depth (default: 128)
+//     cstackdepth=DEPTH     - maximum native stack depth (default: 128)
 //     clock=SOURCE     - clock source for JFR timestamps: 'tsc' or 'monotonic'
 //     allkernel        - include only kernel-mode events
 //     alluser          - include only user-mode events
@@ -346,9 +346,9 @@ Error Arguments::parse(const char* args) {
                     }
                 }
 
-            CASE("cdepth")
-                if (value == NULL || (_cdepth = atoi(value)) <= 0) {
-                    msg = "cdepth must be > 0";
+            CASE("cstackdepth")
+                if (value == NULL || (_cstackdepth = atoi(value)) <= 0) {
+                    msg = "cstackdepth must be > 0";
                 }
 
             CASE("clock")

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -23,6 +23,7 @@
 const long DEFAULT_INTERVAL = 10000000;      // 10 ms
 const long DEFAULT_ALLOC_INTERVAL = 524287;  // 512 KiB
 const int DEFAULT_JSTACKDEPTH = 2048;
+const int DEFAULT_CDEPTH = 128;
 
 const char* const EVENT_CPU    = "cpu";
 const char* const EVENT_ALLOC  = "alloc";
@@ -169,6 +170,7 @@ class Arguments {
     const char* _fdtransfer_path;
     int _style;
     CStack _cstack;
+    int _cdepth;
     Clock _clock;
     Output _output;
     long _chunk_size;
@@ -217,6 +219,7 @@ class Arguments {
         _fdtransfer_path(NULL),
         _style(0),
         _cstack(CSTACK_DEFAULT),
+        _cdepth(DEFAULT_CDEPTH),
         _clock(CLK_DEFAULT),
         _output(OUTPUT_NONE),
         _chunk_size(100 * 1024 * 1024),

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -23,7 +23,7 @@
 const long DEFAULT_INTERVAL = 10000000;      // 10 ms
 const long DEFAULT_ALLOC_INTERVAL = 524287;  // 512 KiB
 const int DEFAULT_JSTACKDEPTH = 2048;
-const int DEFAULT_CDEPTH = 128;
+const int DEFAULT_CSTACKDEPTH = 128;
 
 const char* const EVENT_CPU    = "cpu";
 const char* const EVENT_ALLOC  = "alloc";
@@ -191,7 +191,7 @@ class Arguments {
     int _style;
     StackWalkFeatures _features;
     CStack _cstack;
-    int _cdepth;
+    int _cstackdepth;
     Clock _clock;
     Output _output;
     long _chunk_size;
@@ -241,7 +241,7 @@ class Arguments {
         _style(0),
         _features(),
         _cstack(CSTACK_DEFAULT),
-        _cdepth(DEFAULT_CDEPTH),
+        _cstackdepth(DEFAULT_CSTACKDEPTH),
         _clock(CLK_DEFAULT),
         _output(OUTPUT_NONE),
         _chunk_size(100 * 1024 * 1024),

--- a/src/itimer.cpp
+++ b/src/itimer.cpp
@@ -66,7 +66,7 @@ Error ITimer::start(Arguments& args) {
     }
     _interval = args._interval ? args._interval : DEFAULT_INTERVAL;
     _cstack = args._cstack;
-    _max_native_stack_depth = args._cdepth;
+    _max_native_stack_depth = args._cstackdepth;
 
     if (VM::isOpenJ9()) {
         if (_cstack == CSTACK_DEFAULT) _cstack = CSTACK_DWARF;

--- a/src/itimer.h
+++ b/src/itimer.h
@@ -25,6 +25,7 @@ class ITimer : public Engine {
   private:
     static long _interval;
     static CStack _cstack;
+    static int _max_native_stack_depth;
 
     static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext);
     static void signalHandlerJ9(int signo, siginfo_t* siginfo, void* ucontext);

--- a/src/j9StackTraces.cpp
+++ b/src/j9StackTraces.cpp
@@ -149,7 +149,7 @@ void J9StackTraces::timerLoop() {
             ExecutionEvent event;
             Profiler::instance()->recordExternalSample(notif->counter, tid, EXECUTION_SAMPLE, &event, num_frames, frames);
 
-            ptr += notif->size();
+            ptr += sizeof(*notif);
         }
     }
 
@@ -178,7 +178,7 @@ void J9StackTraces::checkpoint(u64 counter, J9StackTraceNotification* notif) {
             vm_thread->setOverflowMark();
             notif->env = env;
             notif->counter = counter;
-            if (write(_pipe[1], notif, notif->size()) > 0) {
+            if (write(_pipe[1], notif, sizeof(*notif)) > 0) {
                 return;
             }
         }

--- a/src/j9StackTraces.cpp
+++ b/src/j9StackTraces.cpp
@@ -55,13 +55,15 @@ class J9VMThread {
 
 pthread_t J9StackTraces::_thread = 0;
 int J9StackTraces::_max_stack_depth;
+int J9StackTraces::_max_native_stack_depth;
 int J9StackTraces::_pipe[2];
 
 static JNIEnv* _self_env = NULL;
 
 
 Error J9StackTraces::start(Arguments& args) {
-    _max_stack_depth = args._jstackdepth; 
+    _max_stack_depth = args._jstackdepth;
+    _max_native_stack_depth = args._cdepth;
 
     if (pipe(_pipe) != 0) {
         return Error("Failed to create pipe");
@@ -96,7 +98,7 @@ void J9StackTraces::timerLoop() {
     char notification_buf[65536];
     std::map<void*, jthread> known_threads;
 
-    int max_frames = _max_stack_depth + MAX_J9_NATIVE_FRAMES + RESERVED_FRAMES;
+    int max_frames = _max_stack_depth + _max_native_stack_depth + RESERVED_FRAMES;
     ASGCT_CallFrame* frames = (ASGCT_CallFrame*)malloc(max_frames * sizeof(ASGCT_CallFrame));
     jvmtiFrameInfoExtended* jvmti_frames = (jvmtiFrameInfoExtended*)malloc(max_frames * sizeof(jvmtiFrameInfoExtended));
 

--- a/src/j9StackTraces.cpp
+++ b/src/j9StackTraces.cpp
@@ -63,7 +63,7 @@ static JNIEnv* _self_env = NULL;
 
 Error J9StackTraces::start(Arguments& args) {
     _max_stack_depth = args._jstackdepth;
-    _max_native_stack_depth = args._cdepth;
+    _max_native_stack_depth = args._cstackdepth;
 
     if (pipe(_pipe) != 0) {
         return Error("Failed to create pipe");

--- a/src/j9StackTraces.h
+++ b/src/j9StackTraces.h
@@ -22,14 +22,12 @@
 #include "arguments.h"
 
 
-const int MAX_J9_NATIVE_FRAMES = 128;
-
 struct J9StackTraceNotification {
     void* env;
     u64 counter;
     int num_frames;
     int reserved;
-    const void* addr[MAX_J9_NATIVE_FRAMES];
+    const void **addr;
 
     size_t size() {
         return sizeof(*this) - sizeof(this->addr) + num_frames * sizeof(const void*);
@@ -41,6 +39,7 @@ class J9StackTraces {
   private:
     static pthread_t _thread;
     static int _max_stack_depth;
+    static int _max_native_stack_depth;
     static int _pipe[2];
 
     static void* threadEntry(void* unused) {

--- a/src/j9StackTraces.h
+++ b/src/j9StackTraces.h
@@ -28,10 +28,6 @@ struct J9StackTraceNotification {
     int num_frames;
     int reserved;
     const void **addr;
-
-    size_t size() {
-        return sizeof(*this) - sizeof(this->addr) + num_frames * sizeof(const void*);
-    }
 };
 
 

--- a/src/j9WallClock.cpp
+++ b/src/j9WallClock.cpp
@@ -25,6 +25,7 @@ long J9WallClock::_interval;
 Error J9WallClock::start(Arguments& args) {
     _interval = args._interval ? args._interval : DEFAULT_INTERVAL * 5;
     _max_stack_depth = args._jstackdepth;
+    _max_native_stack_depth = args._cdepth;
 
     _running = true;
 
@@ -45,7 +46,7 @@ void J9WallClock::timerLoop() {
     JNIEnv* jni = VM::attachThread("Async-profiler Sampler");
     jvmtiEnv* jvmti = VM::jvmti();
 
-    int max_frames = _max_stack_depth + MAX_NATIVE_FRAMES + RESERVED_FRAMES;
+    int max_frames = _max_stack_depth + _max_native_stack_depth + RESERVED_FRAMES;
     ASGCT_CallFrame* frames = (ASGCT_CallFrame*)malloc(max_frames * sizeof(ASGCT_CallFrame));
 
     while (_running) {

--- a/src/j9WallClock.cpp
+++ b/src/j9WallClock.cpp
@@ -25,7 +25,7 @@ long J9WallClock::_interval;
 Error J9WallClock::start(Arguments& args) {
     _interval = args._interval ? args._interval : DEFAULT_INTERVAL * 5;
     _max_stack_depth = args._jstackdepth;
-    _max_native_stack_depth = args._cdepth;
+    _max_native_stack_depth = args._cstackdepth;
 
     _running = true;
 

--- a/src/j9WallClock.h
+++ b/src/j9WallClock.h
@@ -26,6 +26,7 @@ class J9WallClock : public Engine {
     static long _interval;
 
     int _max_stack_depth;
+    int _max_native_stack_depth;
     volatile bool _running;
     pthread_t _thread;
 

--- a/src/launcher/main.cpp
+++ b/src/launcher/main.cpp
@@ -82,7 +82,7 @@ static const char USAGE_STRING[] =
     "  --all-user        only include user-mode events\n"
     "  --sched           group threads by scheduling policy\n"
     "  --cstack mode     how to traverse C stack: fp|dwarf|lbr|no\n"
-    "  --cdepth depth    maximum native stack depth\n"
+    "  --cstackdepth depth    maximum native stack depth\n"
     "  --signal num      use alternative signal for cpu or wall clock profiling\n"
     "  --clock source    clock source for JFR timestamps: tsc|monotonic\n"
     "  --begin function  begin profiling when function is executed\n"
@@ -446,7 +446,7 @@ int main(int argc, const char** argv) {
 
         } else if (arg == "--alloc" || arg == "--lock" || arg == "--wall" ||
                    arg == "--chunksize" || arg == "--chunktime" ||
-                   arg == "--cstack" || arg == "--cdepth" || arg == "--signal" || arg == "--clock" || arg == "--begin" || arg == "--end") {
+                   arg == "--cstack" || arg == "--cstackdepth" || arg == "--signal" || arg == "--clock" || arg == "--begin" || arg == "--end") {
             params << "," << (arg.str() + 2) << "=" << args.next();
 
         } else if (arg == "--ttsp") {

--- a/src/launcher/main.cpp
+++ b/src/launcher/main.cpp
@@ -80,6 +80,7 @@ static const char USAGE_STRING[] =
     "  --all-user        only include user-mode events\n"
     "  --sched           group threads by scheduling policy\n"
     "  --cstack mode     how to traverse C stack: fp|dwarf|lbr|no\n"
+    "  --cdepth depth    maximum native stack depth\n"
     "  --clock source    clock source for JFR timestamps: tsc|monotonic\n"
     "  --begin function  begin profiling when function is executed\n"
     "  --end function    end profiling when function is executed\n"
@@ -436,7 +437,8 @@ int main(int argc, const char** argv) {
 
         } else if (arg == "--alloc" || arg == "--lock" || arg == "--wall" ||
                    arg == "--chunksize" || arg == "--chunktime" ||
-                   arg == "--cstack" || arg == "--clock" || arg == "--begin" || arg == "--end") {
+                   arg == "--cstack" || arg == "--cdepth" || arg == "--clock" || 
+                   arg == "--begin" || arg == "--end" ) {
             params << "," << (arg.str() + 2) << "=" << args.next();
 
         } else if (arg == "--ttsp") {

--- a/src/perfEvents.h
+++ b/src/perfEvents.h
@@ -37,6 +37,7 @@ class PerfEvents : public Engine {
     static CStack _cstack;
     static bool _use_mmap_page;
     static bool _running;
+    static int _max_native_stack_depth;
 
     static u64 readCounter(siginfo_t* siginfo, void* ucontext);
     static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext);
@@ -50,7 +51,7 @@ class PerfEvents : public Engine {
     const char* title();
     const char* units();
 
-    static int walk(int tid, void* ucontext, const void** callchain, int max_depth, StackContext* java_ctx);
+    static int walk(int tid, void* ucontext, const void** callchain, StackContext* java_ctx);
     static void resetBuffer(int tid);
 
     static bool supported();

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -834,7 +834,7 @@ Error PerfEvents::start(Arguments& args) {
         _ring = RING_USER;
     }
     _cstack = args._cstack;
-    _max_native_stack_depth = args._cdepth;
+    _max_native_stack_depth = args._cstackdepth;
     _use_mmap_page = _cstack != CSTACK_NO && (_ring != RING_USER || _cstack == CSTACK_DEFAULT || _cstack == CSTACK_LBR);
 
     int max_events = OS::getMaxThreadId();

--- a/src/perfEvents_macos.cpp
+++ b/src/perfEvents_macos.cpp
@@ -28,6 +28,7 @@ Ring PerfEvents::_ring;
 CStack PerfEvents::_cstack;
 bool PerfEvents::_use_mmap_page;
 bool PerfEvents::_running;
+int PerfEvents::_max_native_stack_depth;
 
 u64 PerfEvents::readCounter(siginfo_t* siginfo, void* ucontext) {
     return 0;
@@ -58,7 +59,7 @@ Error PerfEvents::start(Arguments& args) {
 void PerfEvents::stop() {
 }
 
-int PerfEvents::walk(int tid, void* ucontext, const void** callchain, int max_depth, StackContext* java_ctx) {
+int PerfEvents::walk(int tid, void* ucontext, const void** callchain, StackContext* java_ctx) {
     return 0;
 }
 

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1034,9 +1034,9 @@ Error Profiler::start(Arguments& args, bool reset) {
     }
 
     // (Re-)allocate calltrace buffers
-    if (_max_stack_depth != args._jstackdepth || _max_native_stack_depth != args._cdepth) {
+    if (_max_stack_depth != args._jstackdepth || _max_native_stack_depth != args._cstackdepth) {
         _max_stack_depth = args._jstackdepth;
-        _max_native_stack_depth = args._cdepth;
+        _max_native_stack_depth = args._cstackdepth;
         size_t buffer_size = (_max_stack_depth + _max_native_stack_depth + RESERVED_FRAMES) * sizeof(CallTraceBuffer);
 
         for (int i = 0; i < CONCURRENCY_LEVEL; i++) {
@@ -1045,7 +1045,7 @@ Error Profiler::start(Arguments& args, bool reset) {
             if (_calltrace_buffer[i] == NULL) {
                 _max_stack_depth = 0;
                 _max_native_stack_depth = 0;
-                return Error("Not enough memory to allocate stack trace buffers (try smaller jstackdepth or cdepth)");
+                return Error("Not enough memory to allocate stack trace buffers (try smaller jstackdepth or cstackdepth)");
             }
         }
     }

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -313,7 +313,7 @@ int Profiler::getNativeTrace(void* ucontext, ASGCT_CallFrame* frames, EventType 
 
     // Use PerfEvents stack walker for execution samples, or basic stack walker for other events
     if (event_type == PERF_SAMPLE) {
-        native_frames = PerfEvents::walk(tid, ucontext, callchain, _max_native_stack_depth, java_ctx);
+        native_frames = PerfEvents::walk(tid, ucontext, callchain, java_ctx);
     } else if (_cstack == CSTACK_DWARF) {
         native_frames = StackWalker::walkDwarf(ucontext, callchain, _max_native_stack_depth, java_ctx);
     } else {

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -36,7 +36,6 @@
 #include "vmEntry.h"
 
 
-const int MAX_NATIVE_FRAMES = 128;
 const int RESERVED_FRAMES   = 4;
 const int CONCURRENCY_LEVEL = 16;
 
@@ -90,6 +89,7 @@ class Profiler {
     SpinLock _locks[CONCURRENCY_LEVEL];
     CallTraceBuffer* _calltrace_buffer[CONCURRENCY_LEVEL];
     int _max_stack_depth;
+    int _max_native_stack_depth;
     int _safe_mode;
     CStack _cstack;
     bool _add_event_frame;
@@ -175,6 +175,7 @@ class Profiler {
         _gc_id(0),
         _timer_id(NULL),
         _max_stack_depth(0),
+        _max_native_stack_depth(0),
         _safe_mode(0),
         _thread_events_state(JVMTI_DISABLE),
         _stubs_lock(),


### PR DESCRIPTION
Adding a config option to control native stack depth. This allows a user to increase resolution of native parts in the profile, or to reduce unwind time and space overhead where possible.

Following curr idioms, I added `--cstackdepth` launcher opt mapped to `cstackdepth=DEPTH` format, replacing `MAX_NATIVE_FRAMES` and the j9 equivalent usage with the injected config while retaining the 128 default, following the curr procedural and object design.

Testing vm:
```
$ uname -a
Linux tomersha 5.15.0-78-generic #85-Ubuntu SMP Fri Jul 7 15:29:30 UTC 2023 aarch64 aarch64 aarch64 GNU/Linux

$ java --version
openjdk 17.0.7 2023-04-18
OpenJDK Runtime Environment (build 17.0.7+7-Ubuntu-0ubuntu122.04.2)
OpenJDK 64-Bit Server VM (build 17.0.7+7-Ubuntu-0ubuntu122.04.2, mixed mode, sharing)

JAVA_HOME=/usr/lib/jvm/java-17-openjdk-arm64

$ g++ --version
$ cc --version
(Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0

$ make --version
GNU Make 4.3
Built for aarch64-unknown-linux-gnu
```
Make builds, smoke suite tests pass, and basic itimer and perf manual sanity tests pass.
