### PR TITLE
#1007: Optimize wall clock profiling

### DIFF
--- a/src/arch.h
+++ b/src/arch.h
@@ -16,6 +16,10 @@ static inline u64 atomicInc(volatile u64& var, u64 increment = 1) {
     return __sync_fetch_and_add(&var, increment);
 }
 
+static inline int atomicInc(volatile u32& var, int increment = 1) {
+    return __sync_fetch_and_add(&var, increment);
+}
+
 static inline int atomicInc(volatile int& var, int increment = 1) {
     return __sync_fetch_and_add(&var, increment);
 }

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -59,6 +59,7 @@ static const Multiplier UNIVERSAL[] = {{'n', 1}, {'u', 1000}, {'m', 1000000}, {'
 //     live             - build allocation profile from live objects only
 //     lock[=DURATION]  - profile contended locks overflowing the DURATION ns bucket (default: 10us)
 //     wall[=NS]        - run wall clock profiling together with CPU profiling
+//     nobatch          - legacy wall clock sampling without batch events
 //     collapsed        - dump collapsed stacks (the format used by FlameGraph script)
 //     flamegraph       - produce Flame Graph in HTML format
 //     tree             - produce call tree in HTML format
@@ -334,6 +335,9 @@ Error Arguments::parse(const char* args) {
 
             CASE("live")
                 _live = true;
+
+            CASE("nobatch")
+                _nobatch = true;
 
             CASE("allkernel")
                 _ring = RING_KERNEL;

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -182,6 +182,7 @@ class Arguments {
     bool _threads;
     bool _sched;
     bool _live;
+    bool _nobatch;
     bool _fdtransfer;
     const char* _fdtransfer_path;
     int _style;
@@ -231,6 +232,7 @@ class Arguments {
         _threads(false),
         _sched(false),
         _live(false),
+        _nobatch(false),
         _fdtransfer(false),
         _fdtransfer_path(NULL),
         _style(0),

--- a/src/callTraceStorage.cpp
+++ b/src/callTraceStorage.cpp
@@ -274,7 +274,7 @@ u32 CallTraceStorage::put(int num_frames, ASGCT_CallFrame* frames, u64 counter) 
     return capacity - (INITIAL_CAPACITY - 1) + slot;
 }
 
-void CallTraceStorage::add(u32 call_trace_id, u64 counter) {
+void CallTraceStorage::add(u32 call_trace_id, u64 samples, u64 counter) {
     if (call_trace_id == OVERFLOW_TRACE_ID) {
         return;
     }
@@ -283,7 +283,7 @@ void CallTraceStorage::add(u32 call_trace_id, u64 counter) {
     for (LongHashTable* table = _current_table; table != NULL; table = table->prev()) {
         if (call_trace_id >= table->capacity()) {
             CallTraceSample& s = table->values()[call_trace_id - table->capacity()];
-            atomicInc(s.samples);
+            atomicInc(s.samples, samples);
             atomicInc(s.counter, counter);
             break;
         }

--- a/src/callTraceStorage.h
+++ b/src/callTraceStorage.h
@@ -69,7 +69,7 @@ class CallTraceStorage {
     void collectSamples(std::map<u64, CallTraceSample>& map);
 
     u32 put(int num_frames, ASGCT_CallFrame* frames, u64 counter);
-    void add(u32 call_trace_id, u64 counter);
+    void add(u32 call_trace_id, u64 samples, u64 counter);
 };
 
 #endif // _CALLTRACESTORAGE

--- a/src/converter/one/jfr/event/Event.java
+++ b/src/converter/one/jfr/event/Event.java
@@ -52,6 +52,10 @@ public abstract class Event implements Comparable<Event> {
         return 0;
     }
 
+    public long samples() {
+        return 1;
+    }
+
     public long value() {
         return 1;
     }

--- a/src/converter/one/jfr/event/EventAggregator.java
+++ b/src/converter/one/jfr/event/EventAggregator.java
@@ -26,14 +26,14 @@ public class EventAggregator {
         int i = hashCode(e) & mask;
         while (keys[i] != null) {
             if (sameGroup(keys[i], e)) {
-                values[i] += total ? e.value() : 1;
+                values[i] += total ? e.value() : e.samples();
                 return;
             }
             i = (i + 1) & mask;
         }
 
         keys[i] = e;
-        values[i] = total ? e.value() : 1;
+        values[i] = total ? e.value() : e.samples();
 
         if (++size * 2 > keys.length) {
             resize(keys.length * 2);

--- a/src/converter/one/jfr/event/ExecutionSample.java
+++ b/src/converter/one/jfr/event/ExecutionSample.java
@@ -7,9 +7,21 @@ package one.jfr.event;
 
 public class ExecutionSample extends Event {
     public final int threadState;
+    public final int samples;
 
-    public ExecutionSample(long time, int tid, int stackTraceId, int threadState) {
+    public ExecutionSample(long time, int tid, int stackTraceId, int threadState, int samples) {
         super(time, tid, stackTraceId);
         this.threadState = threadState;
+        this.samples = samples;
+    }
+
+    @Override
+    public long samples() {
+        return samples;
+    }
+
+    @Override
+    public long value() {
+        return samples;
     }
 }

--- a/src/cpuEngine.cpp
+++ b/src/cpuEngine.cpp
@@ -95,7 +95,8 @@ int CpuEngine::createForAllThreads() {
     int result = EPERM;
 
     ThreadList* thread_list = OS::listThreads();
-    for (int tid; (tid = thread_list->next()) != -1; ) {
+    while (thread_list->hasNext()) {
+        int tid = thread_list->next();
         int err = createForThread(tid);
         if (isResourceLimit(err)) {
             result = err;

--- a/src/event.h
+++ b/src/event.h
@@ -14,6 +14,7 @@
 enum EventType {
     PERF_SAMPLE,
     EXECUTION_SAMPLE,
+    WALL_CLOCK_SAMPLE,
     INSTRUMENTED_METHOD,
     ALLOC_SAMPLE,
     ALLOC_OUTSIDE_TLAB,
@@ -37,6 +38,13 @@ class ExecutionEvent : public Event {
     ThreadState _thread_state;
 
     ExecutionEvent(u64 start_time) : _start_time(start_time), _thread_state(THREAD_UNKNOWN) {}
+};
+
+class WallClockEvent : public Event {
+  public:
+    u64 _start_time;
+    ThreadState _thread_state;
+    u32 _samples;
 };
 
 class AllocEvent : public EventWithClassId {

--- a/src/jfrMetadata.cpp
+++ b/src/jfrMetadata.cpp
@@ -221,6 +221,14 @@ JfrMetadata::JfrMetadata() : Element("root") {
                 << field("allocationSize", T_LONG, "Allocation Size", F_BYTES)
                 << field("allocationTime", T_LONG, "Allocation Time", F_TIME_TICKS))
 
+            << (type("profiler.WallClockSample", T_WALL_CLOCK_SAMPLE, "Wall Clock Sample")
+                << category("Java Virtual Machine", "Profiling")
+                << field("startTime", T_LONG, "Start Time", F_TIME_TICKS)
+                << field("sampledThread", T_THREAD, "Thread", F_CPOOL)
+                << field("stackTrace", T_STACK_TRACE, "Stack Trace", F_CPOOL)
+                << field("state", T_THREAD_STATE, "Thread State", F_CPOOL)
+                << field("samples", T_INT, "Samples", F_UNSIGNED))
+
             << (type("jdk.jfr.Label", T_LABEL, NULL)
                 << field("value", T_STRING))
 

--- a/src/jfrMetadata.h
+++ b/src/jfrMetadata.h
@@ -59,6 +59,7 @@ enum JfrType {
     T_LOG = 115,
     T_WINDOW = 116,
     T_LIVE_OBJECT = 117,
+    T_WALL_CLOCK_SAMPLE = 118,
 
     T_ANNOTATION = 200,
     T_LABEL = 201,

--- a/src/objectSampler.cpp
+++ b/src/objectSampler.cpp
@@ -115,7 +115,7 @@ class LiveRefs {
 
                     int tid = _values[i].trace >> 32;
                     u32 call_trace_id = (u32)_values[i].trace;
-                    profiler->recordExternalSample(event._alloc_size, tid, LIVE_OBJECT, &event, call_trace_id);
+                    profiler->recordExternalSamples(1, event._alloc_size, tid, call_trace_id, LIVE_OBJECT, &event);
                 }
                 jni->DeleteWeakGlobalRef(w);
             }

--- a/src/os.h
+++ b/src/os.h
@@ -27,11 +27,25 @@ enum ThreadState {
 
 
 class ThreadList {
+  protected:
+    u32 _index;
+    u32 _count;
+
+    ThreadList() : _index(0), _count(0) {
+    }
+
   public:
     virtual ~ThreadList() {}
-    virtual void rewind() = 0;
+
+    u32 index() const { return _index; }
+    u32 count() const { return _count; }
+
+    bool hasNext() const {
+        return _index < _count;
+    }
+
     virtual int next() = 0;
-    virtual int size() = 0;
+    virtual void update() = 0;
 };
 
 
@@ -66,6 +80,7 @@ class OS {
     static const char* schedPolicy(int thread_id);
     static bool threadName(int thread_id, char* name_buf, size_t name_len);
     static ThreadState threadState(int thread_id);
+    static u64 threadCpuTime(int thread_id);
     static ThreadList* listThreads();
 
     static bool isLinux();

--- a/src/os_macos.cpp
+++ b/src/os_macos.cpp
@@ -25,14 +25,14 @@ class MacThreadList : public ThreadList {
   private:
     task_t _task;
     thread_array_t _thread_array;
-    unsigned int _thread_count;
-    unsigned int _thread_index;
 
-    void ensureThreadArray() {
-        if (_thread_array == NULL) {
-            _thread_count = 0;
-            _thread_index = 0;
-            task_threads(_task, &_thread_array, &_thread_count);
+    void deallocate() {
+        if (_thread_array != NULL) {
+            for (u32 i = 0; i < _count; i++) {
+                mach_port_deallocate(_task, _thread_array[i]);
+            }
+            vm_deallocate(_task, (vm_address_t)_thread_array, _count * sizeof(thread_t));
+            _thread_array = NULL;
         }
     }
 
@@ -40,33 +40,21 @@ class MacThreadList : public ThreadList {
     MacThreadList() {
         _task = mach_task_self();
         _thread_array = NULL;
+        task_threads(_task, &_thread_array, &_count);
     }
 
     ~MacThreadList() {
-        rewind();
-    }
-
-    void rewind() {
-        if (_thread_array != NULL) {
-            for (int i = 0; i < _thread_count; i++) {
-                mach_port_deallocate(_task, _thread_array[i]);
-            }
-            vm_deallocate(_task, (vm_address_t)_thread_array, _thread_count * sizeof(thread_t));
-            _thread_array = NULL;
-        }
+        deallocate();
     }
 
     int next() {
-        ensureThreadArray();
-        if (_thread_index < _thread_count) {
-            return (int)_thread_array[_thread_index++];
-        }
-        return -1;
+        return (int)_thread_array[_index++];
     }
 
-    int size() {
-        ensureThreadArray();
-        return _thread_count;
+    void update() {
+        deallocate();
+        _index = _count = 0;
+        task_threads(_task, &_thread_array, &_count);
     }
 };
 
@@ -185,6 +173,18 @@ ThreadState OS::threadState(int thread_id) {
         return THREAD_UNKNOWN;
     }
     return info.run_state == TH_STATE_RUNNING ? THREAD_RUNNING : THREAD_SLEEPING;
+}
+
+u64 OS::threadCpuTime(int thread_id) {
+    if (thread_id == 0) thread_id = threadId();
+
+    struct thread_basic_info info;
+    mach_msg_type_number_t size = sizeof(info);
+    if (thread_info((thread_act_t)thread_id, THREAD_BASIC_INFO, (thread_info_t)&info, &size) != 0) {
+        return 0;
+    }
+    return u64(info.user_time.seconds + info.system_time.seconds) * 1000000000 +
+           u64(info.user_time.microseconds + info.system_time.microseconds) * 1000;
 }
 
 ThreadList* OS::listThreads() {

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -203,7 +203,7 @@ class Profiler {
     int convertNativeTrace(int native_frames, const void** callchain, ASGCT_CallFrame* frames, EventType event_type);
     u64 recordSample(void* ucontext, u64 counter, EventType event_type, Event* event);
     void recordExternalSample(u64 counter, int tid, EventType event_type, Event* event, int num_frames, ASGCT_CallFrame* frames);
-    void recordExternalSample(u64 counter, int tid, EventType event_type, Event* event, u32 call_trace_id);
+    void recordExternalSamples(u64 samples, u64 counter, int tid, u32 call_trace_id, EventType event_type, Event* event);
     void recordEventOnly(EventType event_type, Event* event);
     void writeLog(LogLevel level, const char* message);
     void writeLog(LogLevel level, const char* message, size_t len);

--- a/src/wallClock.cpp
+++ b/src/wallClock.cpp
@@ -20,12 +20,83 @@ const int THREADS_PER_TICK = 8;
 
 // Set the hard limit for thread walking interval to 100 microseconds.
 // Smaller intervals are practically unusable due to large overhead.
-const long MIN_INTERVAL = 100000;
+const long long MIN_INTERVAL = 100000;
+
+// How much CPU time a thread can spend after being sampled as idle
+// until it is considered runnable.
+const u64 RUNNABLE_THRESHOLD_NS = 10000;
+
+// How many skipped idle samples can be recorded in a single WallClock event.
+const u32 MAX_IDLE_BATCH = 1000;
+
+
+struct ThreadSleepState {
+    u64 start_time;
+    u64 last_cpu_time;
+    u32 call_trace_id;
+    u32 counter;
+};
+
+typedef std::map<int, ThreadSleepState> ThreadSleepMap;
+
+struct ThreadCpuTime {
+    u64 cpu_time;
+    u64 trace;
+};
+
+// MPSC ring buffer
+class ThreadCpuTimeBuffer {
+  private:
+    enum {
+        RINGBUF_SIZE = 256,
+        PAD_SIZE = 128
+    };
+
+    char _pad0[PAD_SIZE];  // protection against false sharing
+    volatile u32 _write_ptr;
+    char _pad1[PAD_SIZE - sizeof(u32)];
+    u32 _read_ptr;
+    char _pad2[PAD_SIZE - sizeof(u32)];
+    ThreadCpuTime _ringbuf[RINGBUF_SIZE];
+
+  public:
+    ThreadCpuTimeBuffer() : _ringbuf(), _write_ptr(0), _read_ptr(0) {
+    }
+
+    void add(u64 trace) {
+        ThreadCpuTime& t = _ringbuf[atomicInc(_write_ptr) & (RINGBUF_SIZE - 1)];
+        t.trace = trace;
+        storeRelease(t.cpu_time, OS::threadCpuTime(0));
+    }
+
+    void drain(ThreadSleepMap& thread_sleep_state) {
+        u64 read_limit = _read_ptr + RINGBUF_SIZE;
+        do {
+            ThreadCpuTime& t = _ringbuf[_read_ptr & (RINGBUF_SIZE - 1)];
+            u64 cpu_time = loadAcquire(t.cpu_time);
+            if (cpu_time == 0) {
+                break;
+            }
+
+            u64 trace = t.trace;
+            if (__sync_bool_compare_and_swap(&t.cpu_time, cpu_time, 0)) {
+                int thread_id = trace >> 32;
+                ThreadSleepState& tss = thread_sleep_state[thread_id];
+                tss.last_cpu_time = cpu_time;
+                tss.call_trace_id = (u32)trace;
+                tss.counter = 0;
+                _read_ptr++;
+            }
+        } while (_read_ptr < read_limit);
+    }
+};
+
+static ThreadCpuTimeBuffer _thread_cpu_time_buf;
 
 
 long WallClock::_interval;
 int WallClock::_signal;
-bool WallClock::_sample_idle_threads;
+WallClock::Mode WallClock::_mode;
 
 ThreadState WallClock::getThreadState(void* ucontext) {
     StackFrame frame(ucontext);
@@ -50,24 +121,32 @@ ThreadState WallClock::getThreadState(void* ucontext) {
 
 void WallClock::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     ExecutionEvent event(TSC::ticks());
-    event._thread_state = _sample_idle_threads ? getThreadState(ucontext) : THREAD_UNKNOWN;
-    Profiler::instance()->recordSample(ucontext, _interval, EXECUTION_SAMPLE, &event);
+    event._thread_state = _mode == CPU_ONLY ? THREAD_UNKNOWN : getThreadState(ucontext);
+    u64 trace = Profiler::instance()->recordSample(ucontext, _interval, EXECUTION_SAMPLE, &event);
+    if (event._thread_state == THREAD_SLEEPING) {
+        _thread_cpu_time_buf.add(trace);
+    }
 }
 
-long WallClock::adjustInterval(long interval, int thread_count) {
-    if (thread_count > THREADS_PER_TICK) {
-        interval /= (thread_count + THREADS_PER_TICK - 1) / THREADS_PER_TICK;
-    }
-    return interval;
+void WallClock::recordWallClock(u64 start_time, ThreadState state, u32 samples, int tid, u32 call_trace_id) {
+    WallClockEvent event;
+    event._start_time = start_time;
+    event._thread_state = state;
+    event._samples = samples;
+    Profiler::instance()->recordExternalSamples(samples, samples * _interval, tid, call_trace_id, WALL_CLOCK_SAMPLE, &event);
 }
 
 Error WallClock::start(Arguments& args) {
-    _sample_idle_threads = args._wall >= 0 || strcmp(args._event, EVENT_WALL) == 0;
+    if (args._wall >= 0 || strcmp(args._event, EVENT_WALL) == 0) {
+        _mode = args._nobatch ? WALL_LEGACY : WALL_BATCH;
+    } else {
+        _mode = CPU_ONLY;
+    }
 
     _interval = args._wall >= 0 ? args._wall : args._interval;
     if (_interval == 0) {
         // Increase default interval for wall clock mode due to larger number of sampled threads
-        _interval = _sample_idle_threads ? DEFAULT_INTERVAL * 5 : DEFAULT_INTERVAL;
+        _interval = _mode == CPU_ONLY ? DEFAULT_INTERVAL : DEFAULT_INTERVAL * 5;
     }
 
     _signal = args._signal == 0 ? OS::getProfilingSignal(1)
@@ -93,53 +172,73 @@ void WallClock::timerLoop() {
     int self = OS::threadId();
     ThreadFilter* thread_filter = Profiler::instance()->threadFilter();
     bool thread_filter_enabled = thread_filter->enabled();
-    bool sample_idle_threads = _sample_idle_threads;
+    Mode mode = _mode;
 
+    ThreadSleepMap thread_sleep_state;
     ThreadList* thread_list = OS::listThreads();
-    long long next_cycle_time = OS::nanotime();
+    u64 cycle_start_time = OS::nanotime();
 
     while (_running) {
-        if (!_enabled) {
-            OS::sleep(_interval);
-            continue;
-        }
+        bool enabled = _enabled;
 
-        if (sample_idle_threads) {
-            // Try to keep the wall clock interval stable, regardless of the number of profiled threads
-            int estimated_thread_count = thread_filter_enabled ? thread_filter->size() : thread_list->size();
-            next_cycle_time += adjustInterval(_interval, estimated_thread_count);
-        }
-
-        for (int count = 0; count < THREADS_PER_TICK; ) {
+        for (int signaled_threads = 0; signaled_threads < THREADS_PER_TICK && thread_list->hasNext(); ) {
             int thread_id = thread_list->next();
-            if (thread_id == -1) {
-                thread_list->rewind();
-                break;
-            }
-
             if (thread_id == self || (thread_filter_enabled && !thread_filter->accept(thread_id))) {
                 continue;
             }
 
-            if (sample_idle_threads || OS::threadState(thread_id) == THREAD_RUNNING) {
-                if (OS::sendSignalToThread(thread_id, _signal)) {
-                    count++;
+            if (mode == CPU_ONLY) {
+                if (!enabled || OS::threadState(thread_id) == THREAD_SLEEPING) {
+                    continue;
                 }
+            } else if (mode == WALL_BATCH) {
+                ThreadSleepState& tss = thread_sleep_state[thread_id];
+                u64 new_thread_cpu_time = enabled ? OS::threadCpuTime(thread_id) : 0;
+                if (new_thread_cpu_time != 0 && new_thread_cpu_time - tss.last_cpu_time <= RUNNABLE_THRESHOLD_NS) {
+                    if (++tss.counter < MAX_IDLE_BATCH) {
+                        if (tss.counter == 1) tss.start_time = TSC::ticks();
+                        continue;
+                    }
+                }
+                if (tss.counter != 0) {
+                    recordWallClock(tss.start_time, THREAD_SLEEPING, tss.counter, thread_id, tss.call_trace_id);
+                    tss.counter = 0;
+                }
+            }
+
+            if (enabled && OS::sendSignalToThread(thread_id, _signal)) {
+                signaled_threads++;
             }
         }
 
-        if (sample_idle_threads) {
-            long long current_time = OS::nanotime();
-            if (next_cycle_time - current_time > MIN_INTERVAL) {
-                OS::sleep(next_cycle_time - current_time);
-            } else {
-                next_cycle_time = current_time + MIN_INTERVAL;
-                OS::sleep(MIN_INTERVAL);
-            }
+        u64 current_time = OS::nanotime();
+        if (thread_list->hasNext()) {
+            // Try to keep interval stable regardless of the number of profiled threads
+            long long sleep_time = cycle_start_time + (u64)_interval * thread_list->index() / thread_list->count() - current_time;
+            OS::sleep(sleep_time < MIN_INTERVAL ? MIN_INTERVAL : sleep_time);
         } else {
-            OS::sleep(_interval);
+            // Cycle has ended: prepare for the next cycle
+            cycle_start_time += (u64)_interval;
+            long long sleep_time = cycle_start_time - current_time;
+            if (sleep_time < MIN_INTERVAL) {
+                cycle_start_time = current_time + MIN_INTERVAL;
+                sleep_time = MIN_INTERVAL;
+            }
+            OS::sleep(sleep_time);
+            thread_list->update();
         }
+
+        // Sync thread CPU times updated since the previous iteration
+        _thread_cpu_time_buf.drain(thread_sleep_state);
     }
 
     delete thread_list;
+
+    // Flush remaining WallClock batches
+    for (ThreadSleepMap::const_iterator it = thread_sleep_state.begin(); it != thread_sleep_state.end(); ++it) {
+        const ThreadSleepState& tss = it->second;
+        if (tss.counter != 0) {
+            recordWallClock(tss.start_time, THREAD_SLEEPING, tss.counter, it->first, tss.call_trace_id);
+        }
+    }
 }

--- a/src/wallClock.h
+++ b/src/wallClock.h
@@ -15,9 +15,15 @@
 
 class WallClock : public Engine {
   private:
+    enum Mode {
+        CPU_ONLY,
+        WALL_BATCH,
+        WALL_LEGACY
+    };
+
     static long _interval;
     static int _signal;
-    static bool _sample_idle_threads;
+    static Mode _mode;
 
     volatile bool _running;
     pthread_t _thread;
@@ -33,11 +39,11 @@ class WallClock : public Engine {
 
     static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext);
 
-    static long adjustInterval(long interval, int thread_count);
+    static void recordWallClock(u64 start_time, ThreadState state, u32 samples, int tid, u32 call_trace_id);
 
   public:
     const char* title() {
-        return _sample_idle_threads ? "Wall clock profile" : "CPU profile";
+        return _mode == CPU_ONLY ? "CPU profile" : "Wall clock profile";
     }
 
     const char* units() {


### PR DESCRIPTION
### Description

Optimize wall clock profiling by skipping redundant samples when we know thread CPU time has not changed since the last sample.

### Related issues

Resolves #1007.

### Motivation and context

Make wall clock profiling safe for production use, even for applications with thousands of threads.

### How has this been tested?

Run benchmarks with new wall clock mechanism and legacy wall clock (`nobatch`) and compare flame graphs.
Verify the number of `ExecutionSample` and `WallClockSample` events manually.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
