### PR TITLE
Log test args and inputs.

### DIFF
--- a/test/one/profiler/test/Runner.java
+++ b/test/one/profiler/test/Runner.java
@@ -139,7 +139,10 @@ public class Runner {
                 continue;
             }
 
-            log.log(Level.INFO, "Running " + testName + "...");
+            log.log(Level.INFO, "Running " + testName +
+                (test.args() != null && test.args().length() > 0 ? " args: " + test.args() : "" ) +
+                (test.inputs() != null && test.inputs().length > 0 ? " inputs: [" + String.join(" ", test.inputs()) + "]": "" ) +
+                 "...");
 
             String testLogDir = logDir.isEmpty() ? null : logDir + '/' + testName;
             try (TestProcess p = new TestProcess(test, currentOs, testLogDir)) {

--- a/test/one/profiler/test/Runner.java
+++ b/test/one/profiler/test/Runner.java
@@ -140,9 +140,9 @@ public class Runner {
             }
 
             log.log(Level.INFO, "Running " + testName +
-                (test.args() != null && test.args().length() > 0 ? " args: " + test.args() : "" ) +
-                (test.inputs() != null && test.inputs().length > 0 ? " inputs: [" + String.join(" ", test.inputs()) + "]": "" ) +
-                 "...");
+                    (!test.args().isEmpty() ? " args: " + test.args() : "") +
+                    (test.inputs().length > 0 ? " inputs: [" + String.join(" ", test.inputs()) + "]" : "") +
+                    "...");
 
             String testLogDir = logDir.isEmpty() ? null : logDir + '/' + testName;
             try (TestProcess p = new TestProcess(test, currentOs, testLogDir)) {


### PR DESCRIPTION
### Description
While running `make test`, print test args and inputs from annotations if present.

### Motivation and context
Test logs for each test should be unique:

```
INFO: Running XTests.abc
INFO: Running XTests.abc
INFO: Running XTests.abc
```

vs.

```
INFO: Running XTests.abc inputs: [0]...
INFO: Running XTests.abc inputs: [10000]...
INFO: Running XTests.abc inputs: [1000000]...
```

### How has this been tested?
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
