### PR TITLE
If log file is deleted (hard link is zero), log to stdout

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -90,8 +90,13 @@ void Log::log(LogLevel level, const char* msg, va_list args) {
 
     MutexLocker ml(_lock);
     if (level >= _level) {
-        fprintf(_file, "[%s] %s\n", LEVEL_NAME[level], buf);
-        fflush(_file);
+        struct stat file_info;
+        if (_file == stdout || _file == stderr || (fstat(fileno(_file), &file_info) == 0 && file_info.st_nlink > 0)) {
+            fprintf(_file, "[%s] %s\n", LEVEL_NAME[level], buf);
+            fflush(_file);
+        } else {
+            fprintf(stdout, "[%s] %s\n", LEVEL_NAME[level], buf);
+        }
     }
 }
 


### PR DESCRIPTION
hi,

Could I have a review of this patch.

### Description
The log file is unlinked in the end of start. If threads are created frequently and mmap failed, we still fprintf to the unlinked file, this leads to log loss, better to stdout or stderr.

### Related issues
https://github.com/async-profiler/async-profiler/issues/1084

### Motivation and context
There are 2 choices, the first is to log to stdout, the second is to keep the log file. If profiling duration is long, the log file may become large, need log file size control and rotation , but this makes the  solution complicated. So log to stdout is an acceptable solution.

### How has this been tested?
manual tested.
- during starting, logs are printed to the stdout of asprof
- during profiling, logs are printed to the stdout of java process
- during stopping, logs are printed to the stdout of asprof

Thanks.
Long Yang

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
