### PR TITLE
Make converter Arguments class public

### DIFF
--- a/src/converter/Arguments.java
+++ b/src/converter/Arguments.java
@@ -21,7 +21,7 @@ import java.util.GregorianCalendar;
 import java.util.StringTokenizer;
 import java.util.regex.Pattern;
 
-class Arguments {
+public class Arguments {
     String title = "Flame Graph";
     String highlight;
     String state;
@@ -47,7 +47,7 @@ class Arguments {
     String input;
     String output;
 
-    Arguments(String... args) {
+    public Arguments(String... args) {
         for (int i = 0; i < args.length; i++) {
             String arg = args[i];
             if (arg.startsWith("--")) {


### PR DESCRIPTION
Right now now [Arguments](https://github.com/async-profiler/async-profiler/blob/master/src/converter/Arguments.java) class is `package-private`, so is not possible to use `jfr2flame(JfrReader jfr, Arguments args)` programatically to create flamrgrpah (unless i copy the same class locally for non-module apps).  This PR is to make this class public to make it more API friendly.