### PR TITLE
fix(jfr2pprof): Fix multichunk jfr symbols and location's line numbers

### DIFF
--- a/src/converter/jfr2pprof.java
+++ b/src/converter/jfr2pprof.java
@@ -19,7 +19,6 @@ import one.jfr.Dictionary;
 import one.jfr.JfrReader;
 import one.jfr.MethodRef;
 import one.jfr.StackTrace;
-import one.jfr.event.Event;
 import one.jfr.event.ExecutionSample;
 import one.proto.Proto;
 
@@ -30,7 +29,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Convert a JFR file to pprof
@@ -70,13 +68,18 @@ public class jfr2pprof {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
+
             Location location = (Location) o;
-            return line == location.line && Objects.equals(method, location.method);
+
+            if (line != location.line) return false;
+            return method.equals(location.method);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(method, line);
+            int result = method.hashCode();
+            result = 31 * result + line;
+            return result;
         }
     }
 


### PR DESCRIPTION
- Do not use one.jfr.JfrReader#readAllEvents(java.lang.Class<E>) as it may trigger reading new chunk in multichunk jfrs, overwriting cp, producing wrong data(I observerd wrong class names). Note: it is still used in netflix code I did not touch.

- Use Location(method+line) as dedup key to fix line numbers

I've used this JFR file for testing, captured by Intellij IDEA Ultimate on Linux
[FastSlow_2024_01_16_180855.jfr.zip](https://github.com/async-profiler/async-profiler/files/13949433/FastSlow_2024_01_16_180855.jfr.zip)
