### PR TITLE
Avoid JVM crash by deleting JNI refs after calling GetMethodDeclaringClass

### DIFF
--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -134,6 +134,8 @@ class Lookup {
     Dictionary _symbols;
 
   private:
+    JNIEnv* _jni;
+
     void fillNativeMethodInfo(MethodInfo* mi, const char* name, const char* lib_name) {
         if (lib_name == NULL) {
             mi->_class = _classes->lookup("");
@@ -198,6 +200,9 @@ class Lookup {
             mi->_sig = _symbols.lookup("()L;");
         }
 
+        if (method_class) {
+            _jni->DeleteLocalRef(method_class);
+        }
         jvmti->Deallocate((unsigned char*)method_sig);
         jvmti->Deallocate((unsigned char*)method_name);
         jvmti->Deallocate((unsigned char*)class_name);
@@ -227,7 +232,7 @@ class Lookup {
 
   public:
     Lookup(MethodMap* method_map, Dictionary* classes) :
-        _method_map(method_map), _classes(classes), _packages(), _symbols() {
+        _method_map(method_map), _classes(classes), _packages(), _symbols(), _jni(VM::jni()) {
     }
 
     MethodInfo* resolveMethod(ASGCT_CallFrame& frame) {

--- a/src/frameName.cpp
+++ b/src/frameName.cpp
@@ -80,7 +80,8 @@ FrameName::FrameName(Arguments& args, int style, int epoch, Mutex& thread_names_
     _cache_epoch((unsigned char)epoch),
     _cache_max_age(args._mcache),
     _thread_names_lock(thread_names_lock),
-    _thread_names(thread_names)
+    _thread_names(thread_names),
+    _jni(VM::jni())
 {
     // Require printf to use standard C format regardless of system locale
     _saved_locale = uselocale(newlocale(LC_NUMERIC_MASK, "C", (locale_t)0));
@@ -189,6 +190,9 @@ void FrameName::javaMethodName(jmethodID method) {
         _str.assign(buf);
     }
 
+    if (method_class) {
+        _jni->DeleteLocalRef(method_class);
+    }
     jvmti->Deallocate((unsigned char*)class_name);
     jvmti->Deallocate((unsigned char*)method_sig);
     jvmti->Deallocate((unsigned char*)method_name);

--- a/src/frameName.h
+++ b/src/frameName.h
@@ -54,6 +54,7 @@ class FrameName {
   private:
     static JMethodCache _cache;
 
+    JNIEnv* _jni;
     ClassMap _class_names;
     std::vector<Matcher> _include;
     std::vector<Matcher> _exclude;

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -126,7 +126,7 @@ class VM {
 
     static JNIEnv* jni() {
         JNIEnv* jni;
-        return _vm->GetEnv((void**)&jni, JNI_VERSION_1_6) == 0 ? jni : NULL;
+        return _vm && _vm->GetEnv((void**)&jni, JNI_VERSION_1_6) == 0 ? jni : NULL;
     }
 
     static JNIEnv* attachThread(const char* name) {


### PR DESCRIPTION
This is a partial fix for https://github.com/async-profiler/async-profiler/issues/974, complementing JDK-8268364.

### How has this been tested?
Backported JDK-8268364 into Java 17 and tested with reproducer at [gist](https://gist.github.com/krk/a0800bac5bc5a01709be85637285a965):

```
javac Main.java
gcc -shared -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/linux" -fPIC repro.cpp -orepro.so

# Low Xmx to pressure GC into unloading classes sooner.
java -agentpath:"$(pwd)/repro.so" -Xmx100m Main
```