### PR TITLE
Fix 'make test'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ build-test-libs:
 build-test-bins:
 	@mkdir -p $(TEST_BIN_DIR)
 	gcc -o $(TEST_BIN_DIR)/malloc_plt_dyn test/test/nativemem/malloc_plt_dyn.c
-	gcc -o $(TEST_BIN_DIR)/native_api -Isrc -ldl test/test/c/native_api.c
+	gcc -o $(TEST_BIN_DIR)/native_api -Isrc test/test/c/native_api.c -ldl
 
 test-cpp: build-test-cpp
 	echo "Running cpp tests..."


### PR DESCRIPTION
At least with my gcc 9.4.0 I get the following error when doing `make test`:

```
gcc -o build/test/bin/native_api -Isrc -ldl test/test/c/native_api.c
/usr/bin/ld: /tmp/cc7PcONd.o: in function `main':
native_api.c:(.text+0x140): undefined reference to `dlopen'
/usr/bin/ld: native_api.c:(.text+0x173): undefined reference to `dlsym'
/usr/bin/ld: native_api.c:(.text+0x1db): undefined reference to `dlsym'
collect2: error: ld returned 1 exit status
make: *** [Makefile:212: build-test-bins] Error 1
```
which can be easily fixed by putting `-ldl` after the source file.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
