### PR TITLE
Keep CC/CXX env changes without breaking CROSS_COMPILE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,13 @@ API_JAR=jar/async-profiler.jar
 CONVERTER_JAR=jar/jfr-converter.jar
 TEST_JAR=test.jar
 
-CC=$(CROSS_COMPILE)gcc
-CXX=$(CROSS_COMPILE)g++
-STRIP=$(CROSS_COMPILE)strip
+CC ?= gcc
+CXX ?= g++
+STRIP ?= strip
+
+CC := $(CROSS_COMPILE)$(CC)
+CXX := $(CROSS_COMPILE)$(CXX)
+STRIP := $(CROSS_COMPILE)$(STRIP)
 
 CFLAGS_EXTRA ?=
 CXXFLAGS_EXTRA ?=

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,11 @@ CC ?= gcc
 CXX ?= g++
 STRIP ?= strip
 
-CC := $(CROSS_COMPILE)$(CC)
-CXX := $(CROSS_COMPILE)$(CXX)
-STRIP := $(CROSS_COMPILE)$(STRIP)
+ifneq ($(CROSS_COMPILE),)
+CC := $(CROSS_COMPILE)gcc
+CXX := $(CROSS_COMPILE)g++
+STRIP := $(CROSS_COMPILE)strip
+endif
 
 CFLAGS_EXTRA ?=
 CXXFLAGS_EXTRA ?=


### PR DESCRIPTION
### Related issues
https://github.com/async-profiler/async-profiler/pull/1082

### Motivation and context
Allow setting `CC`, `CXX`, `STRIP` from env vars without breaking the `CROSS_COMPILE` sugar.

### How has this been tested?
```
make
CC=gcc14-gcc CXX=gcc14-c++ make
CC= CXX= make CROSS_COMPILE=x86_64-redhat-linux-
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
