### PR TITLE
Add flamegraph to collapsed conversion in test framework

### DIFF
--- a/test/test/alloc/AllocTests.java
+++ b/test/test/alloc/AllocTests.java
@@ -30,11 +30,9 @@ public class AllocTests {
         Output out = p.profile("-e alloc -d 3 -o collapsed --total");
         assert out.samples("java.util.HashMap\\$Node\\[]") > 1_000_000;
 
-        /* Commented out as part of disabling asserting JFR output.
         out = p.profile("stop -o flamegraph --total");
-        assert out.contains("f\\(\\d+,\\d+,\\d+,\\d,'java.lang.Long'\\)");
-        assert out.contains("f\\(\\d+,\\d+,\\d+,\\d,'java.util.HashMap\\$Node\\[]'\\)");
-        */
+        assert out.contains("java\\.lang\\.Long");
+        assert out.contains("java\\.util\\.HashMap\\$Node\\[]");
     }
 
     @Test(mainClass = Hello.class, enabled = false, agentArgs = "start,event=alloc,alloc=1,cstack=fp,flamegraph,file=%f", jvmArgs = "-XX:+UseG1GC -XX:-UseTLAB")

--- a/test/test/kernel/KernelTests.java
+++ b/test/test/kernel/KernelTests.java
@@ -19,15 +19,11 @@ public class KernelTests {
         Output out = p.profile("-e cpu -d 3 -i 1ms -o collapsed");
         Output err = p.readFile(TestProcess.PROFERR);
         assert out.contains("test/kernel/ListFiles.listFiles;java/io/File");
-        if (!err.contains("Kernel symbols are unavailable")) {
-            assert out.contains("sys_getdents");
-        }
+        assert err.contains("Kernel symbols are unavailable") || out.contains("sys_getdents");
 
         out = p.profile("stop -o flamegraph");
-//        assert out.contains("f\\(\\d+,\\d+,\\d+,\\d,'java/io/File.list'(,\\d+,\\d+,\\d+)?\\)");
-//        if (!err.contains("Kernel symbols are unavailable")) {
-//            assert out.contains("sys_getdents");
-//        }
+        assert out.contains("java/io/File.list");
+        assert err.contains("Kernel symbols are unavailable") || out.contains("sys_getdents");
     }
 
     @Test(mainClass = ListFiles.class, os = Os.LINUX)

--- a/test/test/lock/LockTests.java
+++ b/test/test/lock/LockTests.java
@@ -14,7 +14,8 @@ public class LockTests {
     @Test(mainClass = DatagramTest.class, debugNonSafepoints = true) // Fails on Alpine
     public void datagramSocketLock(TestProcess p) throws Exception {
         Output out = p.profile("-e cpu -d 3 -o collapsed --cstack dwarf");
-        assert out.ratio("(PlatformEvent::.ark|PlatformEvent::.npark)") > 0.1 || (out.ratio("ReentrantLock.lock") > 0.1 && out.contains("Unsafe_.ark"));
+        assert out.ratio("(PlatformEvent::.ark|PlatformEvent::.npark)") > 0.1
+                || (out.ratio("ReentrantLock.lock") > 0.1 && out.contains("Unsafe_.ark"));
         out = p.profile("-e lock -d 3 -o collapsed");
         assert out.samples("sun/nio/ch/DatagramChannelImpl.send") > 10;
     }


### PR DESCRIPTION
### Description
The commit includes the following changes:
* Addition of flamegraph to collapsed conversion for test assertions.
* Uncommenting flamegraph test assertions.

### Related issues
N/A

### Motivation and context
Flamegraph generation has changed leading to flamegraph test assertion failures. The test framework required changes to accommodate the flamegraph changes. 

### How has this been tested?
Tested on AL2_x86_64, aarch64 and macOs

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
