### PR TITLE
Fix CHECK_OP string assertions.

### DIFF
--- a/test/native/testRunner.hpp
+++ b/test/native/testRunner.hpp
@@ -67,7 +67,8 @@ struct TestCase {
 #define __ASSERT_OR_CHECK_OP(isAssert, val1, op, val2)                                                               \
     {                                                                                                                \
         const bool is_string =                                                                                       \
-            std::is_same<decltype(val1), const char*>::value || std::is_same<decltype(val2), const char*>::value;    \
+            std::is_same<decltype(val1), const char*>::value || std::is_same<decltype(val2), const char*>::value ||  \
+            std::is_same<decltype(val1), char*>::value || std::is_same<decltype(val2), char*>::value;                \
         if (is_string) {                                                                                             \
             if ((std::string(#op) == "==") || (std::string(#op) == "!=")) {                                          \
                 const char* str1 = reinterpret_cast<const char*>(val1);                                              \


### PR DESCRIPTION
In addition to const char*, accept char* as string as well.

### Motivation and context
Assertions should compare `char*` values as strings, in addition to `const char*` values.

### How has this been tested?
`make test-cpp`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
