### PR TITLE
fix stack trace memory pollution #1089

### DIFF
--- a/src/arch.h
+++ b/src/arch.h
@@ -17,6 +17,12 @@
 
 #define callerPC()     __builtin_return_address(0)
 
+#ifdef _LP64
+#  define LP64_ONLY(code) code
+#else // !_LP64
+#  define LP64_ONLY(code)
+#endif // _LP64
+
 
 typedef unsigned char u8;
 typedef unsigned short u16;

--- a/src/callTraceStorage.cpp
+++ b/src/callTraceStorage.cpp
@@ -7,6 +7,7 @@
 #include "callTraceStorage.h"
 #include "os.h"
 
+#define COMMA ,
 
 static const u32 INITIAL_CAPACITY = 65536;
 static const u32 CALL_TRACE_CHUNK = 8 * 1024 * 1024;
@@ -78,11 +79,7 @@ class LongHashTable {
     }
 };
 
-#if defined(__x86_64__) || defined(__aarch64__) || (defined(__riscv) && (__riscv_xlen == 64))
-CallTrace CallTraceStorage::_overflow_trace = {1, {BCI_ERROR, 0, (jmethodID)"storage_overflow"}};
-#else
-CallTrace CallTraceStorage::_overflow_trace = {1, {BCI_ERROR, (jmethodID)"storage_overflow"}};
-#endif
+CallTrace CallTraceStorage::_overflow_trace = {1, {BCI_ERROR, LP64_ONLY(0 COMMA) (jmethodID)"storage_overflow"}};
 
 CallTraceStorage::CallTraceStorage() : _allocator(CALL_TRACE_CHUNK) {
     _current_table = LongHashTable::allocate(NULL, INITIAL_CAPACITY);

--- a/src/callTraceStorage.cpp
+++ b/src/callTraceStorage.cpp
@@ -78,8 +78,11 @@ class LongHashTable {
     }
 };
 
-
+#if defined(__x86_64__) || defined(__aarch64__) || (defined(__riscv) && (__riscv_xlen == 64))
+CallTrace CallTraceStorage::_overflow_trace = {1, {BCI_ERROR, 0, (jmethodID)"storage_overflow"}};
+#else
 CallTrace CallTraceStorage::_overflow_trace = {1, {BCI_ERROR, (jmethodID)"storage_overflow"}};
+#endif
 
 CallTraceStorage::CallTraceStorage() : _allocator(CALL_TRACE_CHUNK) {
     _current_table = LongHashTable::allocate(NULL, INITIAL_CAPACITY);

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -563,9 +563,7 @@ int Profiler::getJavaTraceJvmti(jvmtiFrameInfo* jvmti_frames, ASGCT_CallFrame* f
             jint bci = jvmti_frames[i].location;
             frames[i].method_id = jvmti_frames[i].method;
             frames[i].bci = bci;
-#if defined(__x86_64__) || defined(__aarch64__) || (defined(__riscv) && (__riscv_xlen == 64))
-            frames[i].padding = 0;
-#endif
+            LP64_ONLY(frames[i].padding = 0;)
         }
     }
     return num_frames;
@@ -1133,11 +1131,11 @@ Error Profiler::start(Arguments& args, bool reset) {
     // (Re-)allocate calltrace buffers
     if (_max_stack_depth != args._jstackdepth) {
         _max_stack_depth = args._jstackdepth;
-        size_t buffer_size = (_max_stack_depth + MAX_NATIVE_FRAMES + RESERVED_FRAMES) * sizeof(CallTraceBuffer);
+        size_t nelem = _max_stack_depth + MAX_NATIVE_FRAMES + RESERVED_FRAMES;
 
         for (int i = 0; i < CONCURRENCY_LEVEL; i++) {
             free(_calltrace_buffer[i]);
-            _calltrace_buffer[i] = (CallTraceBuffer*)malloc(buffer_size);
+            _calltrace_buffer[i] = (CallTraceBuffer*)calloc(nelem, sizeof(CallTraceBuffer));
             if (_calltrace_buffer[i] == NULL) {
                 _max_stack_depth = 0;
                 return Error("Not enough memory to allocate stack trace buffers (try smaller jstackdepth)");

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -563,6 +563,9 @@ int Profiler::getJavaTraceJvmti(jvmtiFrameInfo* jvmti_frames, ASGCT_CallFrame* f
             jint bci = jvmti_frames[i].location;
             frames[i].method_id = jvmti_frames[i].method;
             frames[i].bci = bci;
+#if defined(__x86_64__) || defined(__aarch64__) || (defined(__riscv) && (__riscv_xlen == 64))
+            frames[i].padding = 0;
+#endif
         }
     }
     return num_frames;

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -70,9 +70,7 @@ enum ASGCT_Failure {
 
 typedef struct {
     jint bci;
-#if defined(__x86_64__) || defined(__aarch64__) || (defined(__riscv) && (__riscv_xlen == 64))
-    jint padding;
-#endif
+    LP64_ONLY(jint padding;)
     jmethodID method_id;
 } ASGCT_CallFrame;
 

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -70,6 +70,9 @@ enum ASGCT_Failure {
 
 typedef struct {
     jint bci;
+#if defined(__x86_64__) || defined(__aarch64__) || (defined(__riscv) && (__riscv_xlen == 64))
+    jint padding;
+#endif
     jmethodID method_id;
 } ASGCT_CallFrame;
 

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -7,6 +7,7 @@
 #define _VMENTRY_H
 
 #include <jvmti.h>
+#include "arch.h"
 
 
 enum FrameTypeId {


### PR DESCRIPTION
### Description
Add an explicit padding field on 64-bit platforms and fill it with zero when converting from JVMTI to AGCT frames.

### Related issues
https://github.com/async-profiler/async-profiler/discussions/1089

### Motivation and context
Implement the 3rd option in the discussion above.

### How has this been tested?
Manual tested.
Byte 4 to 7 is changed to zero when calculating the hash for lock sample. see bellow
```
#0  CallTraceStorage::calcHash (this=0x7fff70021308, num_frames=646, frames=0x7fff707f95a0) at src/callTraceStorage.cpp:177
#1  0x00007fffcc39235e in CallTraceStorage::put (this=0x7fff70021308, num_frames=646, frames=0x7fff707f95a0, counter=77567752) at src/callTraceStorage.cpp:231
#2  0x00007fffcc3adb56 in Profiler::recordSample (this=0x7fff700191f0, ucontext=0x0, counter=77567752, event_type=LOCK_SAMPLE, event=0x7fffcc9321f0) at src/profiler.cpp:709
#3  0x00007fffcc3a6d8c in LockTracer::recordContendedLock (event_type=LOCK_SAMPLE, start_time=1412382781432, end_time=1412460349184, lock_name=0x7fff78000d10 "Ljava/lang/Class;", lock=0x7fff78000b98, timeout=0) at src/lockTracer.cpp:271
#4  0x00007fffcc3a68be in LockTracer::MonitorContendedEntered (jvmti=0x7fff7002d3d0, env=0x7ffff01e62e8, thread=0x7fff78000b90, object=0x7fff78000b98) at src/lockTracer.cpp:183
#5  0x00007ffff68d5962 in JvmtiExport::post_monitor_contended_entered(JavaThread*, ObjectMonitor*) () from /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.412.b08-1.el7_9.x86_64/jre/lib/amd64/server/libjvm.so
#6  0x00007ffff6a3fba3 in ObjectMonitor::enter(Thread*) () from /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.412.b08-1.el7_9.x86_64/jre/lib/amd64/server/libjvm.so
#7  0x00007ffff6b0b002 in SharedRuntime::complete_monitor_locking_C(oopDesc*, BasicLock*, JavaThread*) () from /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.412.b08-1.el7_9.x86_64/jre/lib/amd64/server/libjvm.so
#8  0x00007fffe10ff788 in ?? ()
#9  0x0000000000000001 in ?? ()
#10 0x00007fffe116cc40 in ?? ()
#11 0x0000000000000000 in ?? ()

(gdb) x/64x data                 
0x7fff707f95a0: 0xfffffff2      0x00000000      0x0000004a      0x00000000
0x7fff707f95b0: 0x0000000b      0x00000000      0x70769fc0      0x00007fff
0x7fff707f95c0: 0x00000043      0x00000000      0x70769fc0      0x00007fff
0x7fff707f95d0: 0x00000043      0x00000000      0x70769fc0      0x00007fff
0x7fff707f95e0: 0x00000043      0x00000000      0x70769fc0      0x00007fff
0x7fff707f95f0: 0x00000043      0x00000000      0x70769fc0      0x00007fff
0x7fff707f9600: 0x00000043      0x00000000      0x70769fc0      0x00007fff
0x7fff707f9610: 0x00000043      0x00000000      0x70769fc0      0x00007fff
0x7fff707f9620: 0x00000043      0x00000000      0x70769fc0      0x00007fff
0x7fff707f9630: 0x00000043      0x00000000      0x70769fc0      0x00007fff
0x7fff707f9640: 0x00000043      0x00000000      0x70769fc0      0x00007fff
0x7fff707f9650: 0x00000043      0x00000000      0x70769fc0      0x00007fff
0x7fff707f9660: 0x00000043      0x00000000      0x70769fc0      0x00007fff
0x7fff707f9670: 0x00000043      0x00000000      0x70769fc0      0x00007fff
0x7fff707f9680: 0x00000043      0x00000000      0x70769fc0      0x00007fff
0x7fff707f9690: 0x00000043      0x00000000      0x70769fc0      0x00007fff
```
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
