### PR TITLE
Fix possible uninitialized variable access, method_class.

### DIFF
--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -183,7 +183,7 @@ class Lookup {
 
         jvmtiEnv* jvmti = VM::jvmti();
 
-        jclass method_class;
+        jclass method_class = NULL;
         char* class_name = NULL;
         char* method_name = NULL;
         char* method_sig = NULL;

--- a/src/frameName.cpp
+++ b/src/frameName.cpp
@@ -162,7 +162,7 @@ void FrameName::javaMethodName(jmethodID method) {
         }
     }
 
-    jclass method_class;
+    jclass method_class = NULL;
     char* class_name = NULL;
     char* method_name = NULL;
     char* method_sig = NULL;


### PR DESCRIPTION
### Description
`jmethod_class` *may* not be initialized in all code paths.


### How has this been tested?
```
make test
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
