### PR TITLE
support openj9-jdk21

### DIFF
--- a/src/vmStructs.cpp
+++ b/src/vmStructs.cpp
@@ -590,7 +590,7 @@ void VMStructs::initThreadBridge() {
     jclass thread_class = env->FindClass("java/lang/Thread");
     if (thread_class == NULL ||
         (_tid = env->GetFieldID(thread_class, "tid", "J")) == NULL ||
-        (_eetop = env->GetFieldID(thread_class, "eetop", "J")) == NULL) {
+        (_eetop = env->GetFieldID(thread_class, "eetop", "J")) == NULL || VM::isOpenJ9()) {
         // No such field - probably not a HotSpot JVM
         env->ExceptionClear();
 


### PR DESCRIPTION
support openj9-jdk21

### Description
In openj9-jdk21, java.lang.Thread has two attributes, tid & eetop, and we need to add VM::isOpenJ9 for judgment
jdk info:
openjdk version "21.0.5" 2024-10-15 LTS
IBM Semeru Runtime Open Edition 21.0.5.11 (build 21.0.5+11-LTS)
Eclipse OpenJ9 VM 21.0.5.11 (build openj9-0.48.0, JRE 21 Linux amd64-64-Bit Compressed References 20241015_307 (JIT enabled, AOT enabled)
OpenJ9   - 1d5831436e
OMR      - d10a4d553
JCL      - b1b311c53fe based on jdk-21.0.5+11)

### Related issues
#1101 
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
