### PR TITLE
Rectify flamegraph colors guide positioning.

### DIFF
--- a/docs/FlamegraphInterpretation.md
+++ b/docs/FlamegraphInterpretation.md
@@ -68,6 +68,7 @@ heap utilization and wall-clock profiling to view latency.
 
 ## Understanding FlameGraph colors
 The various colours in a FlameGraph output with their relation to underlying code for a Java application:
+
 ![](https://github.com/async-profiler/async-profiler/blob/master/.assets/images/flamegraph_colors.png)
 
 Please note the colours in the example diagrams above have no relation to the official FlameGraph colour palette.


### PR DESCRIPTION
### Description
Color coding image for flamegraph positioning is not correct.

### Related issues


### Motivation and context


### How has this been tested?


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
