### PR TITLE
Make JfrClass field() public for field visibility in Jfr Event classes.

### DIFF
--- a/src/converter/one/jfr/JfrClass.java
+++ b/src/converter/one/jfr/JfrClass.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-class JfrClass extends Element {
+public class JfrClass extends Element {
     final int id;
     final boolean simpleType;
     final String name;
@@ -29,7 +29,7 @@ class JfrClass extends Element {
         }
     }
 
-    JfrField field(String name) {
+    public JfrField field(String name) {
         for (JfrField field : fields) {
             if (field.name.equals(name)) {
                 return field;

--- a/src/converter/one/jfr/JfrField.java
+++ b/src/converter/one/jfr/JfrField.java
@@ -7,7 +7,7 @@ package one.jfr;
 
 import java.util.Map;
 
-class JfrField extends Element {
+public class JfrField extends Element {
     final String name;
     final int type;
     final boolean constantPool;


### PR DESCRIPTION
### Description
Make JfrClass `field()` method public so that event classes are able to read the fields found within the respective event and make parsing decisions based on found fields.

### Related issues


### Motivation and context
The Jfr event G1HeapSummary introduced the field `oldGenUsedSize` which only exists for jdk21. This change allows parsers to check for this dynamic field by calling the `field()` method in the `JfrClass`.

### How has this been tested?
Built locally.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
