### PR TITLE
Refactor nightly builds to delete previous release and create a new release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,8 +3,7 @@ name: Publish Nightly Builds
 on:
   push:
     branches:
-      # - master
-      - recreate_release
+      - master
 
 env:
   JAVA_DISTRIBUTION: 'corretto'
@@ -16,10 +15,8 @@ jobs:
       matrix:
         include:
           - runson: macos-14 # mac arm
-#          - runson: codebuild-async-profiler-nightly-builds-x86-${{ github.run_id }}-${{ github.run_attempt }}
-#          - runson: codebuild-async-profiler-nightly-builds-${{ github.run_id }}-${{ github.run_attempt }}
-          - runson: codebuild-test-x86-${{ github.run_id }}-${{ github.run_attempt }}
-          - runson: codebuild-test-${{ github.run_id }}-${{ github.run_attempt }}
+          - runson: codebuild-async-profiler-nightly-builds-x86-${{ github.run_id }}-${{ github.run_attempt }}
+          - runson: codebuild-async-profiler-nightly-builds-${{ github.run_id }}-${{ github.run_attempt }}
     runs-on: ${{ matrix.runson }}
     steps:
       - name: Setup Java for macOS x64
@@ -85,7 +82,7 @@ jobs:
           script: |
             const fs = require('fs').promises;
             const commonOptions = {
-              owner: "openorclose",
+              owner: "async-profiler",
               repo: "async-profiler",
             };
             let previousRelease = undefined;
@@ -140,4 +137,3 @@ jobs:
               release_id: newReleaseId,
               draft: false,
             });
-           

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,21 +3,23 @@ name: Publish Nightly Builds
 on:
   push:
     branches:
-      - master
+      # - master
+      - recreate_release
 
 env:
   JAVA_DISTRIBUTION: 'corretto'
   JAVA_VERSION: '11'
 
 jobs:
-  build-test-publish:
+  build-test:
     strategy:
-      fail-fast: false
       matrix:
         include:
           - runson: macos-14 # mac arm
-          - runson: codebuild-async-profiler-nightly-builds-x86-${{ github.run_id }}-${{ github.run_attempt }}
-          - runson: codebuild-async-profiler-nightly-builds-${{ github.run_id }}-${{ github.run_attempt }}
+#          - runson: codebuild-async-profiler-nightly-builds-x86-${{ github.run_id }}-${{ github.run_attempt }}
+#          - runson: codebuild-async-profiler-nightly-builds-${{ github.run_id }}-${{ github.run_attempt }}
+          - runson: codebuild-test-x86-${{ github.run_id }}-${{ github.run_attempt }}
+          - runson: codebuild-test-${{ github.run_id }}-${{ github.run_attempt }}
     runs-on: ${{ matrix.runson }}
     steps:
       - name: Setup Java for macOS x64
@@ -67,27 +69,75 @@ jobs:
         with:
           name: test-logs-macos-14-x64
           path: build/test/logs/
-      - name: Upload async-profiler binaries to nightly release and delete previous releases
+  publish:
+    runs-on: ubuntu-latest
+    needs: build-test
+    steps:
+      - name: Download async-profiler binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: async-profiler-*
+          merge-multiple: 'true'
+      - name: Delete previous release and publish new release
         uses: actions/github-script@v7
-        id: delete-previous-and-upload-to-release
         with:
           result-encoding: string
           script: |
             const fs = require('fs').promises;
             const commonOptions = {
-              owner: "async-profiler",
+              owner: "openorclose",
               repo: "async-profiler",
-              release_id: 175290112,
             };
-            const assets = await github.rest.repos.listReleaseAssets(commonOptions);
-            if (assets.status !== 200) {
-              throw new Error("Unable to get list of assets from release!");
+            let previousRelease = undefined;
+            try {
+              previousRelease = await github.rest.repos.getReleaseByTag({
+                ...commonOptions,
+                tag: "nightly",
+              });
+            } catch (e) {
+              console.log("No previous nightly release");
+              // ignore, there was no previous nightly release
             }
-            await Promise.all(assets.data
-              .filter(({name}) => name.startsWith("${{ steps.build.outputs.archive }}"))
-              .map(({id}) => github.rest.repos.deleteReleaseAsset({...commonOptions, asset_id: id})));
-            github.rest.repos.uploadReleaseAsset({
+            if (previousRelease !== undefined) {
+              // delete previous release and nightly tag
+              await github.rest.repos.deleteRelease({
+                ...commonOptions,
+                release_id: previousRelease.data.id,
+              });
+              await github.rest.git.deleteRef({...commonOptions, ref: "tags/nightly"});
+            }
+            // create draft release
+            const newReleaseId = (await github.rest.repos.createRelease({
               ...commonOptions,
-              name: `${{ steps.build.outputs.archive }}-${{ steps.build.outputs.hash }}`,
-              data: await fs.readFile("${{ steps.build.outputs.archive }}"),
+              tag_name: "nightly",
+              target_commitish: "${{ github.sha }}",
+              name: "Nightly builds",
+              body: "Async-profiler binaries published automatically from the latest sources in `master` upon a successful build.",
+              prerelease: true,
+              draft: true,
+            })).data.id;
+            // upload binaries to draft release
+            for (const archiveName of await fs.readdir(process.cwd())) {
+              let basename;
+              let extension;
+              if (archiveName.endsWith(".zip")) {
+                basename = archiveName.substring(0, archiveName.lastIndexOf(".zip"));
+                extension = ".zip";
+              } else {
+                basename = archiveName.substring(0, archiveName.lastIndexOf(".tar.gz"));
+                extension = ".tar.gz";
+              }
+              await github.rest.repos.uploadReleaseAsset({
+                ...commonOptions,
+                release_id: newReleaseId,
+                name: `${basename}-${"${{ github.sha }}".substring(0, 7)}${extension}`,
+                data: await fs.readFile(archiveName),
+              });
+            }
+            // publish release
+            await github.rest.repos.updateRelease({
+              ...commonOptions,
+              release_id: newReleaseId,
+              draft: false,
             });
+           


### PR DESCRIPTION
### Description

Refactor nightly builds to delete previous release and create a new release with new binaries

### Related issues


### Motivation and context

The current implementation always uploads nightly builds to the same nightly release. This nightly release is tagged to a particular commit and remains unchanged, causing confusion to users. Furthermore, the source code files can't be modified for a release, so only the binaries get updated, causing a mismatch between source code and binaries

### How has this been tested?

Example workflow run: 

https://github.com/openorclose/async-profiler/actions/runs/11404731913

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
