### PR TITLE
Update paths to codebuild runners

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         include:
           - runson: macos-14 # mac arm
-          - runson: codebuild-test-x86-${{ github.run_id }}-${{ github.run_attempt }}
-          - runson: codebuild-test-${{ github.run_id }}-${{ github.run_attempt }}
+          - runson: codebuild-async-profiler-nightly-builds-x86-${{ github.run_id }}-${{ github.run_attempt }}
+          - runson: codebuild-async-profiler-nightly-builds-${{ github.run_id }}-${{ github.run_attempt }}
     runs-on: ${{ matrix.runson }}
     steps:
       - name: Setup Java for macOS x64


### PR DESCRIPTION
### Description

Point to the correct codebuild runners meant for this async-profiler repository

### Related issues

https://github.com/async-profiler/async-profiler/pull/998

### Motivation and context

These were still pointing to the codebuild runners for a different forked repository

### How has this been tested?


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
