### PR TITLE
Fix KernelTests#notLinux test

### DIFF
--- a/test/one/profiler/test/TestProcess.java
+++ b/test/one/profiler/test/TestProcess.java
@@ -248,14 +248,16 @@ public class TestProcess implements Closeable {
 
     public Output profile(String args, boolean sudo) throws IOException, TimeoutException, InterruptedException {
         List<String> cmd = new ArrayList<>();
-        if (sudo) {
+        System.err.println("Run profile with");
+	if (sudo) {
+		System.err.println("    sudo");
             cmd.add("/usr/bin/sudo");
         }
         cmd.add("build/bin/asprof");
         addArgs(cmd, args);
         cmd.add(Long.toString(pid()));
         log.log(Level.FINE, "Profiling " + cmd);
-
+System.out.println("   command " + cmd);
         Process p = new ProcessBuilder(cmd)
                 .redirectOutput(createTempFile(PROFOUT))
                 .redirectError(createTempFile(PROFERR))

--- a/test/one/profiler/test/TestProcess.java
+++ b/test/one/profiler/test/TestProcess.java
@@ -248,16 +248,14 @@ public class TestProcess implements Closeable {
 
     public Output profile(String args, boolean sudo) throws IOException, TimeoutException, InterruptedException {
         List<String> cmd = new ArrayList<>();
-        System.err.println("Run profile with");
-	if (sudo) {
-		System.err.println("    sudo");
+        if (sudo) {
             cmd.add("/usr/bin/sudo");
         }
         cmd.add("build/bin/asprof");
         addArgs(cmd, args);
         cmd.add(Long.toString(pid()));
         log.log(Level.FINE, "Profiling " + cmd);
-System.out.println("   command " + cmd);
+
         Process p = new ProcessBuilder(cmd)
                 .redirectOutput(createTempFile(PROFOUT))
                 .redirectError(createTempFile(PROFERR))

--- a/test/test/kernel/KernelTests.java
+++ b/test/test/kernel/KernelTests.java
@@ -41,7 +41,6 @@ public class KernelTests {
             p.profile("-e cpu -d 3 -i 1ms -o collapsed -f %f --fdtransfer");
             throw new AssertionError("FdTransferClient should succeed on Linux only");
         } catch (IOException e) {
-            System.err.println("file content: " + p.readFile(TestProcess.PROFERR));
             assert p.readFile(TestProcess.PROFERR).contains("Failed to initialize FdTransferClient");
         }
     }

--- a/test/test/kernel/KernelTests.java
+++ b/test/test/kernel/KernelTests.java
@@ -38,7 +38,7 @@ public class KernelTests {
     @Test(mainClass = ListFiles.class, jvmArgs = "-XX:+UseParallelGC -Xmx1g -Xms1g", os = {Os.MACOS, Os.WINDOWS})
     public void notLinux(TestProcess p) throws Exception {
         try {
-            p.profile("-e cpu -d 3 -i 1ms -o collapsed -f %f --fdtransfer", true);
+            p.profile("-e cpu -d 3 -i 1ms -o collapsed -f %f --fdtransfer", false);
             throw new AssertionError("FdTransferClient should succeed on Linux only");
         } catch (IOException e) {
             assert p.readFile(TestProcess.PROFERR).contains("Failed to initialize FdTransferClient");

--- a/test/test/kernel/KernelTests.java
+++ b/test/test/kernel/KernelTests.java
@@ -38,9 +38,10 @@ public class KernelTests {
     @Test(mainClass = ListFiles.class, jvmArgs = "-XX:+UseParallelGC -Xmx1g -Xms1g", os = {Os.MACOS, Os.WINDOWS})
     public void notLinux(TestProcess p) throws Exception {
         try {
-            p.profile("-e cpu -d 3 -i 1ms -o collapsed -f %f --fdtransfer", false);
+            p.profile("-e cpu -d 3 -i 1ms -o collapsed -f %f --fdtransfer");
             throw new AssertionError("FdTransferClient should succeed on Linux only");
         } catch (IOException e) {
+            System.err.println("file content: " + p.readFile(TestProcess.PROFERR));
             assert p.readFile(TestProcess.PROFERR).contains("Failed to initialize FdTransferClient");
         }
     }


### PR DESCRIPTION
### Description

Fix the timeout of the `KernelTests#notLinux` test by not running it with `/usr/bin/sudo`.

### Motivation and context

Running `/usr/bin/sudo` on Mac as a non-root user, asks the user for a password infinitely, so the running the profiler with sudo causes timeouts on Mac. 

### How has this been tested?

Ran it on Mac with different Java versions.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
