### PR TITLE
support tsc mode on aarch64 using cntvct_el0

### DIFF
--- a/src/tsc.h
+++ b/src/tsc.h
@@ -48,6 +48,21 @@ static bool cpuHasGoodTimestampCounter() {
     return (edx & (1 << 8)) != 0;
 }
 
+#elif defined(__aarch64__)
+
+#define TSC_SUPPORTED true
+
+static inline u64 rdtsc() {
+    u64 value;
+    asm volatile("mrs %0, cntvct_el0" : "=r"(value));
+    return value;
+}
+
+static bool cpuHasGoodTimestampCounter() {
+    // AARCH64 always has a good timestamp counter.
+    return true;
+}
+
 #else
 
 #define TSC_SUPPORTED false


### PR DESCRIPTION
### Description

This PR makes tsc mode work on aarch64 using cntvct_el0. As far as I can tell, e.g. from [the quanta crate](https://github.com/metrics-rs/quanta/blob/e185d38e56e2743368c92c812d479e2f04dc168d/src/detection.rs), the cntvct timestamp is invariant on all aarch64 machines.

It's supposedly not available on iOS but then AFAICT async-profiler doesn't run on iOS either.

### Related issues

Fixes #1139

### Motivation and context

jfrs with a tsc allow for easier alignment between traces from the application and samples. aarch64 (ARM 64-bit) architecture is getting more and more popular, and it's useful to allow tsc-based profiling on aarch64 as well.

### How has this been tested?

Tested manually on a Graviton 2 machine.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
