### PR TITLE
Make parsing of features more strict and prohibit ill-formed values

### DIFF
--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -76,7 +76,7 @@ static const Multiplier UNIVERSAL[] = {{'n', 1}, {'u', 1000}, {'m', 1000000}, {'
 //     interval=N       - sampling interval in ns (default: 10'000'000, i.e. 10 ms)
 //     jstackdepth=N    - maximum Java stack depth (default: 2048)
 //     signal=N         - use alternative signal for cpu or wall clock profiling
-//     features=LIST    - advanced stack trace features (vtable, comptask)"
+//     features=LIST    - advanced stack trace features (vtable, comptask, probesp)"
 //     safemode=BITS    - disable stack recovery techniques (default: 0, i.e. everything enabled)
 //     file=FILENAME    - output file name for dumping
 //     log=FILENAME     - log warnings and errors to the given dedicated stream
@@ -269,9 +269,14 @@ Error Arguments::parse(const char* args) {
 
             CASE("features")
                 if (value != NULL) {
+                    // strstr to allow list of arguments in free form
                     if (strstr(value, "probesp"))  _features.probe_sp = 1;
                     if (strstr(value, "vtable"))   _features.vtable_target = 1;
                     if (strstr(value, "comptask")) _features.comp_task = 1;
+                    if (!_features.probe_sp && !_features.vtable_target && !_features.comp_task) {
+                        msg = "Incorrect features value, must include one of: "
+                              "'probesp', 'vtable', 'comptask' ";
+                    }
                 }
 
             CASE("safemode") {

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -57,7 +57,7 @@ static const char USAGE_STRING[] =
     "  -I include        output only stack traces containing the specified pattern\n"
     "  -X exclude        exclude stack traces with the specified pattern\n"
     "  -L level          log level: debug|info|warn|error|none\n"
-    "  -F features       advanced stack trace features: vtable, comptask\n"
+    "  -F features       advanced stack trace features: vtable, comptask, probesp\n"
     "  -v, --version     display version string\n"
     "\n"
     "  --title string    FlameGraph title\n"


### PR DESCRIPTION
Prevent errors in the case when a completely invalid value was passed (e.g. 'vtabl' or 'comptaks').

Rationale: typos in command-line scripts when the value is ill-formed before this commit are silently ignored. Taking into account that `--features` (potentially slightly) change the profiling result, such an error might skew the expected results and cause some debugging time that could've been avoided.