### PR TITLE
Reduce max canvas size

### DIFF
--- a/src/res/heatmap.html
+++ b/src/res/heatmap.html
@@ -3575,7 +3575,7 @@
 	}
 
 	function renderWithMatch(newCanvasHeight, root, level, minLevel) {
-		newCanvasHeight = Math.min(32767, newCanvasHeight);
+		newCanvasHeight = Math.min(16384 / (devicePixelRatio || 1), newCanvasHeight) | 0;
 		if (canvasHeight !== newCanvasHeight) {
 			canvasHeight = newCanvasHeight;
 			canvas.style.height = canvasHeight + 'px';


### PR DESCRIPTION
### Description
Reduce max canvas size

### Related issues
https://github.com/async-profiler/async-profiler/issues/418

### Motivation and context
My tests with chrome shows that if canvas dimensions become greater than 16384x16384 pixels on any side, any draw operations became significantly slower, so let's fix it with 16384.

### How has this been tested?
Locally with latest chrome version.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
