### PR TITLE
Make profiler version and arch tag configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-PROFILER_VERSION=3.0
+ifeq ($(PROFILER_VERSION),)
+  PROFILER_VERSION=3.0
+endif
 
 ifeq ($(COMMIT_TAG),true)
   PROFILER_VERSION := $(PROFILER_VERSION)-$(shell git rev-parse --short=8 HEAD)
@@ -76,23 +78,25 @@ else
   OS_TAG=linux
 endif
 
-ARCH:=$(shell uname -m)
-ifeq ($(ARCH),x86_64)
-  ARCH_TAG=x64
-else ifeq ($(ARCH),aarch64)
-  ARCH_TAG=arm64
-else ifeq ($(ARCH),arm64)
-  ARCH_TAG=arm64
-else ifeq ($(findstring arm,$(ARCH)),arm)
-  ARCH_TAG=arm32
-else ifeq ($(ARCH),ppc64le)
-  ARCH_TAG=ppc64le
-else ifeq ($(ARCH),riscv64)
-  ARCH_TAG=riscv64
-else ifeq ($(ARCH),loongarch64)
-  ARCH_TAG=loongarch64
-else
-  ARCH_TAG=x86
+ifeq ($(ARCH_TAG),)
+  ARCH:=$(shell uname -m)
+  ifeq ($(ARCH),x86_64)
+    ARCH_TAG=x64
+  else ifeq ($(ARCH),aarch64)
+    ARCH_TAG=arm64
+  else ifeq ($(ARCH),arm64)
+    ARCH_TAG=arm64
+  else ifeq ($(findstring arm,$(ARCH)),arm)
+    ARCH_TAG=arm32
+  else ifeq ($(ARCH),ppc64le)
+    ARCH_TAG=ppc64le
+  else ifeq ($(ARCH),riscv64)
+    ARCH_TAG=riscv64
+  else ifeq ($(ARCH),loongarch64)
+    ARCH_TAG=loongarch64
+  else
+    ARCH_TAG=x86
+  endif
 endif
 
 STATIC_BINARY=$(findstring musl-gcc,$(CC))

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-ifeq ($(PROFILER_VERSION),)
-  PROFILER_VERSION=3.0
-endif
+PROFILER_VERSION ?= 3.0
 
 ifeq ($(COMMIT_TAG),true)
   PROFILER_VERSION := $(PROFILER_VERSION)-$(shell git rev-parse --short=8 HEAD)


### PR DESCRIPTION
### Description

I am trying to cross-compile async-profiler binaries in my CI. I am doing this on x86_64 host. Unfortunately, `ARCH_TAG` is getting rewritten by the unconditional `uname -a`. Additionally, current build produces the binaries that claim they are `3.0`, but that is misleading.

### Related issues

No related issues?

### Motivation and context

Enough configuration to make cross-compiled builds work.

### How has this been tested?

The default invocation of `make clean release` seems to produce the same result. For cross-compilation testing, I added this patch into my build pipeline, and then set `PROFILER_VERSION=nightly ARCH_TAG=... CROSS_COMPILE=...`. It produces the following binaries: https://builds.shipilev.net/async-profiler/

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
