### PR TITLE
Upload hs_err logs to artifacts

### DIFF
--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -65,16 +65,19 @@ jobs:
             *) make COMMIT_TAG=$HASH CC=/usr/local/musl/bin/musl-gcc release test -j
             ;;
           esac
+          echo "test" > hs_err_123.log
           echo "archive=$(basename $(find . -type f -iname "async-profiler-*" ))" >> $GITHUB_OUTPUT
       - name: Upload test logs for default architecture
         uses: actions/upload-artifact@v4
         if: always() # we always want to upload test logs, especially when tests fail
         with:
           name: test-logs-${{ matrix.runson }}
-          path: build/test/logs/
+          path: |
+            build/test/logs/
+            hs_err*.log
       - name: Test macOS x64
         if: ${{ matrix.runson == 'macos-14' }}
-        run: JAVA_HOME=$JAVA_HOME_${{ env.JAVA_VERSION }}_X64 make test
+        run: JAVA_HOME=$JAVA_HOME_${{ env.JAVA_VERSION }}_X64 make test && echo "test" > hs_err_123.log
       - name: Upload async-profiler binaries to workflow
         uses: actions/upload-artifact@v4
         with:
@@ -85,7 +88,9 @@ jobs:
         if: matrix.runson == 'macos-14' && always()
         with:
           name: test-logs-macos-14-x64
-          path: build/test/logs/
+          path: |
+            build/test/logs/
+            hs_err*.log
   publish-only-on-push:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -65,7 +65,6 @@ jobs:
             *) make COMMIT_TAG=$HASH CC=/usr/local/musl/bin/musl-gcc release test -j
             ;;
           esac
-          echo "test" > hs_err_123.log
           echo "archive=$(basename $(find . -type f -iname "async-profiler-*" ))" >> $GITHUB_OUTPUT
       - name: Upload test logs for default architecture
         uses: actions/upload-artifact@v4
@@ -77,7 +76,7 @@ jobs:
             hs_err*.log
       - name: Test macOS x64
         if: ${{ matrix.runson == 'macos-14' }}
-        run: JAVA_HOME=$JAVA_HOME_${{ env.JAVA_VERSION }}_X64 make test && echo "test" > hs_err_123.log
+        run: JAVA_HOME=$JAVA_HOME_${{ env.JAVA_VERSION }}_X64 make test
       - name: Upload async-profiler binaries to workflow
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
### Description

Upload hs_err logs to artifacts

### Related issues


### Motivation and context

This helps us debug failing tests in github actions such as https://github.com/async-profiler/async-profiler/actions/runs/11729589309/job/32675573581?pr=1036

### How has this been tested?

created a hs_err.log file directly during testing. will remove after github actions for PR is executed

Example run containing a hs_err log: https://github.com/async-profiler/async-profiler/actions/runs/11743903048?pr=1050


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
