### PR TITLE
Fix Proto encoding of negative integers

### DIFF
--- a/src/converter/one/proto/Proto.java
+++ b/src/converter/one/proto/Proto.java
@@ -71,7 +71,7 @@ public class Proto {
         int length = n == 0 ? 1 : (38 - Integer.numberOfLeadingZeros(n)) / 7;
         ensureCapacity(length);
 
-        while (n > 0x7f) {
+        while ((n >>> 7) != 0) {
             buf[pos++] = (byte) (0x80 | (n & 0x7f));
             n >>>= 7;
         }
@@ -82,7 +82,7 @@ public class Proto {
         int length = n == 0 ? 1 : (70 - Long.numberOfLeadingZeros(n)) / 7;
         ensureCapacity(length);
 
-        while (n > 0x7f) {
+        while ((n >>> 7) != 0) {
             buf[pos++] = (byte) (0x80 | (n & 0x7f));
             n >>>= 7;
         }


### PR DESCRIPTION
Currently the `Proto` class determines whether to emit a continuing byte for the integer value `n` this way:

```java
while (n > 0x7f) {
```

The intention of the comparison is to check whether `n` has any bit set below the lowest 7 bits.  Unfortunately it does not work if `n` is negative, which causes the loop to be skipped entirely.  When that happens, the `jfr2pprof` produces a protobuf profile that is rejected by `pprof`.

This PR fixes the bug so that `Proto` encodes negative integer values correctly.
