### PR TITLE
#955 Add an asprof option to specify the path of libasyncProfier.so in the container

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -82,6 +82,7 @@ static const char USAGE_STRING[] =
     "  --jfrsync config  synchronize profiler with JFR recording\n"
     "  --fdtransfer      use fdtransfer to serve perf requests\n"
     "                    from the non-privileged target\n"
+    "  --libpath path    full path to libasyncProfiler.so in the container\n"
     "\n"
     "<pid> is a numeric process ID of the target JVM\n"
     "      or 'jps' keyword to find running JVM automatically\n"
@@ -458,6 +459,9 @@ int main(int argc, const char** argv) {
         } else if (arg == "-l" || arg == "--lib") {
             format << ",lib";
 
+        } else if (arg == "--libpath") {
+            libpath = args.next();
+
         } else if (arg == "-I" || arg == "--include") {
             format << ",include=" << args.next();
 
@@ -545,7 +549,9 @@ int main(int argc, const char** argv) {
     }
 
     setup_output_files(pid);
-    setup_lib_path();
+    if (libpath == "") {
+        setup_lib_path();
+    }
 
     if (action == "collect") {
         run_fdtransfer(pid, fdtransfer);


### PR DESCRIPTION
Hi, could I have a review of this PR. I would appreciate it.

### Description
Add --libpath option to specify the path of libasyncProfier.so in the container

### Related issues
https://github.com/async-profiler/async-profiler/issues/955

### Motivation and context
In async-profiler 2.9, there is an option --lib path in profiler.sh to specify the path of libasyncProfier.so in the container.
But in 3.0 and above, this option is missing. After [discussion](https://github.com/async-profiler/async-profiler/issues/955), I know that there is a plan is to make asprof automatically provide libasyncProfier.so to the process inside a container, but no timeline for this feature, adding --libpath is straightforward and acceptable.

### How has this been tested?
The tests below ran in both container and non-container scenarios, all passed:
- If --libpath is not used, the libasyncProfiler.so relative to asprof is used.
- If --libpath is used and the file exists, the specified libasyncProfiler.so is used.
- If --libpath is used and the file does not exist, asprof reports: `Target JVM failed to load /tmp/libasyncProfiler.so.1`.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
