### PR TITLE
Fifo trace streaming demo

### DIFF
--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -225,6 +225,12 @@ Error Arguments::parse(const char* args) {
                     msg = "Invalid loop duration";
                 }
 
+            CASE("fifo")
+                if (value == NULL || value[0] == 0) {
+                    msg = "fifo must not be empty";
+                }
+                _fifo = value;
+
             CASE("alloc")
                 _alloc = value == NULL ? 0 : parseUnits(value, BYTES);
 

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -198,6 +198,7 @@ class Arguments {
     const char* _title;
     double _minwidth;
     bool _reverse;
+    const char* _fifo;
 
     Arguments() :
         _buf(NULL),
@@ -245,7 +246,8 @@ class Arguments {
         _end(NULL),
         _title(NULL),
         _minwidth(0),
-        _reverse(false) {
+        _reverse(false), 
+        _fifo(NULL) {
     }
 
     ~Arguments();

--- a/src/callTraceStorage.h
+++ b/src/callTraceStorage.h
@@ -8,9 +8,11 @@
 
 #include <map>
 #include <vector>
+#include <memory>
 #include "arch.h"
 #include "linearAllocator.h"
 #include "vmEntry.h"
+#include "frameName.h"
 
 
 class LongHashTable;
@@ -70,6 +72,37 @@ class CallTraceStorage {
 
     u32 put(int num_frames, ASGCT_CallFrame* frames, u64 counter);
     void add(u32 call_trace_id, u64 counter);
+};
+
+class CallTraceStreamer {
+
+private:
+        static const int TRIES_LIMIT = 0;
+        static const int HEADER_OFFSET = 4;
+
+        static bool is_eagain() {
+            return errno == EAGAIN;
+        }
+
+        std::unique_ptr<FrameName> _fn;
+        int _fifo_fd = -1;
+        int _read_fd = -1;
+        int _concurrency_level = 1;
+        int _buffer_size = 0;
+        char** _msg_buffer = NULL;
+        bool _attached = false;
+
+public:
+
+    CallTraceStreamer() = default;
+    ~CallTraceStreamer();
+
+    // cannot be used with thread ids (maybe?)
+    const char* attachFrameName(const char* fifo_name, int max_stack_depth, int concurrency_level, Arguments& args, int style, int epoch, Mutex& thread_names_lock, ThreadMap& thread_names);
+    bool attached() const;
+    int streamTrace(int num_frames, ASGCT_CallFrame* frames, u64 counter, int lock_index);
+
+    
 };
 
 #endif // _CALLTRACESTORAGE

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -433,6 +433,8 @@ int main(int argc, const char** argv) {
                 params << ",event=" << event;
             }
 
+        } else if (arg == "--fifo") {
+            params << ",fifo=" << args.next();
         } else if (arg == "-i" || arg == "--interval") {
             params << ",interval=" << args.next();
 
@@ -545,6 +547,8 @@ int main(int argc, const char** argv) {
 
     setup_output_files(pid);
     setup_lib_path();
+
+    fprintf(stderr, "params: %s\n", params.str());
 
     if (action == "collect") {
         run_fdtransfer(pid, fdtransfer);

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -28,7 +28,7 @@
 
 const int MAX_NATIVE_FRAMES = 128;
 const int RESERVED_FRAMES   = 4;
-const int CONCURRENCY_LEVEL = 16;
+const int CONCURRENCY_LEVEL = 1;
 
 
 union CallTraceBuffer {
@@ -93,6 +93,8 @@ class Profiler {
     CodeCacheArray _native_libs;
     const void* _call_stub_begin;
     const void* _call_stub_end;
+
+    CallTraceStreamer _trace_streamer;
 
     // dlopen() hook support
     void** _dlopen_entry;

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -391,6 +391,7 @@ Agent_OnAttach(JavaVM* vm, char* options, void* reserved) {
     Error error = args.parse(options);
 
     Log::open(args);
+    Log::warn("Args are %s\n", options);
 
     if (error) {
         Log::error("%s", error.message());


### PR DESCRIPTION
Демо поставки стектрейосв в online-режиме через FIFO.

По итогам, пока не имеет практического применения и потенциала развития из-за ряда проблем:
- Профилировщик в обычном режиме работает с трейсами представленными в виде указателей на jmethodId, резолвинг их в непосредственные имена методов происходит уже на этапе постпроцессинга. Для небольших приложений с не очень глубокими стектрейсами возможно проигрыш будет не очень тяжелый, но оверхед станет линейно заметнее с ростом глубины. Купировать проблему можно было бы переиспользовав callTraceStorage для кеширования отрендеренного имени, но решение все еще сомнительное.
- По сути все методы непосредственно постобработки трейсов заточены под offline однопоточный постпроцессинг и имеют не thread-safe реализацию, из-за этого компоненты невозможно использовать с CONCURRENCY_LEVEL больше 1 [без явных блокировок]

По итогам данную ветвь можно в целом признать тупиковой, ибо сложности которые необходимо преодолеть для безопасной работы не дают сильного выигрыша перед обычным запуском в loop режиме с синхронным постпроцессингом