### PR TITLE
Fix memory leak of keys from jvmti->GetSystemProperties

### DIFF
--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -917,6 +917,7 @@ class Recording {
                 buf->putVar32(start, buf->offset() - start);
                 jvmti->Deallocate((unsigned char*)value);
             }
+            jvmti->Deallocate((unsigned char*)key);
         }
 
         jvmti->Deallocate((unsigned char*)keys);


### PR DESCRIPTION
From [JVMTI-GetSystemProperties](https://docs.oracle.com/javase/8/docs/platform/jvmti/jvmti.html#GetSystemProperties) docs: Each of the elements should be freed with Deallocate.

It's easy to reproduce if there are many/big properties. 
Fast Reproducer:

```
    public static void main(String[] args) {
        for(;;) {}
    }
```

`java -DTTTTTTT(very-very-very-long-string)=5 Main` I used 50k for fast reproducer.


`while true; do build/bin/asprof -e alloc -f profile.jfr -d 0.001 jps; done`


RSS increases very fast until OOM. NMT shows:
```
Details:

[0x00000001025bdf24] JvmtiEnv::GetSystemProperties(int*, char***)+0xf4
[0x00000001025815c0] jvmti_GetSystemProperties(_jvmtiEnv*, int*, char***)+0x108
[0x0000000100cd6d04] Recording::writeSystemProperties(Buffer*)+0x58
[0x0000000100cd5650] Recording::Recording(int, char const*, Arguments&)+0x314
                             (malloc=505381KB type=Internal #142000) (at peak)
```


After fix I still see a little memory increase over a long period of time but much-much slower than it was before. NMT diff shows on load_agent, but didn't investigate further:
```
[0x0000000105d4af70] JvmtiAgent::JvmtiAgent(char const*, char const*, bool, bool)+0x44
[0x0000000105d4c7f8] JvmtiAgentList::load_agent(char const*, char const*, char const*, outputStream*)+0x70
[0x00000001058649dc] load_agent(AttachOperation*, outputStream*)+0x54
[0x00000001058648a0] attach_listener_thread_entry(JavaThread*, JavaThread*)+0x260
                             (malloc=3627KB type=Serviceability +2329KB #53064 +34066)

[0x0000000105d4af84] JvmtiAgent::JvmtiAgent(char const*, char const*, bool, bool)+0x58
[0x0000000105d4c7f8] JvmtiAgentList::load_agent(char const*, char const*, char const*, outputStream*)+0x70
[0x00000001058649dc] load_agent(AttachOperation*, outputStream*)+0x54
[0x00000001058648a0] attach_listener_thread_entry(JavaThread*, JavaThread*)+0x260
                             (malloc=4737KB type=Serviceability +3040KB #53064 +34066)

[0x0000000105d4c7e0] JvmtiAgentList::load_agent(char const*, char const*, char const*, outputStream*)+0x58
[0x00000001058649dc] load_agent(AttachOperation*, outputStream*)+0x54
[0x00000001058648a0] attach_listener_thread_entry(JavaThread*, JavaThread*)+0x260
[0x0000000105beec90] JavaThread::thread_main_inner()+0x98
                             (malloc=4560KB type=Serviceability +2928KB #53064 +34066)
```

Everything was tested on Mac, but should be the same on Linux.

I guess it would be a good idea to add a test that verify that memory is not increased much after attach/deattach.