### PR TITLE
FlameGraph: search with Command+F key (⌘F) on mac

### DIFF
--- a/demo/flamegraph.html
+++ b/demo/flamegraph.html
@@ -260,7 +260,7 @@
 	}
 
 	window.onkeydown = function() {
-		if (event.ctrlKey && event.keyCode === 70) {
+		if ((event.ctrlKey || event.metaKey) && event.keyCode === 70) {
 			event.preventDefault();
 			search(true);
 		} else if (event.keyCode === 27) {

--- a/src/res/flame.html
+++ b/src/res/flame.html
@@ -260,7 +260,7 @@
 	}
 
 	window.onkeydown = function() {
-		if (event.ctrlKey && event.keyCode === 70) {
+		if ((event.ctrlKey || event.metaKey) && event.keyCode === 70) {
 			event.preventDefault();
 			search(true);
 		} else if (event.keyCode === 27) {


### PR DESCRIPTION
* ctrl+f is already overridden
* On OS X the default way to search on page is command+f, would be nice to have it in flamegraphs as well