### PR TITLE
Profiling output respects loglevel.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /test/*.class
 .vscode
 *.iml
+/src/api/**/*.class

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -62,6 +62,15 @@ void Log::close() {
     }
 }
 
+void Log::writeRaw(LogLevel level, const char* msg, size_t len) {
+    if (level < _level) {
+        return;
+    }
+
+    fwrite(msg, 1, len, _file);
+    fflush(_file);
+}
+
 void Log::log(LogLevel level, const char* msg, va_list args) {
     char buf[1024];
     size_t len = vsnprintf(buf, sizeof(buf), msg, args);

--- a/src/log.h
+++ b/src/log.h
@@ -41,6 +41,7 @@ class Log {
     static void close();
 
     static void log(LogLevel level, const char* msg, va_list args);
+    static void writeRaw(LogLevel level, const char* msg, size_t len);
 
     static void ATTR_FORMAT trace(const char* msg, ...);
     static void ATTR_FORMAT debug(const char* msg, ...);

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1752,7 +1752,7 @@ Error Profiler::runInternal(Arguments& args, Writer& out) {
 
 Error Profiler::run(Arguments& args) {
     if (!args.hasOutputFile()) {
-        FileWriter out(STDOUT_FILENO);
+        LogWriter out;
         return runInternal(args, out);
     } else {
         // Open output file under the lock to avoid races with background timer

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -99,3 +99,7 @@ void CallbackWriter::write(const char* data, size_t len) {
         _output_callback(data, len);
     }
 }
+
+void LogWriter::write(const char* data, size_t len) {
+    Log::writeRaw(_logLevel, data, len);
+}

--- a/src/writer.h
+++ b/src/writer.h
@@ -7,6 +7,7 @@
 #define _WRITER_H
 
 #include "asprof.h"
+#include "log.h"
 
 
 class Writer {
@@ -46,6 +47,16 @@ class FileWriter : public Writer {
 
     bool is_open() const {
         return _fd >= 0;
+    }
+
+    virtual void write(const char* data, size_t len);
+};
+
+class LogWriter : public Writer {
+    LogLevel _logLevel;
+
+  public:
+    LogWriter(LogLevel logLevel = LOG_INFO) : _logLevel(logLevel) {
     }
 
     virtual void write(const char* data, size_t len);


### PR DESCRIPTION
### Description

"Profiling started" and other messages are now INFO loglevel and will respect the current loglevel.

### Related issues
https://github.com/async-profiler/async-profiler/issues/960

### Motivation and context
All messages should respect loglevel, "Profiling started" etc. messages did not.

### How has this been tested?
With different `loglevel` parameters:

```
java ... -agentpath: ...,loglevel=info ...
Profiling started
```

```
java ... -agentpath: ...,loglevel=warn ...
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
