### PR TITLE
Fix wrong addresses of original functions with LD_PRELOAD'ed allocator

### DIFF
--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -187,3 +187,5 @@ void Hooks::patchLibraries() {
         cc->patchImport(im_pthread_exit, (void*)pthread_exit_hook);
     }
 }
+
+#undef ADDRESS_OF

--- a/src/mallocTracer.cpp
+++ b/src/mallocTracer.cpp
@@ -13,9 +13,9 @@
 #include <dlfcn.h>
 #include <string.h>
 
-#define ADDRESS_OF(sym) ({               \
-    void* addr = dlsym(RTLD_NEXT, #sym); \
-    addr != NULL ? (sym##_t)addr : sym;  \
+#define ADDRESS_OF(sym) ({                  \
+    void* addr = dlsym(RTLD_DEFAULT, #sym); \
+    addr != NULL ? (sym##_t)addr : sym;     \
 })
 
 typedef void* (*malloc_t)(size_t);
@@ -193,3 +193,5 @@ void MallocTracer::stop() {
     // in the view of library unloading. Consider using dl_iterate_phdr.
     _running = false;
 }
+
+#undef ADDRESS_OF


### PR DESCRIPTION
### Description

Fix nativemem crashes when LD_PRELOAD'ing libjemalloc.so and libasyncProfiler.so together.

### Motivation and context

dlsym(RTLD_NEXT) may return wrong address depending on the order of preloaded libraries.
However, since async-profiler library no longer exposes malloc functions itself, the correct option will be RTLD_DEFAULT.

### How has this been tested?

```
LD_PRELOAD="libjemalloc.so libasyncProfiler.so" ASPROF_COMMAND=start,nativemem java -version
LD_PRELOAD="libasyncProfiler.so libjemalloc.so" ASPROF_COMMAND=start,nativemem java -version
LD_PRELOAD="libasyncProfiler.so" ASPROF_COMMAND=start,nativemem java -version

+ all regular tests
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
