### PR TITLE
Initialize rem_* in DwarfParser.parseInstructions.

### DIFF
--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -138,10 +138,10 @@ void DwarfParser::parseInstructions(u32 loc, const char* end) {
     int fp_off = DW_SAME_FP;
     int pc_off = -EMPTY_FRAME_SIZE;
 
-    u32 rem_cfa_reg;
-    int rem_cfa_off;
-    int rem_fp_off;
-    int rem_pc_off;
+    u32 rem_cfa_reg = 0;
+    int rem_cfa_off = 0;
+    int rem_fp_off = 0;
+    int rem_pc_off = 0;
 
     while (_ptr < end) {
         u8 op = get8();

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -138,10 +138,10 @@ void DwarfParser::parseInstructions(u32 loc, const char* end) {
     int fp_off = DW_SAME_FP;
     int pc_off = -EMPTY_FRAME_SIZE;
 
-    u32 rem_cfa_reg = 0;
-    int rem_cfa_off = 0;
-    int rem_fp_off = 0;
-    int rem_pc_off = 0;
+    u32 rem_cfa_reg = DW_REG_SP;
+    int rem_cfa_off = EMPTY_FRAME_SIZE;
+    int rem_fp_off = DW_SAME_FP;
+    int rem_pc_off = -EMPTY_FRAME_SIZE;
 
     while (_ptr < end) {
         u8 op = get8();


### PR DESCRIPTION
### Description
`rem_*` variables *may* not be initialized in all code paths.

### How has this been tested?
```
make test
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
