### PR TITLE
Update build status badge in README.md to new workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Here are some useful native methods that you may want to profile:
 
 ## Building
 
-Build status: [![Build Status](https://github.com/async-profiler/async-profiler/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/async-profiler/async-profiler/actions/workflows/ci.yml)
+Build status: [![Build Status](https://github.com/async-profiler/async-profiler/actions/workflows/test-and-publish-nightly.yml/badge.svg?branch=master)](https://github.com/async-profiler/async-profiler/actions/workflows/test-and-publish-nightly.yml)
 
 Make sure the `JAVA_HOME` environment variable points to your JDK installation,
 and then run `make`. GCC or Clang is required. After building, the profiler binaries


### PR DESCRIPTION
### Description

Update build status badge in README.md to new workflow

### Related issues


### Motivation and context

There is a new workflow now and the old ci.yml has been deleted, leading to a broken badge. 

This changes the README to use the correct one at https://github.com/async-profiler/async-profiler/actions/workflows/test-and-publish-nightly.yml/badge.svg?branch=master


### How has this been tested?

Test out the change right here

```
Build status: [![Build Status](https://github.com/async-profiler/async-profiler/actions/workflows/test-and-publish-nightly.yml/badge.svg?branch=master)](https://github.com/async-profiler/async-profiler/actions/workflows/test-and-publish-nightly.yml)
```

Build status: [![Build Status](https://github.com/async-profiler/async-profiler/actions/workflows/test-and-publish-nightly.yml/badge.svg?branch=master)](https://github.com/async-profiler/async-profiler/actions/workflows/test-and-publish-nightly.yml)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
