### PR TITLE
Test corretto 11, 17, 21, 23 in CI.

### DIFF
--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -33,8 +33,10 @@ jobs:
     strategy:
       matrix:
         runson:
-          display: linux-x64,
-          name: "codebuild-async-profiler-nightly-builds-x86-${{ github.run_id }}-${{ github.run_attempt }}"
+          - {
+              display: linux-x64,
+              name: "codebuild-async-profiler-nightly-builds-x86-${{ github.run_id }}-${{ github.run_attempt }}"
+            }
         java-version: [11, 17, 21, 23]
         java-distribution: [corretto]
         include:

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -9,7 +9,6 @@ on:
       - master
 
 env:
-  JAVA_DISTRIBUTION: 'corretto'
   RELEASE_FROM_JAVA_VERSION: '11'
 
 jobs:
@@ -39,6 +38,7 @@ jobs:
               name: "codebuild-async-profiler-nightly-builds-x86-${{ github.run_id }}-${{ github.run_attempt }}"
             }
         java-version: [11, 17, 21, 23]
+        java-distribution: [corretto]
         include:
           - runson:
               display: macos-14-arm64
@@ -49,19 +49,19 @@ jobs:
               name: "codebuild-async-profiler-nightly-builds-${{ github.run_id }}-${{ github.run_attempt }}"
             java-version: 11
     runs-on: ${{ matrix.runson.name }}
-    name: "test (${{ matrix.runson.display }}, ${{ env.JAVA_DISTRIBUTION }} ${{ matrix.java-version }})"
+    name: "test (${{ matrix.runson.display }}, ${{ matrix.java-distribution }} ${{ matrix.java-version }})"
     steps:
       - name: Setup Java for macOS x64
         uses: actions/setup-java@v4
         if: ${{ matrix.runson.name == 'macos-14' }}
         with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          distribution: ${{ matrix.java-distribution }}
           java-version: ${{ matrix.java-version }}
           architecture: x64 # set up for x64, as the default arm one will override this later
       - name: Setup Java for default architecture
         uses: actions/setup-java@v4
         with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          distribution: ${{ matrix.java-distribution }}
           java-version: ${{ matrix.java-version }}
           # architecture: not specifying this defaults to architecture of the runner
       - name: Checkout sources

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -33,10 +33,8 @@ jobs:
     strategy:
       matrix:
         runson:
-          - {
-              display: linux-x64,
-              name: "codebuild-async-profiler-nightly-builds-x86-${{ github.run_id }}-${{ github.run_attempt }}"
-            }
+          display: linux-x64,
+          name: "codebuild-async-profiler-nightly-builds-x86-${{ github.run_id }}-${{ github.run_attempt }}"
         java-version: [11, 17, 21, 23]
         java-distribution: [corretto]
         include:

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -33,10 +33,8 @@ jobs:
     strategy:
       matrix:
         runson:
-          - {
-              display: linux-x64,
-              name: "codebuild-async-profiler-nightly-builds-x86-${{ github.run_id }}-${{ github.run_attempt }}"
-            }
+          - display: linux-x64,
+            name: "codebuild-async-profiler-nightly-builds-x86-${{ github.run_id }}-${{ github.run_attempt }}"
         java-version: [11, 17, 21, 23]
         java-distribution: [corretto]
         include:

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -49,7 +49,7 @@ jobs:
               name: "codebuild-async-profiler-nightly-builds-${{ github.run_id }}-${{ github.run_attempt }}"
             java-version: 11
     runs-on: ${{ matrix.runson.name }}
-    name: "test (${{ matrix.runson.display }}, Corretto ${{ matrix.java-version }})"
+    name: "test (${{ matrix.runson.display }}, ${{ env.JAVA_DISTRIBUTION }} ${{ matrix.java-version }})"
     steps:
       - name: Setup Java for macOS x64
         uses: actions/setup-java@v4

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   JAVA_DISTRIBUTION: 'corretto'
-  JAVA_VERSION: '11'
+  RELEASE_FROM_JAVA_VERSION: '11'
 
 jobs:
   build-jars:
@@ -33,28 +33,36 @@ jobs:
   build-binaries-and-test:
     strategy:
       matrix:
+        runson:
+          - {
+              display: linux-x64,
+              name: "codebuild-async-profiler-nightly-builds-x86-${{ github.run_id }}-${{ github.run_attempt }}"
+            }
+        java-version: [11, 17, 21, 23]
         include:
-          - runson: macos-14
-            display: macos-14-arm64
-          - runson: codebuild-async-profiler-nightly-builds-x86-${{ github.run_id }}-${{ github.run_attempt }}
-            display: linux-x64
-          - runson: codebuild-async-profiler-nightly-builds-${{ github.run_id }}-${{ github.run_attempt }}
-            display: linux-arm64
-    runs-on: ${{ matrix.runson }}
-    name: "test (${{ matrix.display }})"
+          - runson:
+              display: macos-14-arm64
+              name: macos-14
+            java-version: 11
+          - runson:
+              display: linux-arm64
+              name: "codebuild-async-profiler-nightly-builds-${{ github.run_id }}-${{ github.run_attempt }}"
+            java-version: 11
+    runs-on: ${{ matrix.runson.name }}
+    name: "test (${{ matrix.runson.display }}, Corretto ${{ matrix.java-version }})"
     steps:
       - name: Setup Java for macOS x64
         uses: actions/setup-java@v4
-        if: ${{ matrix.runson == 'macos-14' }}
+        if: ${{ matrix.runson.name == 'macos-14' }}
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
+          java-version: ${{ matrix.java-version }}
           architecture: x64 # set up for x64, as the default arm one will override this later
       - name: Setup Java for default architecture
         uses: actions/setup-java@v4
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
+          java-version: ${{ matrix.java-version }}
           # architecture: not specifying this defaults to architecture of the runner
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -63,7 +71,7 @@ jobs:
         run: |
           # there is no git on the codebuild runner, so it's easier to get it from github.sha
           HASH=$(echo ${{ github.sha }} | cut -c-7)
-          case "${{ matrix.runson }}" in
+          case "${{ matrix.runson.name }}" in
             macos*)
               make COMMIT_TAG=$HASH FAT_BINARY=true release test -j
             ;;
@@ -77,7 +85,7 @@ jobs:
         run: |
           # there is no git on the codebuild runner, so it's easier to get it from github.sha
           HASH=$(echo ${{ github.sha }} | cut -c-7)
-          case "${{ matrix.runson }}" in
+          case "${{ matrix.runson.name }}" in
             macos*)
               brew install gcovr
               make COMMIT_TAG=$HASH FAT_BINARY=true coverage -j
@@ -88,30 +96,36 @@ jobs:
           esac
       - name: Upload test logs for default architecture
         uses: actions/upload-artifact@v4
+
         if: always() # we always want to upload test logs, especially when tests fail
         with:
-          name: test-logs-${{ matrix.runson }}
+          name: test-logs-${{ matrix.runson.name }}-${{ matrix.java-version }}
           path: |
             build/test/logs/
             hs_err*.log
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
+
         with:
-          name: test-coverage-${{ matrix.runson }}
+          name: test-coverage-${{ matrix.runson.name }}-${{ matrix.java-version }}
           path: build/test/coverage/
       - name: Test macOS x64
-        if: ${{ matrix.runson == 'macos-14' }}
+        if: ${{ matrix.runson.name == 'macos-14' }}
         run: JAVA_HOME=$JAVA_HOME_${{ env.JAVA_VERSION }}_X64 make test
+
       - name: Upload async-profiler binaries to workflow
         uses: actions/upload-artifact@v4
+
+        if: env.RELEASE_FROM_JAVA_VERSION == matrix.java-version
         with:
           name: ${{ steps.build.outputs.archive }}
           path: ${{ steps.build.outputs.archive }}
       - name: Upload test logs for macOS x64
         uses: actions/upload-artifact@v4
-        if: matrix.runson == 'macos-14' && always()
+
+        if: matrix.runson.name == 'macos-14' && always()
         with:
-          name: test-logs-macos-14-x64
+          name: test-logs-macos-14-x64-${{ matrix.java-version }}
           path: |
             build/test/logs/
             hs_err*.log

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -38,7 +38,7 @@ jobs:
               name: "codebuild-async-profiler-nightly-builds-x86-${{ github.run_id }}-${{ github.run_attempt }}"
             }
         java-version: [11, 17, 21, 23]
-        java-distribution: [corretto]
+        java-distribution: ["corretto"]
         include:
           - runson:
               display: macos-14-arm64

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -38,16 +38,18 @@ jobs:
               name: "codebuild-async-profiler-nightly-builds-x86-${{ github.run_id }}-${{ github.run_attempt }}"
             }
         java-version: [11, 17, 21, 23]
-        java-distribution: ["corretto"]
+        java-distribution: [corretto]
         include:
           - runson:
               display: macos-14-arm64
               name: macos-14
             java-version: 11
+            java-distribution: corretto
           - runson:
               display: linux-arm64
               name: "codebuild-async-profiler-nightly-builds-${{ github.run_id }}-${{ github.run_attempt }}"
             java-version: 11
+            java-distribution: corretto
     runs-on: ${{ matrix.runson.name }}
     name: "test (${{ matrix.runson.display }}, ${{ matrix.java-distribution }} ${{ matrix.java-version }})"
     steps:


### PR DESCRIPTION
Run tests on multiple Corretto versions.

### Motivation and context
Tests in the CI use Corretto 11. Run tests on Corretto 17, 21 and 23 as well, for the linux x64 target.

### How has this been tested?
`make test` in CI.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
