### PR TITLE
An option to accumulate JFR events in memory instead of flushing to a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,10 @@ $ asprof -d 30 -f /tmp/flamegraph.html 8983
   only events between the safepoint request and the start of the VM operation
   will be recorded.
 
+* `--jfropts OPTIONS` - comma separated list of JFR recording options. The only
+  option currently supported is `mem`: accumulate events in memory instead of
+  flushing synchronously to a file.
+
 * `--jfrsync CONFIG` - start Java Flight Recording with the given configuration
   synchronously with the profiler. The output .jfr file will include all regular
   JFR events, except that execution samples will be obtained from async-profiler.

--- a/README.md
+++ b/README.md
@@ -455,9 +455,10 @@ $ asprof -d 30 -f /tmp/flamegraph.html 8983
   only events between the safepoint request and the start of the VM operation
   will be recorded.
 
-* `--jfropts OPTIONS` - comma separated list of JFR recording options. The only
-  option currently supported is `mem`: accumulate events in memory instead of
-  flushing synchronously to a file.
+* `--jfropts OPTIONS` - comma separated list of JFR recording options.
+  Currently, the only available option is `mem` supported on Linux 3.17+.
+  `mem` enables accumulating events in memory instead of flushing
+  synchronously to a file.
 
 * `--jfrsync CONFIG` - start Java Flight Recording with the given configuration
   synchronously with the profiler. The output .jfr file will include all regular

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -173,7 +173,7 @@ Error Arguments::parse(const char* args) {
 
             CASE("jfrsync")
                 _output = OUTPUT_JFR;
-                _jfr_options = JFR_SYNC_OPTS;
+                _jfr_options |= JFR_SYNC_OPTS;
                 _jfr_sync = value == NULL ? "default" : value;
 
             CASE("traces")

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -63,7 +63,8 @@ static const Multiplier UNIVERSAL[] = {{'n', 1}, {'u', 1000}, {'m', 1000000}, {'
 //     flamegraph       - produce Flame Graph in HTML format
 //     tree             - produce call tree in HTML format
 //     jfr              - dump events in Java Flight Recorder format
-//     jfrsync[=CONFIG] - start Java Flight Recording with the given config along with the profiler 
+//     jfropts=OPTIONS  - JFR recording options: numeric bitmask or 'mem'
+//     jfrsync[=CONFIG] - start Java Flight Recording with the given config along with the profiler
 //     traces[=N]       - dump top N call traces
 //     flat[=N]         - dump top N methods (aka flat profile)
 //     samples          - count the number of samples (default)
@@ -167,8 +168,15 @@ Error Arguments::parse(const char* args) {
 
             CASE("jfr")
                 _output = OUTPUT_JFR;
-                if (value != NULL) {
+
+            CASE("jfropts")
+                _output = OUTPUT_JFR;
+                if (value == NULL) {
+                    msg = "Invalid jfropts";
+                } else if (value[0] >= '0' && value[0] <= '9') {
                     _jfr_options = (int)strtol(value, NULL, 0);
+                } else if (strstr(value, "mem")) {
+                    _jfr_options |= IN_MEMORY;
                 }
 
             CASE("jfrsync")

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -89,6 +89,8 @@ enum JfrOption {
     NO_CPU_LOAD     = 0x8,
     NO_HEAP_SUMMARY = 0x10,
 
+    IN_MEMORY       = 0x100,
+
     JFR_SYNC_OPTS   = NO_SYSTEM_INFO | NO_SYSTEM_PROPS | NO_NATIVE_LIBS | NO_CPU_LOAD | NO_HEAP_SUMMARY
 };
 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -78,6 +78,7 @@ static const char USAGE_STRING[] =
     "  --begin function  begin profiling when function is executed\n"
     "  --end function    end profiling when function is executed\n"
     "  --ttsp            time-to-safepoint profiling\n"
+    "  --jfropts opts    JFR recording options: mem\n"
     "  --jfrsync config  synchronize profiler with JFR recording\n"
     "  --fdtransfer      use fdtransfer to serve perf requests\n"
     "                    from the non-privileged target\n"

--- a/src/os.h
+++ b/src/os.h
@@ -83,6 +83,7 @@ class OS {
     static u64 getProcessCpuTime(u64* utime, u64* stime);
     static u64 getTotalCpuTime(u64* utime, u64* stime);
 
+    static int createMemoryFile(const char* name);
     static void copyFile(int src_fd, int dst_fd, off_t offset, size_t size);
     static void freePageCache(int fd, off_t start_offset);
 };

--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -350,6 +350,10 @@ u64 OS::getTotalCpuTime(u64* utime, u64* stime) {
     return real;
 }
 
+int OS::createMemoryFile(const char* name) {
+    return syscall(__NR_memfd_create, name, 0);
+}
+
 void OS::copyFile(int src_fd, int dst_fd, off_t offset, size_t size) {
     // copy_file_range() is probably better, but not supported on all kernels
     while (size > 0) {

--- a/src/os_macos.cpp
+++ b/src/os_macos.cpp
@@ -326,6 +326,11 @@ u64 OS::getTotalCpuTime(u64* utime, u64* stime) {
     return user + system + idle;
 }
 
+int OS::createMemoryFile(const char* name) {
+    // TODO: Use shm_open
+    return -1;
+}
+
 void OS::copyFile(int src_fd, int dst_fd, off_t offset, size_t size) {
     char* buf = (char*)mmap(NULL, size + offset, PROT_READ, MAP_PRIVATE, src_fd, 0);
     if (buf == NULL) {

--- a/src/os_macos.cpp
+++ b/src/os_macos.cpp
@@ -16,6 +16,7 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 #include <sys/times.h>
+#include <stdio.h>
 #include <time.h>
 #include <unistd.h>
 #include "os.h"
@@ -327,8 +328,13 @@ u64 OS::getTotalCpuTime(u64* utime, u64* stime) {
 }
 
 int OS::createMemoryFile(const char* name) {
-    // TODO: Use shm_open
-    return -1;
+    char buf[128];
+    snprintf(buf, sizeof(buf), "%.100s.%d", name, processId());
+    int fd = shm_open(buf, O_RDWR | O_CREAT | O_TRUNC, 0600);
+    if (fd >= 0) {
+        shm_unlink(buf);
+    }
+    return fd;
 }
 
 void OS::copyFile(int src_fd, int dst_fd, off_t offset, size_t size) {

--- a/src/os_macos.cpp
+++ b/src/os_macos.cpp
@@ -16,7 +16,6 @@
 #include <sys/sysctl.h>
 #include <sys/time.h>
 #include <sys/times.h>
-#include <stdio.h>
 #include <time.h>
 #include <unistd.h>
 #include "os.h"
@@ -328,13 +327,8 @@ u64 OS::getTotalCpuTime(u64* utime, u64* stime) {
 }
 
 int OS::createMemoryFile(const char* name) {
-    char buf[128];
-    snprintf(buf, sizeof(buf), "%.100s.%d", name, processId());
-    int fd = shm_open(buf, O_RDWR | O_CREAT | O_TRUNC, 0600);
-    if (fd >= 0) {
-        shm_unlink(buf);
-    }
-    return fd;
+    // Not supported on macOS
+    return -1;
 }
 
 void OS::copyFile(int src_fd, int dst_fd, off_t offset, size_t size) {

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1337,7 +1337,8 @@ Error Profiler::dump(Writer& out, Arguments& args) {
 
 void Profiler::printUsedMemory(Writer& out) {
     size_t call_trace_storage = _call_trace_storage.usedMemory();
-    size_t dictionaries = _class_map.usedMemory() + _symbol_map.usedMemory() + _thread_filter.usedMemory() + _jfr.usedMemory();
+    size_t flight_recording = _jfr.usedMemory();
+    size_t dictionaries = _class_map.usedMemory() + _symbol_map.usedMemory() + _thread_filter.usedMemory();
 
     size_t code_cache = _runtime_stubs.usedMemory();
     int native_lib_count = _native_libs.count();
@@ -1350,12 +1351,13 @@ void Profiler::printUsedMemory(Writer& out) {
     const size_t KB = 1024;
     snprintf(buf, sizeof(buf) - 1,
              "Call trace storage: %7zu KB\n"
+             "  Flight recording: %7zu KB\n"
              "      Dictionaries: %7zu KB\n"
              "        Code cache: %7zu KB\n"
              "------------------------------\n"
              "             Total: %7zu KB\n",
-             call_trace_storage / KB, dictionaries / KB, code_cache / KB,
-             (call_trace_storage + dictionaries + code_cache) / KB);
+             call_trace_storage / KB, flight_recording / KB, dictionaries / KB, code_cache / KB,
+             (call_trace_storage + flight_recording + dictionaries + code_cache) / KB);
     out << buf;
 }
 


### PR DESCRIPTION
Added `jfropts=mem` argument backed by `memfd_create` and supported on Linux 3.17+.
With this option, async-profiler does not dump events to a disk while profiling session is running. All events are flushed after the profiling session terminates.

As a side change, previously undocumented syntax `jfr=options` is no longer supported.