### PR TITLE
Regression: Cross-compilation does not work after CC/CXX changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ API_JAR=jar/async-profiler.jar
 CONVERTER_JAR=jar/jfr-converter.jar
 TEST_JAR=test.jar
 
-CC ?= $(CROSS_COMPILE)gcc
-CXX ?= $(CROSS_COMPILE)g++
+CC=$(CROSS_COMPILE)gcc
+CXX=$(CROSS_COMPILE)g++
 STRIP=$(CROSS_COMPILE)strip
 
 CFLAGS_EXTRA ?=


### PR DESCRIPTION
### Description

I noticed that my own cross-compiled binaries from https://builds.shipilev.net/async-profiler/ do not build cleanly anymore. In fact, there is a bug in `Makefile`, introduced by this hunk:
https://github.com/async-profiler/async-profiler/commit/3cf733d58970f8c130b659821e244150eef40ee8#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R19

The problem is that `CC` and `CXX` are pre-defined in GNU Make: https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html. So, `?=` does not work well: it _never_ overwrites to `$(CROSS_COMPILE)...`, which results in binaries being compiled by host compiler, and only later `strip` discovers the binary format is wrong:

```
$ ARCH_TAG=aarch64 CROSS_COMPILE=/home/buildbot/deps/x-tools/aarch64-linux-gnu/bin/aarch64-linux-gnu- make clean release
rm -f -r build
mkdir -p build/bin
mkdir -p build/lib
for f in src/*.cpp; do echo '#include "'$f'"'; done |\
g++  -O3 -fno-exceptions -fno-omit-frame-pointer -fvisibility=hidden -std=c++11  -U_FORTIFY_SOURCE -Wl,-z,defs -Wl,--exclude-libs,ALL -static-libstdc++ -static-libgcc -fdata-sections -ffunction-sections -Wl,--gc-sections -fwhole-program -DPROFILER_VERSION=\"3.0\" -I/usr/lib/jvm/java-11-openjdk-amd64/include -Isrc/helper -I/usr/lib/jvm/java-11-openjdk-amd64/include/linux -fPIC -shared -o build/lib/libasyncProfiler.so -xc++ - -ldl -lpthread -lrt
cc  -O3 -fno-exceptions  -DPROFILER_VERSION=\"3.0\" -o build/bin/asprof src/main/*.cpp src/jattach/*.c
/home/buildbot/deps/x-tools/aarch64-linux-gnu/bin/aarch64-linux-gnu-strip build/bin/asprof
/home/buildbot/deps/x-tools/aarch64-linux-gnu/bin/aarch64-linux-gnu-strip: Unable to recognise the format of the input file `build/bin/asprof'
make: *** [Makefile:152: build/bin/asprof] Error 1
```

This PR reverts `?=` back to original form.

### Related issues

https://github.com/async-profiler/async-profiler/pull/1036 introduced the bug.

### How has this been tested?

Tested to build fine on `builds.shipilev.net` workers.

I am not actually sure it does not break some assumptions in https://github.com/async-profiler/async-profiler/pull/1036, and GHA workflows need maintainer approval to run :)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
