### PR TITLE
Fix misses and build issues in Non Java profiling example in documentation.

### DIFF
--- a/docs/FlamegraphInterpretation.md
+++ b/docs/FlamegraphInterpretation.md
@@ -68,6 +68,7 @@ heap utilization and wall-clock profiling to view latency.
 
 ## Understanding FlameGraph colors
 The various colours in a FlameGraph output with their relation to underlying code for a Java application:
+
 ![](https://github.com/async-profiler/async-profiler/blob/master/.assets/images/flamegraph_colors.png)
 
 Please note the colours in the example diagrams above have no relation to the official FlameGraph colour palette.

--- a/docs/ProfilingNonJavaApplications.md
+++ b/docs/ProfilingNonJavaApplications.md
@@ -27,8 +27,13 @@ typedef const char* (*asprof_error_str_t)(asprof_error_t err);
 DLLEXPORT asprof_error_t asprof_execute(const char* command, asprof_writer_t output_callback);
 typedef asprof_error_t (*asprof_execute_t)(const char* command, asprof_writer_t output_callback);
 ```
-To use it in a C/C++ application, include asprof.h. Below is an example usage showing how to use async-profiler command with the API. The :
+To use it in a C/C++ application, include asprof.h. Below is an example usage showing how to use async-profiler command with the API:
 ```
+#include "asprof.h"
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+
 void test_output_callback(const char* buffer, size_t size) {
     fwrite(buffer, sizeof(char), size, stderr);
 }
@@ -42,7 +47,7 @@ int main() {
         exit(1);
     }
 
-    asprof_init_t asprof_init = dlsym(lib, "asprof_init");
+    asprof_init_t asprof_init = (asprof_init_t)dlsym(lib, "asprof_init");
     if(asprof_init == NULL) {
         printf("%s\n", dlerror());
         dlclose(lib);
@@ -55,13 +60,14 @@ int main() {
 
     printf("Starting profiler\n");
     
-    asprof_execute_t asprof_execute = dlsym(lib, "asprof_execute");
+    asprof_execute_t asprof_execute = (asprof_execute_t)dlsym(lib, "asprof_execute");
     if(asprof_execute == NULL) {
         printf("%s\n", dlerror());
         dlclose(lib);
         exit(1);
     }
 
+    asprof_error_str_t asprof_error_str = (asprof_error_str_t)dlsym(lib, "asprof_error_str");
     asprof_error_t err = asprof_execute(cmd, test_output_callback);
     if (err != NULL) {
         fprintf(stderr, "%s\n", asprof_error_str(err));


### PR DESCRIPTION
### Description
Fix misses and build issues in Non Java profiling example in documentation.

### Related issues
N/A

### Motivation and context
N/A

### How has this been tested?
Compiled with `gcc NonJava.c -o NonJava -I/home/roysouma/workplace/async-profiler/src -L/home/roysouma/workplace/async-profiler/build/lib -lasyncProfiler -ldl -Wl,-rpath=/home/roysouma/workplace/async-profiler/build/lib` and program ran as expected.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
