### PR TITLE
Fix errors in LockTests.datagramSocketLock

### DIFF
--- a/test/test/lock/LockTests.java
+++ b/test/test/lock/LockTests.java
@@ -16,7 +16,7 @@ public class LockTests {
     public void datagramSocketLock(TestProcess p) throws Exception {
         Output out = p.profile("-e cpu -d 3 -o collapsed --cstack dwarf");
         assert out.ratio("(PlatformEvent::.ark|PlatformEvent::.npark)") > 0.1
-                || (out.ratio("ReentrantLock.lock") > 0.1 && out.contains("Unsafe_.ark"));
+                || ((out.ratio("ReentrantLock.lock") + out.ratio("ReentrantLock.unlock")) > 0.1 && out.contains("Unsafe_.ark"));
         out = p.profile("-e lock -d 3 -o collapsed");
         assert out.contains("sun/nio/ch/DatagramChannelImpl.send");
     }


### PR DESCRIPTION
### Description
Modified `LockTests.datagramSocketLock` to check the sum of `ReentrantLock.lock()` and `ReentrantLock.unlock()`

### Related issues


### Motivation and context
The test assumes `ReentrantLock.lock()` takes > 10%, but sometimes, it is `ReentrantLock.unlock()` the one that takes time. This may cause the test to sometimes fail.

### How has this been tested?
```
make TESTS=test.lock.LockTests test
```
Test passes, although this is not a guarantee as problem is not consistent
```
Total test duration: 15.311 s
Results Summary:
PASS: 4 (100.0%)
FAIL: 0
SKIP (disabled): 0
SKIP (config mismatch): 0
TOTAL: 4
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
