### PR TITLE
#873: the accuracy issue of ObjectSampler in --total mode

### DIFF
--- a/src/objectSampler.cpp
+++ b/src/objectSampler.cpp
@@ -160,7 +160,7 @@ void ObjectSampler::recordAllocation(jvmtiEnv* jvmti, JNIEnv* jni, EventType eve
         u64 trace = Profiler::instance()->recordSample(NULL, 0, event_type, &event);
         live_refs.add(jni, object, size, trace);
     } else {
-        Profiler::instance()->recordSample(NULL, size, event_type, &event);
+        Profiler::instance()->recordSample(NULL, event._total_size, event_type, &event);
     }
 }
 


### PR DESCRIPTION
Hi Andrei

As discussed in [#873](https://github.com/async-profiler/async-profiler/issues/873).

Because [JEP 331](https://openjdk.org/jeps/331) doesn't return the actual pseudo-random `interval` in `JVM`, the `event._total_size` is the best we can use now.

I would appreciate it if you can help review this.