### PR TITLE
Implement search feature

### DIFF
--- a/demo/flamegraph.html
+++ b/demo/flamegraph.html
@@ -33,6 +33,8 @@
 	let level0 = 0, left0 = 0, width0 = 0;
 	let reverse = false;
 	const levels = Array(36);
+	let matchedFrames = [];
+	let currentMatchedIndex = 0;
 	for (let h = 0; h < levels.length; h++) {
 		levels[h] = [];
 	}
@@ -66,7 +68,7 @@
 	}
 
 	function f(key, level, left, width, inln, c1, int) {
-		levels[level0 = level].push({left: left0 += left, width: width0 = width || width0,
+		levels[level0 = level].push({level, left: left0 += left, width: width0 = width || width0,
 			color: getColor(palette[key & 7]), title: cpool[key >>> 3],
 			details: (int ? ', int=' + int : '') + (c1 ? ', c1=' + c1 : '') + (inln ? ', inln=' + inln : '')
 		});
@@ -133,12 +135,15 @@
 		}
 
 		pattern = r ? RegExp(r) : undefined;
-		const matched = render(root, rootLevel);
+		const [matched, bottomMatchedFrames] = render(root, rootLevel);
+		matchedFrames = bottomMatchedFrames;
+		currentMatchedIndex = matchedFrames.length;
 		document.getElementById('matchval').textContent = pct(matched, root.width) + '%';
 		document.getElementById('match').style.display = r ? 'inline-block' : 'none';
 	}
 
 	function render(newRoot, newLevel) {
+		const matchedFrames = [];
 		if (root) {
 			c.fillStyle = '#ffffff';
 			c.fillRect(0, 0, canvasWidth, canvasHeight);
@@ -153,6 +158,11 @@
 		const marked = [];
 
 		function mark(f) {
+			const h = f.level;
+			const y = reverse ? h * 16 : canvasHeight - h * 16 - window.innerHeight;
+			f.x = f.left - x0;
+			f.y = y
+			matchedFrames.push(f);
 			return marked[f.left] >= f.width || (marked[f.left] = f.width);
 		}
 
@@ -194,8 +204,17 @@
 				drawFrame(frames[i], y, h < rootLevel);
 			}
 		}
-
-		return totalMarked();
+        // sort matched frames from left to right, lowest level to highest level
+        matchedFrames.sort((a, b) => {
+            if (a.left < b.left) {
+                return -1;
+            } else if (a.left === b.left) {
+                return a.level - b.level;
+            } else {
+                return 1;
+            }
+        })
+		return [totalMarked(), matchedFrames];
 	}
 
 	function unpack(cpool) {
@@ -259,11 +278,24 @@
 		search(false);
 	}
 
-	window.onkeydown = function() {
-		if ((event.ctrlKey || event.metaKey) && event.keyCode === 70) {
+	window.onkeydown = function(event) {
+		if (event.key.toLowerCase() === "n") {
+			if (matchedFrames.length === 0) {
+				return;
+			}
+			currentMatchedIndex += event.shiftKey ? -1 : 1;
+			if (currentMatchedIndex < 0) {
+				currentMatchedIndex = matchedFrames.length - 1;
+			} else if (currentMatchedIndex > matchedFrames.length - 1) {
+				currentMatchedIndex = 0;
+			}
+			const frame = matchedFrames[currentMatchedIndex];
+			render(frame, frame.level);
+			window.scroll(frame.x, frame.y + canvas.offsetTop);
+		} else if ((event.ctrlKey || event.metaKey) && event.key === "f") {
 			event.preventDefault();
 			search(true);
-		} else if (event.keyCode === 27) {
+		} else if (event.key === "Escape") {
 			search(false);
 		}
 	}


### PR DESCRIPTION
### Description

Press N to go to the next search result and Shift-N to go to the previous

Search results are visited depth-first, visiting all results of a stack before moving on to the next stack on the right.

This doesn't try to filter out any frames at all, so it is more intuitive how the next and previous works, at the cost of possibly navigating to more frames than neccesary.

Note: I only updated the demo `flamegraph html` for now, will update the actual one once the PR is finalised.

### Related issues


### Motivation and context

This allows users to search for results that may be see when they are a low % of the samples.



### How has this been tested?

This branch is built automatically to https://openorclose.github.io/async-profiler/demo/flamegraph.html for testing.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
