### PR TITLE
support clock=tsc without a JVM

### DIFF
--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -559,7 +559,7 @@ class Recording {
         if (TSC::enabled()) {
             tsc_frequency = (u64)(double(_stop_ticks - _start_ticks) / double(_stop_time - _start_time) * 1000000);
         } else {
-            // Not checking frequencyAvailable here since it's only relevant with TSC enabled.
+            // TSC is not enabled, so frequency can be used to get the constant clock tick frequency
             tsc_frequency = TSC::frequency();
         }
 

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -754,8 +754,8 @@ class Recording {
         buf->put64(_start_time * 1000);  // start time, ns
         buf->put64(0);                   // duration, ns
         buf->put64(_start_ticks);        // start ticks
-        // the frequency here will be incorrect in TSC node but no JVM. It will be overridden
-        // in finishChunk later.
+        // A frequency here may be inaccurate when using TSC clock.
+        // It will be overwritten with a correct value in finishChunk later.
         buf->put64(TSC::frequency());    // ticks per sec
         buf->put32(1);                   // features
     }

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -555,9 +555,12 @@ class Recording {
         (void)result;
 
         // Workaround for JDK-8191415: compute actual TSC frequency, in case JFR is wrong
-        u64 tsc_frequency = TSC::frequency();
+        u64 tsc_frequency;
         if (TSC::enabled()) {
             tsc_frequency = (u64)(double(_stop_ticks - _start_ticks) / double(_stop_time - _start_time) * 1000000);
+        } else {
+            // Not checking frequencyAvailable here since it's only relevant with TSC enabled.
+            tsc_frequency = TSC::frequency();
         }
 
         // Patch chunk header
@@ -751,6 +754,8 @@ class Recording {
         buf->put64(_start_time * 1000);  // start time, ns
         buf->put64(0);                   // duration, ns
         buf->put64(_start_ticks);        // start ticks
+        // the frequency here will be incorrect in TSC node but no JVM. It will be overridden
+        // in finishChunk later.
         buf->put64(TSC::frequency());    // ticks per sec
         buf->put32(1);                   // features
     }

--- a/src/lockTracer.cpp
+++ b/src/lockTracer.cpp
@@ -36,16 +36,7 @@ UnsafeParkFunc LockTracer::_orig_unsafe_park = NULL;
 
 
 Error LockTracer::start(Arguments& args) {
-    if (!VM::loaded()) {
-        return Error("lock tracer only works with the JVM loaded");
-    }
-
-    if (!TSC::frequencyAvailable()) {
-        // shouldn't really happen - frequency should always be available with the JVM loaded.
-        // check anyway.
-        return Error("lock tracer only works with the JVM's TSC frequency calibration");
-    }
-
+    // There is a JVM here, so TSC::frequency is calibrated from it
     _ticks_to_nanos = 1e9 / TSC::frequency();
     _interval = (u64)(args._lock * (TSC::frequency() / 1e9));
     _total_duration = 0;

--- a/src/lockTracer.cpp
+++ b/src/lockTracer.cpp
@@ -36,6 +36,16 @@ UnsafeParkFunc LockTracer::_orig_unsafe_park = NULL;
 
 
 Error LockTracer::start(Arguments& args) {
+    if (!VM::loaded()) {
+        return Error("lock tracer only works with the JVM loaded");
+    }
+
+    if (!TSC::frequencyAvailable()) {
+        // shouldn't really happen - frequency should always be available with the JVM loaded.
+        // check anyway.
+        return Error("lock tracer only works with the JVM's TSC frequency calibration");
+    }
+
     _ticks_to_nanos = 1e9 / TSC::frequency();
     _interval = (u64)(args._lock * (TSC::frequency() / 1e9));
     _total_duration = 0;

--- a/src/tsc.cpp
+++ b/src/tsc.cpp
@@ -7,6 +7,7 @@
 #include "tsc.h"
 #include "vmEntry.h"
 
+
 bool TSC::_initialized = false;
 bool TSC::_available = false;
 bool TSC::_enabled = false;
@@ -41,11 +42,9 @@ void TSC::enable(Clock clock) {
             }
 
             env->ExceptionClear();
-        } else {
-            if (cpuHasGoodTimestampCounter()) {
-                _offset = 0;
-                _available = true;
-            }
+        } else if (cpuHasGoodTimestampCounter()) {
+            _offset = 0;
+            _available = true;
         }
 
         _initialized = true;

--- a/src/tsc.cpp
+++ b/src/tsc.cpp
@@ -7,43 +7,48 @@
 #include "tsc.h"
 #include "vmEntry.h"
 
-
 bool TSC::_initialized = false;
 bool TSC::_available = false;
+bool TSC::_frequencyAvailable = true;
 bool TSC::_enabled = false;
 u64 TSC::_offset = 0;
 u64 TSC::_frequency = NANOTIME_FREQ;
 
-
 void TSC::enable(Clock clock) {
-    if (!TSC_SUPPORTED || clock == CLK_MONOTONIC || !VM::loaded()) {
+    if (!TSC_SUPPORTED || clock == CLK_MONOTONIC) {
         _enabled = false;
         return;
     }
 
     if (!_initialized) {
-        JNIEnv* env = VM::jni();
+        if (VM::loaded()) {
+            JNIEnv* env = VM::jni();
 
-        jfieldID jvm;
-        jmethodID getTicksFrequency, counterTime;
-        jclass cls = env->FindClass("jdk/jfr/internal/JVM");
-        if (cls != NULL
-                && ((jvm = env->GetStaticFieldID(cls, "jvm", "Ljdk/jfr/internal/JVM;")) != NULL)
-                && ((getTicksFrequency = env->GetMethodID(cls, "getTicksFrequency", "()J")) != NULL)
-                && ((counterTime = env->GetStaticMethodID(cls, "counterTime", "()J")) != NULL)) {
-
-            u64 frequency = env->CallLongMethod(env->GetStaticObjectField(cls, jvm), getTicksFrequency);
-            if (frequency > NANOTIME_FREQ) {
-                // Default 1GHz frequency might mean that rdtsc is not available
-                u64 jvm_ticks = env->CallStaticLongMethod(cls, counterTime);
-                _offset = rdtsc() - jvm_ticks;
-                _frequency = frequency;
-                _available = true;
+            jfieldID jvm;
+            jmethodID getTicksFrequency, counterTime;
+            jclass cls = env->FindClass("jdk/jfr/internal/JVM");
+            if (cls != NULL
+                    && ((jvm = env->GetStaticFieldID(cls, "jvm", "Ljdk/jfr/internal/JVM;")) != NULL)
+                    && ((getTicksFrequency = env->GetMethodID(cls, "getTicksFrequency", "()J")) != NULL)
+                    && ((counterTime = env->GetStaticMethodID(cls, "counterTime", "()J")) != NULL)) {
+                u64 frequency = env->CallLongMethod(env->GetStaticObjectField(cls, jvm), getTicksFrequency);
+                if (frequency > NANOTIME_FREQ) {
+                    // Default 1GHz frequency might mean that rdtsc is not available
+                    u64 jvm_ticks = env->CallStaticLongMethod(cls, counterTime);
+                    _offset = rdtsc() - jvm_ticks;
+                    _frequency = frequency;
+                    _available = true;
+                }
             }
-        }
 
-        env->ExceptionClear();
-        _initialized = true;
+            _frequencyAvailable = true;
+            env->ExceptionClear();
+            _initialized = true;
+        } else {
+            _offset = 0;
+            _frequencyAvailable = false; // frequency not available when using TSC with no JVM.
+            _available = true;
+        }
     }
 
     _enabled = _available;

--- a/src/tsc.cpp
+++ b/src/tsc.cpp
@@ -9,7 +9,6 @@
 
 bool TSC::_initialized = false;
 bool TSC::_available = false;
-bool TSC::_frequencyAvailable = true;
 bool TSC::_enabled = false;
 u64 TSC::_offset = 0;
 u64 TSC::_frequency = NANOTIME_FREQ;
@@ -41,13 +40,11 @@ void TSC::enable(Clock clock) {
                 }
             }
 
-            _frequencyAvailable = true;
             env->ExceptionClear();
             _initialized = true;
         } else {
             if (cpuHasGoodTimestampCounter()) {
                 _offset = 0;
-                _frequencyAvailable = false; // frequency not available when using TSC with no JVM.
                 _available = true;
             }
         }

--- a/src/tsc.cpp
+++ b/src/tsc.cpp
@@ -41,13 +41,14 @@ void TSC::enable(Clock clock) {
             }
 
             env->ExceptionClear();
-            _initialized = true;
         } else {
             if (cpuHasGoodTimestampCounter()) {
                 _offset = 0;
                 _available = true;
             }
         }
+
+        _initialized = true;
     }
 
     _enabled = _available;

--- a/src/tsc.cpp
+++ b/src/tsc.cpp
@@ -45,9 +45,11 @@ void TSC::enable(Clock clock) {
             env->ExceptionClear();
             _initialized = true;
         } else {
-            _offset = 0;
-            _frequencyAvailable = false; // frequency not available when using TSC with no JVM.
-            _available = true;
+            if (cpuHasGoodTimestampCounter()) {
+                _offset = 0;
+                _frequencyAvailable = false; // frequency not available when using TSC with no JVM.
+                _available = true;
+            }
         }
     }
 

--- a/src/tsc.h
+++ b/src/tsc.h
@@ -64,7 +64,6 @@ class TSC {
     static bool _initialized;
     static bool _available;
     static bool _enabled;
-    static bool _frequencyAvailable;
     static u64 _offset;
     static u64 _frequency;
 
@@ -80,11 +79,8 @@ class TSC {
     }
 
     // Frequency is only used for Java lock profiling. When using the TSC with
-    // no JVM, there is no frequency calibration and no frequency available.
-    static bool frequencyAvailable() {
-        return _frequencyAvailable;
-    }
-
+    // no JVM, since there is no calibration, this function will return
+    // an incorrect value.
     static u64 frequency() {
         return enabled() ? _frequency : NANOTIME_FREQ;
     }

--- a/src/tsc.h
+++ b/src/tsc.h
@@ -31,8 +31,8 @@ static inline u64 rdtsc() {
 #endif
 }
 
+// Returns true if this CPU has a good ("invariant") timestamp counter
 static bool cpuHasGoodTimestampCounter() {
-    // returns true if this CPU has a good ("invariant") timestamp counter
     unsigned int eax, ebx, ecx, edx;
 
     // Check if CPUID supports misc feature flags
@@ -56,6 +56,7 @@ static bool cpuHasGoodTimestampCounter() {
 static bool cpuHasGoodTimestampCounter() {
     return false;
 }
+
 #endif
 
 

--- a/src/tsc.h
+++ b/src/tsc.h
@@ -46,6 +46,7 @@ class TSC {
     static bool _initialized;
     static bool _available;
     static bool _enabled;
+    static bool _frequencyAvailable;
     static u64 _offset;
     static u64 _frequency;
 
@@ -58,6 +59,12 @@ class TSC {
 
     static u64 ticks() {
         return enabled() ? rdtsc() - _offset : OS::nanotime();
+    }
+
+    // Frequency is only used for Java lock profiling. When using the TSC with
+    // no JVM, there is no frequency calibration and no frequency available.
+    static bool frequencyAvailable() {
+        return _frequencyAvailable;
     }
 
     static u64 frequency() {


### PR DESCRIPTION
### Description

Supports clock=tsc without a JVM. See #1106.

The clock calibration logic has been copied from https://github.com/metrics-rs/quanta

### How has this been tested?

unit tests + tested locally


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
