### PR TITLE
Fixed JFR test on macOS

### DIFF
--- a/src/cpuEngine.h
+++ b/src/cpuEngine.h
@@ -19,6 +19,7 @@ class CpuEngine : public Engine {
     static long _interval;
     static CStack _cstack;
     static int _signal;
+    static bool _count_overrun;
 
     static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext);
     static void signalHandlerJ9(int signo, siginfo_t* siginfo, void* ucontext);

--- a/src/ctimer_linux.cpp
+++ b/src/ctimer_linux.cpp
@@ -98,6 +98,7 @@ Error CTimer::start(Arguments& args) {
     _interval = args._interval ? args._interval : DEFAULT_INTERVAL;
     _cstack = args._cstack;
     _signal = args._signal == 0 ? OS::getProfilingSignal(0) : args._signal & 0xff;
+    _count_overrun = true;
 
     int max_timers = OS::getMaxThreadId();
     if (max_timers != _max_timers) {

--- a/src/itimer.cpp
+++ b/src/itimer.cpp
@@ -31,6 +31,7 @@ Error ITimer::start(Arguments& args) {
     _interval = args._interval ? args._interval : DEFAULT_INTERVAL;
     _cstack = args._cstack;
     _signal = SIGPROF;
+    _count_overrun = false;
 
     if (VM::isOpenJ9()) {
         if (_cstack == CSTACK_DEFAULT) _cstack = CSTACK_DWARF;

--- a/src/os.h
+++ b/src/os.h
@@ -70,6 +70,7 @@ class OS {
     static u64 micros();
     static u64 processStartTime();
     static void sleep(u64 nanos);
+    static u64 overrun(siginfo_t* siginfo);
 
     static u64 hton64(u64 x);
     static u64 ntoh64(u64 x);

--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -131,6 +131,10 @@ void OS::sleep(u64 nanos) {
     nanosleep(&ts, NULL);
 }
 
+u64 OS::overrun(siginfo_t* siginfo) {
+    return siginfo->si_overrun;
+}
+
 u64 OS::hton64(u64 x) {
     return htonl(1) == 1 ? x : bswap_64(x);
 }

--- a/src/os_macos.cpp
+++ b/src/os_macos.cpp
@@ -117,6 +117,10 @@ void OS::sleep(u64 nanos) {
     nanosleep(&ts, NULL);
 }
 
+u64 OS::overrun(siginfo_t* siginfo) {
+    return 0;
+}
+
 u64 OS::processStartTime() {
     static u64 start_time = 0;
 

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -795,6 +795,7 @@ Error PerfEvents::start(Arguments& args) {
     _interval = args._interval ? args._interval : _event_type->default_interval;
     _cstack = args._cstack;
     _signal = args._signal == 0 ? OS::getProfilingSignal(0) : args._signal & 0xff;
+    _count_overrun = false;
 
     _alluser = args._alluser;
     _kernel_stack = !_alluser && _cstack != CSTACK_NO;

--- a/test/one/profiler/test/Output.java
+++ b/test/one/profiler/test/Output.java
@@ -13,7 +13,6 @@ import one.jfr.JfrReader;
 import java.io.*;
 import java.util.Arrays;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class Output {
@@ -43,6 +42,10 @@ public class Output {
 
     public long samples(String regex) {
         return stream(regex).mapToLong(Output::extractSamples).sum();
+    }
+
+    public long total() {
+        return stream().mapToLong(Output::extractSamples).sum();
     }
 
     public double ratio(String regex) {
@@ -84,13 +87,6 @@ public class Output {
             converter.dump(outputStream);
             return new Output(outputStream.toString("UTF-8").split(System.lineSeparator()));
         }
-    }
-
-    public double ratio(String regex1, String regex2) {
-        long matched1 = samples(regex1);
-        long matched2 = samples(regex2);
-
-        return (double) matched1 / (matched1 + matched2);
     }
 
     public Output filter(String regex) {

--- a/test/test/cpu/CpuBurner.java
+++ b/test/test/cpu/CpuBurner.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package test.cpu;
+
+import java.util.Random;
+
+public class CpuBurner {
+    private static final Random random = new Random();
+
+    static void burn() {
+        long n = random.nextLong();
+        if (Long.toString(n).hashCode() == 0) {
+            System.out.println(n);
+        }
+    }
+
+    public static void main(String[] args) {
+        while (true) {
+            burn();
+        }
+    }
+}

--- a/test/test/cpu/CpuTests.java
+++ b/test/test/cpu/CpuTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package test.cpu;
+
+import one.profiler.test.Assert;
+import one.profiler.test.Os;
+import one.profiler.test.Output;
+import one.profiler.test.Test;
+import one.profiler.test.TestProcess;
+
+public class CpuTests {
+
+    private static void assertCloseTo(long value, long target, String message) {
+        Assert.isGreaterOrEqual(value, target * 0.75, message);
+        Assert.isLessOrEqual(value, target * 1.25, message);
+    }
+
+    @Test(mainClass = CpuBurner.class, os = Os.LINUX)
+    public void ctimerTotal(TestProcess p) throws Exception {
+        Output out = p.profile("-d 2 -e ctimer -i 100ms --total -o collapsed");
+        assertCloseTo(out.total(), 2_000_000_000, "ctimer total should match profiling duration");
+
+        out = p.profile("-d 2 -e ctimer -i 1us --total -o collapsed");
+        assertCloseTo(out.total(), 2_000_000_000, "ctimer total should not depend on the profiling interval");
+    }
+
+    @Test(mainClass = CpuBurner.class)
+    public void itimerTotal(TestProcess p) throws Exception {
+        Output out = p.profile("-d 2 -e itimer -i 100ms --total -o collapsed");
+        assertCloseTo(out.total(), 2_000_000_000, "itimer total should match profiling duration");
+
+        out = p.profile("-d 2 -e itimer -i 1us --total -o collapsed");
+        Assert.isLess(out.total(), 5_000_000, "itimer does not support overrun");
+    }
+}

--- a/test/test/cpu/CpuTests.java
+++ b/test/test/cpu/CpuTests.java
@@ -33,6 +33,6 @@ public class CpuTests {
         assertCloseTo(out.total(), 2_000_000_000, "itimer total should match profiling duration");
 
         out = p.profile("-d 2 -e itimer -i 1us --total -o collapsed");
-        Assert.isLess(out.total(), 5_000_000, "itimer does not support overrun");
+        Assert.isLess(out.total(), 1_000_000_000, "itimer does not support overrun");
     }
 }

--- a/test/test/jfr/JfrTests.java
+++ b/test/test/jfr/JfrTests.java
@@ -18,9 +18,10 @@ import java.util.Map;
 
 public class JfrTests {
 
-    @Test(mainClass = RegularPeak.class)
+    @Test(mainClass = RegularPeak.class, agentArgs = "start,event=cpu,file=%f.jfr")
     public void regularPeak(TestProcess p) throws Exception {
-        Output out = p.profile("-e cpu -d 6 -f %f.jfr");
+        Thread.sleep(6000);
+        Output out = p.profile("stop");
         String jfrOutPath = p.getFile("%f").getAbsolutePath();
         out = Output.convertJfrToCollapsed(jfrOutPath, "--to", "2500");
         assert !out.contains("test/jfr/Cache\\.lambda\\$calculateTop\\$1");

--- a/test/test/jfr/JfrTests.java
+++ b/test/test/jfr/JfrTests.java
@@ -18,17 +18,16 @@ import java.util.Map;
 
 public class JfrTests {
 
-    @Test(mainClass = RegularPeak.class, agentArgs = "start,event=cpu,file=%f.jfr")
+    @Test(mainClass = RegularPeak.class)
     public void regularPeak(TestProcess p) throws Exception {
-        Thread.sleep(6000);
-        Output out = p.profile("stop");
+        Output out = p.profile("-e cpu -d 6 -f %f.jfr");
         String jfrOutPath = p.getFile("%f").getAbsolutePath();
         out = Output.convertJfrToCollapsed(jfrOutPath, "--to", "2500");
-        assert !out.contains("test/jfr/Cache\\.lambda\\$calculateTop\\$1");
+        assert !out.contains("test/jfr/Cache\\.calculateTop");
         out = Output.convertJfrToCollapsed(jfrOutPath,"--from", "2500", "--to", "5000");
-        assert out.samples("test/jfr/Cache\\.lambda\\$calculateTop\\$1") >= 1;
+        assert out.samples("test/jfr/Cache\\.calculateTop") >= 1;
         out = Output.convertJfrToCollapsed(jfrOutPath,"--from", "5000");
-        assert !out.contains("test/jfr/Cache\\.lambda\\$calculateTop\\$1");
+        assert !out.contains("test/jfr/Cache\\.calculateTop");
     }
 
     /**


### PR DESCRIPTION
### Description

Fix intermittent failures of `JfrTests.regularPeak` on macOS by checking existence a root function instead of lambda that a sampling profiler may miss.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
