### PR TITLE
use github hosted runners for Test and Publish Nightly Builds worklfow

### DIFF
--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -47,7 +47,7 @@ jobs:
             container: ""
           - runson:
               display: linux-arm64
-              name: ubuntu-latest
+              name: ubuntu-24.04-arm
             java-version: 11
             java-distribution: corretto
             container: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -72,6 +72,8 @@ jobs:
           # architecture: not specifying this defaults to architecture of the runner
       - name: Checkout sources
         uses: actions/checkout@v4
+      - name: Enable perf event paranoid kernel flag
+        run: sudo sysctl kernel.perf_event_paranoid = 1
       - name: Build and test
         id: build
         run: |

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.runson.name }}
     container:
       image: ${{ matrix.container }}
-      options: --privileged --security-opt seccomp=unconfined --cap-add SYS_ADMIN
+      options: --privileged
     name: "test (${{ matrix.runson.display }}, ${{ matrix.java-distribution }} ${{ matrix.java-version }})"
     steps:
       - name: Setup Java for macOS x64

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.runson.name }}
     container:
       image: ${{ matrix.container }}
-      options: --security-opt seccomp=unconfined --cap-add SYS_ADMIN
+      options: --security-opt seccomp=unconfined --cap-add SYS_ADMIN --sysctl kernel.perf_event_paranoid=1
     name: "test (${{ matrix.runson.display }}, ${{ matrix.java-distribution }} ${{ matrix.java-version }})"
     steps:
       - name: Setup Java for macOS x64
@@ -72,8 +72,6 @@ jobs:
           # architecture: not specifying this defaults to architecture of the runner
       - name: Checkout sources
         uses: actions/checkout@v4
-      - name: Enable perf event paranoid kernel flag
-        run: sudo sysctl kernel.perf_event_paranoid = 1
       - name: Build and test
         id: build
         run: |

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -37,14 +37,14 @@ jobs:
             name: ubuntu-latest
         java-version: [11, 17, 21, 23]
         java-distribution: [corretto]
-        container: "public.ecr.aws/async-profiler/asprof-builder-x86:latest"
+        container: ["public.ecr.aws/async-profiler/asprof-builder-x86:latest"]
         include:
           - runson:
               display: macos-14-arm64
               name: macos-14
             java-version: 11
             java-distribution: corretto
-            container: null
+            container: ""
           - runson:
               display: linux-arm64
               name: ubuntu-24.04-arm

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -47,7 +47,7 @@ jobs:
             container: ""
           - runson:
               display: linux-arm64
-              name: ubuntu-24.04-arm
+              name: ubuntu-22.04-arm
             java-version: 11
             java-distribution: corretto
             container: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -47,7 +47,7 @@ jobs:
             container: ""
           - runson:
               display: linux-arm64
-              name: ubuntu-24.04-arm
+              name: ubuntu-latest
             java-version: 11
             java-distribution: corretto
             container: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -72,8 +72,6 @@ jobs:
           # architecture: not specifying this defaults to architecture of the runner
       - name: Checkout sources
         uses: actions/checkout@v4
-      - name: Enable perf event paranoid kernel flag
-        run: sudo sysctl kernel.perf_event_paranoid = 1
       - name: Build and test
         id: build
         run: |

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.runson.name }}
     container:
       image: ${{ matrix.container }}
-      options: --security-opt seccomp=unconfined --cap-add SYS_ADMIN --sysctl kernel.perf_event_paranoid=1
+      options: --security-opt seccomp=unconfined --cap-add SYS_ADMIN
     name: "test (${{ matrix.runson.display }}, ${{ matrix.java-distribution }} ${{ matrix.java-version }})"
     steps:
       - name: Setup Java for macOS x64
@@ -72,6 +72,8 @@ jobs:
           # architecture: not specifying this defaults to architecture of the runner
       - name: Checkout sources
         uses: actions/checkout@v4
+      - name: Enable perf event paranoid kernel flag
+        run: sudo sysctl kernel.perf_event_paranoid = 1
       - name: Build and test
         id: build
         run: |

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.runson.name }}
     container:
       image: ${{ matrix.container }}
-      options: --security-opt seccomp=unconfined --cap-add SYS_ADMIN
+      options: --privileged --security-opt seccomp=unconfined --cap-add SYS_ADMIN
     name: "test (${{ matrix.runson.display }}, ${{ matrix.java-distribution }} ${{ matrix.java-version }})"
     steps:
       - name: Setup Java for macOS x64

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -33,8 +33,8 @@ jobs:
     strategy:
       matrix:
         runson:
-          - display: linux-x64,
-            name: "codebuild-async-profiler-nightly-builds-x86-${{ github.run_id }}-${{ github.run_attempt }}"
+          - display: linux-x64
+            name: ubuntu-latest
         java-version: [11, 17, 21, 23]
         java-distribution: [corretto]
         include:
@@ -45,7 +45,7 @@ jobs:
             java-distribution: corretto
           - runson:
               display: linux-arm64
-              name: "codebuild-async-profiler-nightly-builds-${{ github.run_id }}-${{ github.run_attempt }}"
+              name: ubuntu-24.04-arm
             java-version: 11
             java-distribution: corretto
     runs-on: ${{ matrix.runson.name }}

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -52,7 +52,9 @@ jobs:
             java-distribution: corretto
             container: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"
     runs-on: ${{ matrix.runson.name }}
-    container: ${{ matrix.container }}
+    container:
+      image: ${{ matrix.container }}
+      options: --security-opt seccomp=unconfined
     name: "test (${{ matrix.runson.display }}, ${{ matrix.java-distribution }} ${{ matrix.java-version }})"
     steps:
       - name: Setup Java for macOS x64

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -31,26 +31,33 @@ jobs:
           path: build/jar/jfr-converter.jar
   build-binaries-and-test:
     strategy:
+#      matrix:
+#        runson:
+#          - display: linux-x64
+#            name: ubuntu-latest
+#        java-version: [11, 17, 21, 23]
+#        java-distribution: [corretto]
+#        container: ["public.ecr.aws/async-profiler/asprof-builder-x86:latest"]
+#        include:
+#          - runson:
+#              display: macos-14-arm64
+#              name: macos-14
+#            java-version: 11
+#            java-distribution: corretto
+#            container: ""
+#          - runson:
+#              display: linux-arm64
+#              name: ubuntu-22.04-arm
+#            java-version: 11
+#            java-distribution: corretto
+#            container: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"
       matrix:
         runson:
-          - display: linux-x64
-            name: ubuntu-latest
-        java-version: [11, 17, 21, 23]
+          - display: linux-arm64
+            name: ubuntu-22.04-arm
+        java-version: [11]
         java-distribution: [corretto]
-        container: ["public.ecr.aws/async-profiler/asprof-builder-x86:latest"]
-        include:
-          - runson:
-              display: macos-14-arm64
-              name: macos-14
-            java-version: 11
-            java-distribution: corretto
-            container: ""
-          - runson:
-              display: linux-arm64
-              name: ubuntu-22.04-arm
-            java-version: 11
-            java-distribution: corretto
-            container: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"
+        container: ["public.ecr.aws/async-profiler/asprof-builder-arm:latest"]
     runs-on: ${{ matrix.runson.name }}
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -37,18 +37,22 @@ jobs:
             name: ubuntu-latest
         java-version: [11, 17, 21, 23]
         java-distribution: [corretto]
+        container: "public.ecr.aws/async-profiler/asprof-builder-x86:latest"
         include:
           - runson:
               display: macos-14-arm64
               name: macos-14
             java-version: 11
             java-distribution: corretto
+            container: null
           - runson:
               display: linux-arm64
               name: ubuntu-24.04-arm
             java-version: 11
             java-distribution: corretto
+            container: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"
     runs-on: ${{ matrix.runson.name }}
+    container: ${{ matrix.container }}
     name: "test (${{ matrix.runson.display }}, ${{ matrix.java-distribution }} ${{ matrix.java-version }})"
     steps:
       - name: Setup Java for macOS x64
@@ -69,7 +73,6 @@ jobs:
       - name: Build and test
         id: build
         run: |
-          # there is no git on the codebuild runner, so it's easier to get it from github.sha
           HASH=$(echo ${{ github.sha }} | cut -c-7)
           case "${{ matrix.runson.name }}" in
             macos*)
@@ -83,7 +86,6 @@ jobs:
       - name: Coverage
         id: coverage
         run: |
-          # there is no git on the codebuild runner, so it's easier to get it from github.sha
           HASH=$(echo ${{ github.sha }} | cut -c-7)
           case "${{ matrix.runson.name }}" in
             macos*)

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.runson.name }}
     container:
       image: ${{ matrix.container }}
-      options: --security-opt seccomp=unconfined
+      options: --security-opt seccomp=unconfined --cap-add SYS_ADMIN
     name: "test (${{ matrix.runson.display }}, ${{ matrix.java-distribution }} ${{ matrix.java-version }})"
     steps:
       - name: Setup Java for macOS x64

--- a/test/one/profiler/test/TestProcess.java
+++ b/test/one/profiler/test/TestProcess.java
@@ -314,7 +314,7 @@ public class TestProcess implements Closeable {
                 .redirectError(createTempFile(PROFERR))
                 .start();
 
-        waitForExit(p, 10);
+        waitForExit(p, 60);
         int exitCode = p.waitFor();
         if (exitCode != 0) {
             throw new IOException("Profiling call failed: " + readFile(PROFERR));

--- a/test/test/pmu/PmuTests.java
+++ b/test/test/pmu/PmuTests.java
@@ -21,7 +21,7 @@ public class PmuTests {
     public void cycles(TestProcess p) throws Exception {
         try {
             System.out.println("Error file location: " + TestProcess.PROFERR);
-            p.profile("-e cycles -d 3 -o collapsed -f %f");
+            p.profile("-e cycles -d 10 -o collapsed -f %f");
             Output out = p.readFile("%f");
             System.out.println("Error output: " + p.readFile(TestProcess.PROFERR));
             double ratio16K = out.ratio("test/pmu/Dictionary.test16K");

--- a/test/test/pmu/PmuTests.java
+++ b/test/test/pmu/PmuTests.java
@@ -24,6 +24,10 @@ public class PmuTests {
             p.profile("-e cycles -d 3 -o collapsed -f %f");
             Output out = p.readFile("%f");
             System.out.println("Error output: " + p.readFile(TestProcess.PROFERR));
+            double ratio16K = out.ratio("test/pmu/Dictionary.test16K");
+            double ratio8M = out.ratio("test/pmu/Dictionary.test8M");
+            System.out.println("Ratio 16K: " + ratio16K);
+            System.out.println("Ratio 8M: " + ratio8M);
             Assert.isGreater(out.ratio("test/pmu/Dictionary.test16K"), 0.4);
             Assert.isGreater(out.ratio("test/pmu/Dictionary.test8M"), 0.4);
         } catch (Exception e) {

--- a/test/test/pmu/PmuTests.java
+++ b/test/test/pmu/PmuTests.java
@@ -20,8 +20,10 @@ public class PmuTests {
     @Test(mainClass = Dictionary.class, os = Os.LINUX)
     public void cycles(TestProcess p) throws Exception {
         try {
+            System.out.println("Error file location: " + TestProcess.PROFERR);
             p.profile("-e cycles -d 3 -o collapsed -f %f");
             Output out = p.readFile("%f");
+            System.out.println("Error output: " + p.readFile(TestProcess.PROFERR));
             Assert.isGreater(out.ratio("test/pmu/Dictionary.test16K"), 0.4);
             Assert.isGreater(out.ratio("test/pmu/Dictionary.test8M"), 0.4);
         } catch (Exception e) {


### PR DESCRIPTION
### Description
Moving away from Self hosted runners (using AWS CodeBuild) to Github hosted runners for Test and Publish Nightly Builds workflow.

### Related issues
https://github.com/async-profiler/async-profiler/issues/1118

### Motivation and context
TODO

### How has this been tested?
TODO

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
