### PR TITLE
[PoC] Implemented multi-producer, single-consumer queue for profiler events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /test/*.class
 .vscode
 *.iml
+#Mac filesystem mangement files
+**/.DS_Store

--- a/src/eventBuffer.cpp
+++ b/src/eventBuffer.cpp
@@ -1,0 +1,79 @@
+#include "eventBuffer.h"
+
+namespace {
+
+    template<typename T>
+    BufferedEventImpl<T>* allocEvent(LinearAllocator& allocator, T& event) {
+        //TODO: double check alignment
+        void* memory = allocator.alloc(sizeof(BufferedEventImpl<T>));
+        BufferedEventImpl<T>* bufEv = new(memory) BufferedEventImpl<T>(event);
+        return bufEv;
+    }
+    
+    //returns the new head after reversing (aka the previously last list element)
+    BufferedEvent* reverseList(BufferedEvent* head) {
+        BufferedEvent* previous = nullptr;
+        BufferedEvent* current = head;
+        while (current != nullptr) {
+            BufferedEvent* next = current->next;
+            current->next = previous;
+
+            previous = current;
+            current = next;
+        }
+        return previous;
+    }
+}
+
+void EventBuffer::publish(EventType type, Event& event, int tid, u32 call_trace_id) {
+    BufferedEvent* outEvent = nullptr;
+    switch (type)
+    {
+    case PERF_SAMPLE:
+    case EXECUTION_SAMPLE:
+    case INSTRUMENTED_METHOD:
+        outEvent = allocEvent<ExecutionEvent>(_allocator, (ExecutionEvent&)event);
+        break;
+    case ALLOC_SAMPLE:
+    case ALLOC_OUTSIDE_TLAB:
+        outEvent = allocEvent<AllocEvent>(_allocator, (AllocEvent&)event);
+        break;
+    //TODO: add other event types
+    }
+    if(outEvent == nullptr) {
+        //unsupported event type, do nothing
+        return;
+    }
+    outEvent->type = type;
+    outEvent->tid = tid;
+    outEvent->call_trace_id = call_trace_id;
+
+    //add the event as new head of the output list
+    BufferedEvent* prevHead;
+    do {
+        prevHead = _producerHead;
+        outEvent->next = prevHead;
+    } while (!_producerHead.compare_exchange_strong(prevHead, outEvent));
+}
+
+BufferedEvent* EventBuffer::poll() {
+
+    if(_consumerHead == nullptr) {
+        //Move events from _outputHead list to _consumerHead
+        //we reverse the list so that we consume the oldest events first
+        _consumerHead = reverseList(_producerHead.exchange(nullptr));
+    }
+
+    if(_consumerHead != nullptr) {
+        BufferedEvent* result = _consumerHead;
+        _consumerHead = result->next;
+        return result;
+    }
+    return nullptr;
+}
+
+void EventBuffer::clear() {
+    _producerHead = nullptr;
+    _consumerHead = nullptr;
+    _allocator.clear();
+}

--- a/src/eventBuffer.h
+++ b/src/eventBuffer.h
@@ -1,0 +1,37 @@
+#ifndef _EVENTBUFFER_H
+#define _EVENTBUFFER_H
+
+#include "event.h"
+#include "linearAllocator.h"
+#include <atomic>
+
+struct BufferedEvent {
+    BufferedEvent* next; //pointers for single linked list management
+    EventType type;
+    int tid; //native thread id on which the event was recorded
+    u32 call_trace_id; //reference to the call stacktrace stored in CallTraceStorage
+};
+
+template<typename EventStruct>
+struct BufferedEventImpl : public BufferedEvent {
+    EventStruct event;
+    BufferedEventImpl(const EventStruct& ev) : event(ev){}
+};
+
+// Simple Single Consumer, Multi Producer buffer based on single linked lists
+// Producing events is async-signal safe
+class EventBuffer {
+    LinearAllocator _allocator;
+
+    std::atomic<BufferedEvent*> _producerHead;
+    std::atomic<BufferedEvent*> _consumerHead;
+
+public:
+    void publish(EventType type, Event& event, int tid, u32 call_trace_id);
+    // consumes the next available event , returns nullptr if no event is available
+    BufferedEvent* poll();
+    // clear may only be called if no producers and consumers are currently active
+    void clear();
+};
+
+#endif


### PR DESCRIPTION
Proof of Concept implementation for the event buffer suggested in [this comment](https://github.com/async-profiler/async-profiler/issues/913#issuecomment-2042456292).
The idea is to have a multi-producer, single-consumer buffer for events, so that the consuming can happen asynchronously and outside of signal handlers.

The `EventBuffer::publish` would be called from signal handlers producing profiling events.

The implementation is complete and compiles, but hasn't been tested yet.