### PR TITLE
LD_PRELOAD nativemem test

### DIFF
--- a/test/one/profiler/test/TestProcess.java
+++ b/test/one/profiler/test/TestProcess.java
@@ -30,6 +30,7 @@ public class TestProcess implements Closeable {
     public static final String STDERR = "%err";
     public static final String PROFOUT = "%pout";
     public static final String PROFERR = "%perr";
+    public static final String LIBPROF = "%lib";
 
     private static final Pattern filePattern = Pattern.compile("(%[a-z]+)(\\.[a-z]+)?");
 
@@ -67,7 +68,7 @@ public class TestProcess implements Closeable {
         this.logDir = logDir;
         this.inputs = test.inputs();
 
-        List<String> cmd = buildCommandLine(test, currentOs);
+        List<String> cmd = buildCommandLine(test);
         log.log(Level.FINE, "Running " + cmd);
 
         ProcessBuilder pb = new ProcessBuilder(cmd).inheritIO();
@@ -81,7 +82,7 @@ public class TestProcess implements Closeable {
         for (String env : test.env()) {
             String[] keyValue = env.split("=", 2);
             if (keyValue.length == 2) {
-                pb.environment().put(keyValue[0], keyValue[1]);
+                pb.environment().put(keyValue[0], substituteFiles(keyValue[1]));
             }
         }
 
@@ -109,7 +110,7 @@ public class TestProcess implements Closeable {
         return "build/lib/libasyncProfiler." + currentOs.getLibExt();
     }
 
-    private List<String> buildCommandLine(Test test, Os currentOs) {
+    private List<String> buildCommandLine(Test test) {
         List<String> cmd = new ArrayList<>();
 
         String[] sh = test.sh();
@@ -172,11 +173,18 @@ public class TestProcess implements Closeable {
 
         StringBuffer sb = new StringBuffer();
         do {
-            File f = createTempFile(m.group(1), m.group(2));
-            m.appendReplacement(sb, f.getPath());
+            String path = substituteFile(m.group(1), m.group(2));
+            m.appendReplacement(sb, path);
         } while (m.find());
 
         return m.appendTail(sb).toString();
+    }
+
+    private String substituteFile(String fileId, String ext) {
+        if (fileId.equals(LIBPROF)) {
+            return profilerLibPath();
+        }
+        return createTempFile(fileId, ext).getPath();
     }
 
     private File createTempFile(String fileId) {
@@ -309,6 +317,10 @@ public class TestProcess implements Closeable {
 
     public File getFile(String fileId) {
         return tmpFiles.get(fileId);
+    }
+
+    public String getFilePath(String fileId) {
+        return getFile(fileId).getAbsolutePath();
     }
 
     public Output readFile(String fileId) {

--- a/test/test/alloc/AllocTests.java
+++ b/test/test/alloc/AllocTests.java
@@ -102,7 +102,7 @@ public class AllocTests {
     @Test(mainClass = RandomBlockRetainer.class, jvmVer = {11, Integer.MAX_VALUE}, args = "1.0", agentArgs = "start,alloc=1k,total,file=%f.jfr,live")
     public void livenessJfrHasStacks(TestProcess p) throws Exception {
         p.waitForExit();
-        String filename = p.getFile("%f").toPath().toString();
+        String filename = p.getFilePath("%f");
         try (JfrReader r = new JfrReader(filename)) {
             List<AllocationSample> events = r.readAllEvents(AllocationSample.class);
             assert !events.isEmpty() : "No AllocationSample events found in JFR output";

--- a/test/test/jfr/JfrTests.java
+++ b/test/test/jfr/JfrTests.java
@@ -22,7 +22,7 @@ public class JfrTests {
     @Test(mainClass = RegularPeak.class)
     public void regularPeak(TestProcess p) throws Exception {
         Output out = p.profile("-e cpu -d 6 -f %f.jfr");
-        String jfrOutPath = p.getFile("%f").getAbsolutePath();
+        String jfrOutPath = p.getFilePath("%f");
         String peakPattern = "test/jfr/Cache.*calculateTop.*";
 
         out = Output.convertJfrToCollapsed(jfrOutPath, "--to", "2500");
@@ -43,7 +43,7 @@ public class JfrTests {
     public void parseRecording(TestProcess p) throws Exception {
         p.profile("-d 3 -e cpu -f %f.jfr");
         StringBuilder builder = new StringBuilder();
-        try (RecordingFile recordingFile = new RecordingFile(Paths.get(p.getFile("%f").getAbsolutePath()))) {
+        try (RecordingFile recordingFile = new RecordingFile(p.getFile("%f").toPath())) {
             while (recordingFile.hasMoreEvents()) {
                 RecordedEvent event = recordingFile.readEvent();
                 builder.append(event);
@@ -65,7 +65,7 @@ public class JfrTests {
     public void parseMultiModeRecording(TestProcess p) throws Exception {
         p.waitForExit();
         Map<String, Integer> eventsCount = new HashMap<>();
-        try (RecordingFile recordingFile = new RecordingFile(Paths.get(p.getFile("%f").getAbsolutePath()))) {
+        try (RecordingFile recordingFile = new RecordingFile(p.getFile("%f").toPath())) {
             while (recordingFile.hasMoreEvents()) {
                 RecordedEvent event = recordingFile.readEvent();
                 String eventName = event.getEventType().getName();
@@ -89,7 +89,7 @@ public class JfrTests {
         p.profile("-d 3 -i 1ms --ttsp -f %f.jfr");
         assert !containsSamplesOutsideWindow(p) : "Expected no samples outside of ttsp window";
 
-        Output out = Output.convertJfrToCollapsed(p.getFile("%f").getAbsolutePath());
+        Output out = Output.convertJfrToCollapsed(p.getFilePath("%f"));
         assert out.samples("indexOfTest") >= 10;
     }
 
@@ -108,7 +108,7 @@ public class JfrTests {
     private boolean containsSamplesOutsideWindow(TestProcess p) throws Exception {
         TreeMap<Instant, Instant> profilerWindows = new TreeMap<>();
         List<RecordedEvent> samples = new ArrayList<>();
-        try (RecordingFile recordingFile = new RecordingFile(Paths.get(p.getFile("%f").getAbsolutePath()))) {
+        try (RecordingFile recordingFile = new RecordingFile(p.getFile("%f").toPath())) {
             while (recordingFile.hasMoreEvents()) {
                 RecordedEvent event = recordingFile.readEvent();
                 if (event.getEventType().getName().equals("profiler.Window")) {

--- a/test/test/nativemem/NativememTests.java
+++ b/test/test/nativemem/NativememTests.java
@@ -90,7 +90,7 @@ public class NativememTests {
 
     private static void assertNoLeaks(TestProcess p) throws Exception {
         p.waitForExit();
-        String filename = p.getFile("%f").toPath().toString();
+        String filename = p.getFilePath("%f");
 
         boolean nofree = Arrays.asList(p.inputs()).contains("nofree");
         boolean hasFree = false;
@@ -144,5 +144,13 @@ public class NativememTests {
     @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX, args = "once", inputs = "nofree", agentArgs = "start,cpu,alloc,nativemem,nofree,total,file=%f.jfr")
     public void jfrNoFree(TestProcess p) throws Exception {
         assertNoLeaks(p);
+    }
+
+    @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX, args = "once", env = {"LD_PRELOAD=%lib", "ASPROF_COMMAND=start,nativemem,file=%f.jfr"})
+    public void ldpreload(TestProcess p) throws Exception {
+        p.waitForExit();
+        Output out = Output.convertJfrToCollapsed(p.getFilePath("%f"), "--nativemem");
+        assert out.contains("JavaMain");
+        assert out.contains("os::malloc");
     }
 }

--- a/test/test/nativemem/NativememTests.java
+++ b/test/test/nativemem/NativememTests.java
@@ -148,7 +148,8 @@ public class NativememTests {
 
     @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX, args = "once", env = {"LD_PRELOAD=%lib", "ASPROF_COMMAND=start,nativemem,file=%f.jfr"})
     public void ldpreload(TestProcess p) throws Exception {
-        p.waitForExit();
+        assertNoLeaks(p);
+
         Output out = Output.convertJfrToCollapsed(p.getFilePath("%f"), "--nativemem");
         assert out.contains("JavaMain");
         assert out.contains("JVM_");

--- a/test/test/nativemem/NativememTests.java
+++ b/test/test/nativemem/NativememTests.java
@@ -151,6 +151,7 @@ public class NativememTests {
         p.waitForExit();
         Output out = Output.convertJfrToCollapsed(p.getFilePath("%f"), "--nativemem");
         assert out.contains("JavaMain");
-        assert out.contains("os::malloc");
+        assert out.contains("JVM_");
+        assert out.contains("malloc_hook");
     }
 }


### PR DESCRIPTION
### Description

1. Test LD_PRELOAD mechanism to start async-profiler.
2. Test JFR-to-collapsed conversion of non-Java profiles.

PR includes additional refactoring:
- `%lib` can be used as a placeholder for the path to `libasyncProfiler.so`;
- `TestProcess.getFilePath()` as a shortcut for `TestProcess.getFilePath().getAbsolutePath()`.

### Motivation and context

Basic coverage of non-Java profiling.
Also, a regression test for 3d950aed897fd58e1b4fea82b2f833750f49d3b4.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
