### PR TITLE
Support alloc event in pprof converter

### DIFF
--- a/src/converter/Arguments.java
+++ b/src/converter/Arguments.java
@@ -30,6 +30,7 @@ class Arguments {
     double minwidth;
     int skip;
     boolean reverse;
+    boolean cpu;
     boolean alloc;
     boolean live;
     boolean lock;

--- a/src/converter/jfr2pprof.java
+++ b/src/converter/jfr2pprof.java
@@ -79,6 +79,7 @@ public class jfr2pprof {
     // Sample IDs
     public static final int SAMPLE_LOCATION_ID = 1;
     public static final int SAMPLE_VALUE = 2;
+    public static final int SAMPLE_LABEL = 3;
 
     // Location IDs
     public static final int LOCATION_ID = 1;
@@ -87,7 +88,6 @@ public class jfr2pprof {
     // Line IDs
     public static final int LINE_FUNCTION_ID = 1;
     public static final int LINE_LINE = 2;
-    public static final int SAMPLE_LABEL = 3;
 
     // Label IDs
     public static final int LABEL_KEY = 1;

--- a/src/converter/jfr2pprof.java
+++ b/src/converter/jfr2pprof.java
@@ -110,7 +110,7 @@ public class jfr2pprof {
 
     // `Proto` instances are mutable, careful with reordering
     public void dump(final OutputStream out, Class<? extends Event> eventClass) throws Exception {
-        if ((eventClass != ExecutionSample.class && eventClass != AllocationSample.class)) {
+        if (eventClass != ExecutionSample.class && eventClass != AllocationSample.class) {
             // Fallback to execution sample event
             eventClass = ExecutionSample.class;
         }
@@ -258,7 +258,7 @@ public class jfr2pprof {
 
         Class<? extends Event> eventClass = args.alloc ? AllocationSample.class : ExecutionSample.class;
 
-        String output = Optional.ofNullable(args.output).orElse(args.input).replace(".jfr", ".pprof");
+        String output = Optional.ofNullable(args.output).orElse(args.input.replace(".jfr", ".pprof"));
         File dst = new File(output);
         if (dst.isDirectory()) {
             dst = new File(dst, new File(args.input).getName().replace(".jfr", ".pprof"));

--- a/src/converter/jfr2pprof.java
+++ b/src/converter/jfr2pprof.java
@@ -156,6 +156,10 @@ public class jfr2pprof {
         final Dictionary<StackTrace> stackTraces = reader.stackTraces;
         long previousTime = reader.startTicks; // Mutate this to keep track of time deltas
 
+        final Proto allocationLabel = new Proto(16)
+                .field(LABEL_KEY, allocationSizeKeyId)
+                .field(LABEL_NUM_UNIT, allocationSizeUnitId);
+
         // Iterate over samples
         for (final Event jfrSample : jfrSamples) {
             final StackTrace stackTrace = stackTraces.get(jfrSample.stackTraceId);
@@ -166,12 +170,7 @@ public class jfr2pprof {
             final long nanosSinceLastSample = (jfrSample.time - previousTime) * 1_000_000_000 / reader.ticksPerSec;
             sample.field(SAMPLE_VALUE, nanosSinceLastSample);
             if (eventClass == AllocationSample.class) {
-                final long allocationSize = jfrSample.value();
-                final Proto label = new Proto(16)
-                        .field(LABEL_KEY, allocationSizeKeyId)
-                        .field(LABEL_NUM, allocationSize)
-                        .field(LABEL_NUM_UNIT, allocationSizeUnitId);
-                sample.field(SAMPLE_LABEL, label);
+                sample.field(SAMPLE_LABEL, allocationLabel.field(LABEL_NUM, jfrSample.value()));
             }
 
             for (int current = 0; current < methods.length; current++) {

--- a/src/converter/one/jfr/event/Event.java
+++ b/src/converter/one/jfr/event/Event.java
@@ -16,24 +16,12 @@
 
 package one.jfr.event;
 
-import one.profiler.Events;
-
 import java.lang.reflect.Field;
-import java.util.HashMap;
-import java.util.Map;
 
 public abstract class Event implements Comparable<Event> {
     public final long time;
     public final int tid;
     public final int stackTraceId;
-
-    private static final Map<String, Class<? extends Event>> eventClassMap;
-
-    static {
-        eventClassMap = new HashMap<>();
-        eventClassMap.put(Events.CPU, ExecutionSample.class);
-        eventClassMap.put(Events.ALLOC, AllocationSample.class);
-    }
 
     protected Event(long time, int tid, int stackTraceId) {
         this.time = time;
@@ -73,9 +61,5 @@ public abstract class Event implements Comparable<Event> {
 
     public long value() {
         return 1;
-    }
-
-    public static Class<? extends Event> of(String eventType) {
-        return eventClassMap.getOrDefault(eventType, ExecutionSample.class);
     }
 }

--- a/src/converter/one/jfr/event/Event.java
+++ b/src/converter/one/jfr/event/Event.java
@@ -16,12 +16,24 @@
 
 package one.jfr.event;
 
+import one.profiler.Events;
+
 import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
 
 public abstract class Event implements Comparable<Event> {
     public final long time;
     public final int tid;
     public final int stackTraceId;
+
+    private static final Map<String, Class<? extends Event>> eventClassMap;
+
+    static {
+        eventClassMap = new HashMap<>();
+        eventClassMap.put(Events.CPU, ExecutionSample.class);
+        eventClassMap.put(Events.ALLOC, AllocationSample.class);
+    }
 
     protected Event(long time, int tid, int stackTraceId) {
         this.time = time;
@@ -61,5 +73,9 @@ public abstract class Event implements Comparable<Event> {
 
     public long value() {
         return 1;
+    }
+
+    public static Class<? extends Event> of(String eventType) {
+        return eventClassMap.getOrDefault(eventType, ExecutionSample.class);
     }
 }


### PR DESCRIPTION
Currently, the pprof converter only supports CPU events. This PR adds support for converting alloc events to pprof format.