### PR TITLE
Increase setup_lib_path buf size to PATH_MAX

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -6,6 +6,7 @@
 #include <alloca.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -16,13 +17,9 @@
 #include <unistd.h>
 #include "fdtransferServer.h"
 
-#ifdef __linux__
-#include <linux/limits.h>
-#endif
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
-#include <sys/syslimits.h>
 #endif
 
 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -22,6 +22,7 @@
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
+#include <sys/syslimits.h>
 #endif
 
 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -16,6 +16,10 @@
 #include <unistd.h>
 #include "fdtransferServer.h"
 
+#ifdef __linux__
+#include <linux/limits.h>
+#endif
+
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
 #endif
@@ -234,7 +238,7 @@ static void setup_output_files(int pid) {
 }
 
 static void setup_lib_path() {
-    char buf[1024];
+    char buf[PATH_MAX];
 
 #ifdef __linux__
     const char* lib = "../lib/libasyncProfiler.so";


### PR DESCRIPTION
### Description
Buffer smaller than `PATH_MAX` would cause silent truncation when path length is larger than the buffer size.

### Motivation and context
To eliminate possible silent filename truncation, which may cause an error or surprising behavior.

### How has this been tested?
```
make test
asprof start and check libpath value.
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
