### PR TITLE
An option to coarsen flame graphs

### DIFF
--- a/src/converter/Main.java
+++ b/src/converter/Main.java
@@ -113,6 +113,7 @@ public class Main {
                 "Flame Graph options:\n" +
                 "     --title STRING     Flame Graph title\n" +
                 "     --minwidth X       Skip frames smaller than X%\n" +
+                "     --grain X          Coarsen Flame Graph to the given grain size\n" +
                 "     --skip N           Skip N bottom frames\n" +
                 "  -r --reverse          Reverse stack traces (icicle graph)\n" +
                 "  -I --include REGEX    Include only stacks with the specified frames\n" +

--- a/src/converter/one/convert/Arguments.java
+++ b/src/converter/one/convert/Arguments.java
@@ -18,6 +18,7 @@ public class Arguments {
     public Pattern include;
     public Pattern exclude;
     public double minwidth;
+    public double grain;
     public int skip;
     public boolean help;
     public boolean reverse;

--- a/src/converter/one/convert/JfrConverter.java
+++ b/src/converter/one/convert/JfrConverter.java
@@ -70,6 +70,10 @@ public abstract class JfrConverter extends Classifier {
             }
         }
 
+        if (args.grain > 0) {
+            agg.coarsen(args.grain);
+        }
+
         return agg;
     }
 


### PR DESCRIPTION
### Description

Add jfrconv `--grain` option to coarsen flame graphs by subsamling stack traces.
Shape of the result flame graph should be similar to the original one.

Example:
```
jfrconv --grain 4 source.jfr dest.html
```
will produce a flame graph that is 4 times smaller in number of samples.

Grain value can be fractional. E.g., to shrink a flame graph containing 314 samples to 100 samples, specify `--grain 3.14`

### Motivation and context

There are two main use cases for the feature:
1. Reduce flame graph size by dropping out least relevant stacks.
2. Normalize flame graphs so that they contain a fixed number of samples.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
