### PR TITLE
Obtain can_generate_sampled_object_alloc_events JVMTI capability only when needed

### DIFF
--- a/src/objectSampler.cpp
+++ b/src/objectSampler.cpp
@@ -188,7 +188,7 @@ void ObjectSampler::stop() {
     jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_GARBAGE_COLLECTION_START, NULL);
     jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, NULL);
 
-    VM::relinquishCanSampleObjectsCapability();
+    VM::releaseSampleObjectsCapability();
 
     dumpLiveRefs();
 }

--- a/src/objectSampler.cpp
+++ b/src/objectSampler.cpp
@@ -170,19 +170,7 @@ void ObjectSampler::dumpLiveRefs() {
     }
 }
 
-Error ObjectSampler::check(Arguments& args) {
-    if (!VM::canSampleObjects()) {
-        return Error("SampledObjectAlloc is not supported on this JVM");
-    }
-    return Error::OK;
-}
-
 Error ObjectSampler::start(Arguments& args) {
-    Error error = check(args);
-    if (error) {
-        return error;
-    }
-
     _interval = args._alloc > 0 ? args._alloc : DEFAULT_ALLOC_INTERVAL;
 
     initLiveRefs(args._live);
@@ -199,6 +187,8 @@ void ObjectSampler::stop() {
     jvmtiEnv* jvmti = VM::jvmti();
     jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_GARBAGE_COLLECTION_START, NULL);
     jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, NULL);
+
+    VM::relinquishCanSampleObjectsCapability();
 
     dumpLiveRefs();
 }

--- a/src/objectSampler.h
+++ b/src/objectSampler.h
@@ -33,7 +33,6 @@ class ObjectSampler : public Engine {
         return "bytes";
     }
 
-    Error check(Arguments& args);
     Error start(Arguments& args);
     void stop();
 

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1001,7 +1001,7 @@ Engine* Profiler::selectEngine(const char* event_name) {
 }
 
 Engine* Profiler::selectAllocEngine(long alloc_interval, bool live) {
-    if (VM::addCanSampleObjectsCapability()) {
+    if (VM::addSampleObjectsCapability()) {
         return &object_sampler;
     } else if (VM::isOpenJ9()) {
         return &j9_object_sampler;

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1001,7 +1001,7 @@ Engine* Profiler::selectEngine(const char* event_name) {
 }
 
 Engine* Profiler::selectAllocEngine(long alloc_interval, bool live) {
-    if (VM::addCanSampleObjectsCapability() == 0) {
+    if (VM::addCanSampleObjectsCapability()) {
         return &object_sampler;
     } else if (VM::isOpenJ9()) {
         return &j9_object_sampler;

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1001,7 +1001,7 @@ Engine* Profiler::selectEngine(const char* event_name) {
 }
 
 Engine* Profiler::selectAllocEngine(long alloc_interval, bool live) {
-    if (VM::canSampleObjects()) {
+    if (VM::addCanSampleObjectsCapability() == 0) {
         return &object_sampler;
     } else if (VM::isOpenJ9()) {
         return &j9_object_sampler;

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -244,14 +244,14 @@ bool VM::init(JavaVM* vm, bool attach) {
         }
     }
 
-    if (addCanSampleObjectsCapability()) {
+    if (addSampleObjectsCapability()) {
         // SetHeapSamplingInterval does not have immediate effect, so apply the configuration
         // as early as possible to allow profiling all startup allocations
         JVMFlag* f = JVMFlag::find("UseTLAB");
         if (f != NULL && !f->get()) {
             _jvmti->SetHeapSamplingInterval(0);
         }
-        VM::relinquishCanSampleObjectsCapability();
+        VM::releaseSampleObjectsCapability();
     }
 
     if (attach) {

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -31,7 +31,7 @@ jvmtiEnv* VM::_jvmti = NULL;
 int VM::_hotspot_version = 0;
 bool VM::_openj9 = false;
 bool VM::_zing = false;
-bool VM::_can_sample_objects = false;
+const jvmtiCapabilities VM::canSampleObjectsCapability = {.can_generate_sampled_object_alloc_events = 1};
 
 jvmtiError (JNICALL *VM::_orig_RedefineClasses)(jvmtiEnv*, jint, const jvmtiClassDefinition*);
 jvmtiError (JNICALL *VM::_orig_RetransformClasses)(jvmtiEnv*, jint, const jclass* classes);
@@ -152,7 +152,6 @@ bool VM::init(JavaVM* vm, bool attach) {
     profiler->updateSymbols(false);
 
     _openj9 = !is_hotspot && J9Ext::initialize(_jvmti, profiler->resolveSymbol("j9thread_self"));
-    _can_sample_objects = !is_hotspot || hotspot_version() >= 11;
 
     CodeCache* lib = isOpenJ9()
         ? profiler->findJvmLibrary("libj9vm")
@@ -200,7 +199,6 @@ bool VM::init(JavaVM* vm, bool attach) {
     capabilities.can_retransform_classes = 1;
     capabilities.can_retransform_any_class = isOpenJ9() ? 0 : 1;
     capabilities.can_generate_vm_object_alloc_events = isOpenJ9() ? 1 : 0;
-    capabilities.can_generate_sampled_object_alloc_events = _can_sample_objects ? 1 : 0;
     capabilities.can_get_bytecodes = 1;
     capabilities.can_get_constant_pool = 1;
     capabilities.can_get_source_file_name = 1;
@@ -209,11 +207,7 @@ bool VM::init(JavaVM* vm, bool attach) {
     capabilities.can_generate_monitor_events = 1;
     capabilities.can_generate_garbage_collection_events = 1;
     capabilities.can_tag_objects = 1;
-    if (_jvmti->AddCapabilities(&capabilities) != 0) {
-        _can_sample_objects = false;
-        capabilities.can_generate_sampled_object_alloc_events = 0;
-        _jvmti->AddCapabilities(&capabilities);
-    }
+    _jvmti->AddCapabilities(&capabilities);
 
     jvmtiEventCallbacks callbacks = {0};
     callbacks.VMInit = VMInit;
@@ -251,13 +245,14 @@ bool VM::init(JavaVM* vm, bool attach) {
         }
     }
 
-    if (_can_sample_objects) {
+    if (VM::addCanSampleObjectsCapability() == 0) {
         // SetHeapSamplingInterval does not have immediate effect, so apply the configuration
         // as early as possible to allow profiling all startup allocations
         JVMFlag* f = JVMFlag::find("UseTLAB");
         if (f != NULL && !f->get()) {
             _jvmti->SetHeapSamplingInterval(0);
         }
+        VM::relinquishCanSampleObjectsCapability();
     }
 
     if (attach) {

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -31,7 +31,6 @@ jvmtiEnv* VM::_jvmti = NULL;
 int VM::_hotspot_version = 0;
 bool VM::_openj9 = false;
 bool VM::_zing = false;
-const jvmtiCapabilities VM::canSampleObjectsCapability = {.can_generate_sampled_object_alloc_events = 1};
 
 jvmtiError (JNICALL *VM::_orig_RedefineClasses)(jvmtiEnv*, jint, const jvmtiClassDefinition*);
 jvmtiError (JNICALL *VM::_orig_RetransformClasses)(jvmtiEnv*, jint, const jclass* classes);
@@ -245,7 +244,7 @@ bool VM::init(JavaVM* vm, bool attach) {
         }
     }
 
-    if (VM::addCanSampleObjectsCapability() == 0) {
+    if (addCanSampleObjectsCapability()) {
         // SetHeapSamplingInterval does not have immediate effect, so apply the configuration
         // as early as possible to allow profiling all startup allocations
         JVMFlag* f = JVMFlag::find("UseTLAB");

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -93,8 +93,6 @@ class VM {
     static bool _openj9;
     static bool _zing;
 
-    static const jvmtiCapabilities canSampleObjectsCapability;
-
     static jvmtiError (JNICALL *_orig_RedefineClasses)(jvmtiEnv*, jint, const jvmtiClassDefinition*);
     static jvmtiError (JNICALL *_orig_RetransformClasses)(jvmtiEnv*, jint, const jclass* classes);
 
@@ -145,12 +143,16 @@ class VM {
         return _zing;
     }
 
-    static int addCanSampleObjectsCapability() {
-        return _jvmti->AddCapabilities(&canSampleObjectsCapability);
+    static bool addCanSampleObjectsCapability() {
+        jvmtiCapabilities capabilities = {0};
+        capabilities.can_generate_sampled_object_alloc_events = 1;
+        return _jvmti->AddCapabilities(&capabilities) == 0;
     }
 
-    static int relinquishCanSampleObjectsCapability() {
-        return _jvmti->RelinquishCapabilities(&canSampleObjectsCapability);
+    static void relinquishCanSampleObjectsCapability() {
+        jvmtiCapabilities capabilities = {0};
+        capabilities.can_generate_sampled_object_alloc_events = 1;
+        _jvmti->RelinquishCapabilities(&capabilities);
     }
 
     static void JNICALL VMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread);

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -143,13 +143,13 @@ class VM {
         return _zing;
     }
 
-    static bool addCanSampleObjectsCapability() {
+    static bool addSampleObjectsCapability() {
         jvmtiCapabilities capabilities = {0};
         capabilities.can_generate_sampled_object_alloc_events = 1;
         return _jvmti->AddCapabilities(&capabilities) == 0;
     }
 
-    static void relinquishCanSampleObjectsCapability() {
+    static void releaseSampleObjectsCapability() {
         jvmtiCapabilities capabilities = {0};
         capabilities.can_generate_sampled_object_alloc_events = 1;
         _jvmti->RelinquishCapabilities(&capabilities);

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -92,7 +92,8 @@ class VM {
     static int _hotspot_version;
     static bool _openj9;
     static bool _zing;
-    static bool _can_sample_objects;
+
+    static const jvmtiCapabilities canSampleObjectsCapability;
 
     static jvmtiError (JNICALL *_orig_RedefineClasses)(jvmtiEnv*, jint, const jvmtiClassDefinition*);
     static jvmtiError (JNICALL *_orig_RetransformClasses)(jvmtiEnv*, jint, const jclass* classes);
@@ -144,8 +145,12 @@ class VM {
         return _zing;
     }
 
-    static bool canSampleObjects() {
-        return _can_sample_objects;
+    static int addCanSampleObjectsCapability() {
+        return _jvmti->AddCapabilities(&canSampleObjectsCapability);
+    }
+
+    static int relinquishCanSampleObjectsCapability() {
+        return _jvmti->RelinquishCapabilities(&canSampleObjectsCapability);
     }
 
     static void JNICALL VMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread);

--- a/test/one/profiler/test/TestProcess.java
+++ b/test/one/profiler/test/TestProcess.java
@@ -31,6 +31,8 @@ public class TestProcess implements Closeable {
     public static final String PROFOUT = "%pout";
     public static final String PROFERR = "%perr";
 
+    public static final String PROFILER_LIB_NAME = "libasyncProfiler";
+
     private static final Pattern filePattern = Pattern.compile("(%[a-z]+)(\\.[a-z]+)?");
 
     private static final MethodHandle pid = getPidHandle();
@@ -92,7 +94,7 @@ public class TestProcess implements Closeable {
     }
 
     public String profilerLibPath() {
-        return "build/lib/libasyncProfiler." + currentOs.getLibExt();
+        return "build/lib/" + PROFILER_LIB_NAME + "." + currentOs.getLibExt();
     }
 
     private List<String> buildCommandLine(Test test, Os currentOs) {

--- a/test/one/profiler/test/TestProcess.java
+++ b/test/one/profiler/test/TestProcess.java
@@ -53,6 +53,7 @@ public class TestProcess implements Closeable {
         }
     }
 
+    private final Os currentOs;
     private final String logDir;
     private final String[] inputs;
     private final Process p;
@@ -60,6 +61,7 @@ public class TestProcess implements Closeable {
     private final int timeout = 30;
 
     public TestProcess(Test test, Os currentOs, String logDir) throws Exception {
+        this.currentOs = currentOs;
         this.logDir = logDir;
         this.inputs = test.inputs();
 
@@ -83,6 +85,10 @@ public class TestProcess implements Closeable {
 
     public String[] inputs() {
         return this.inputs;
+    }
+
+    public Os currentOs() {
+        return this.currentOs;
     }
 
     private List<String> buildCommandLine(Test test, Os currentOs) {

--- a/test/one/profiler/test/TestProcess.java
+++ b/test/one/profiler/test/TestProcess.java
@@ -91,6 +91,10 @@ public class TestProcess implements Closeable {
         return this.currentOs;
     }
 
+    public String profilerLibPath() {
+        return "build/lib/libasyncProfiler." + currentOs.getLibExt();
+    }
+
     private List<String> buildCommandLine(Test test, Os currentOs) {
         List<String> cmd = new ArrayList<>();
 
@@ -110,7 +114,7 @@ public class TestProcess implements Closeable {
             }
             addArgs(cmd, test.jvmArgs());
             if (!test.agentArgs().isEmpty()) {
-                cmd.add("-agentpath:build/lib/libasyncProfiler." + currentOs.getLibExt() + "=" +
+                cmd.add("-agentpath:" + profilerLibPath() + "=" +
                         substituteFiles(test.agentArgs()));
             }
             cmd.add(test.mainClass().getName());

--- a/test/test/alloc/AllocTests.java
+++ b/test/test/alloc/AllocTests.java
@@ -66,10 +66,10 @@ public class AllocTests {
         Output out = p.profile("-e alloc -d 3 -o collapsed");
         // _[k] suffix in collapsed output corresponds to jdk.ObjectAllocationOutsideTLAB, which means alloc tracer is being used
         assert !out.contains("_\\[k\\]"); // we are using alloc tracer instead of object sampler, should definitely not happen on first profiling call
-        File asprofCopy = File.createTempFile("libAsyncProfiler", p.currentOs().getLibExt());
+        File asprofCopy = File.createTempFile(TestProcess.PROFILER_LIB_NAME, p.currentOs().getLibExt());
+        asprofCopy.deleteOnExit();
         Files.copy(Path.of(p.profilerLibPath()), asprofCopy.toPath(), StandardCopyOption.REPLACE_EXISTING);
         Output outWithCopy = p.profile(String.format("--libpath %s -e alloc -d 3 -o collapsed", asprofCopy.getAbsolutePath()));
-        asprofCopy.deleteOnExit();
         assert !outWithCopy.contains("_\\[k\\]"); // first instance of profiler has not properly relinquished the can_generate_sampled_object_alloc_events capability.
     }
 }


### PR DESCRIPTION
### Description

Only one JVM TI agent can hold can_generate_sampled_object_alloc_events capability at a time. To avoid multiple profiler instances from conflicting with each other, profiler should obtain the capability only when needed and release it as soon as a profiling session finishes.

### Related issues


### Motivation and context

This allows multiple different async profiler instances to use the object sampler on the same java process one after the other. 

### How has this been tested?
Verifying that the test fails without implementation changes: https://github.com/openorclose/async-profiler/actions/runs/11050192717/job/30697437468#step:6:51

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
