### PR TITLE
Change flame graph ordering of frames from by-name to by-total

### DIFF
--- a/src/flameGraph.cpp
+++ b/src/flameGraph.cpp
@@ -204,7 +204,7 @@ void FlameGraph::printFrame(Writer& out, u32 key, const Trie& f, int level, u64 
     for (std::map<u32, Trie>::const_iterator it = f._children.begin(); it != f._children.end(); ++it) {
         children.push_back(Node(it->first, _name_order[f.nameIndex(it->first)], it->second));
     }
-    std::sort(children.begin(), children.end(), Node::orderByName);
+    std::sort(children.begin(), children.end(), Node::orderByTotal);
 
     x += f._self;
     for (size_t i = 0; i < children.size(); i++) {


### PR DESCRIPTION
### Description
Changes frame ordering from by-name to by-total in flame graphs.

### Motivation and context
Usually when someone is using flame graphs, they are looking for performance problems. If there is a large number of frames, it is near impossible to visually make out the most expensive one. This orders them by total time, which is much easier to read.

### How has this been tested?
I habe been using this for some time for profiling/debugging.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
