### PR TITLE
CI/CD: use runson.display for publishing test artifacts instead of runson.name

### DIFF
--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -43,7 +43,7 @@ jobs:
             container: ""  # Not using container for mac-os as we have images only for linux
           - runson:
               display: linux-arm64
-              name: ubuntu-24.04-arm # There is no "latest" tag available (yet) as ARM runners are still in public preview
+              name: ubuntu-24-04-arm # There is no "latest" tag available (yet) as ARM runners are still in public preview
             java-version: 11
             java-distribution: corretto
             container: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -43,7 +43,7 @@ jobs:
             container: ""  # Not using container for mac-os as we have images only for linux
           - runson:
               display: linux-arm64
-              name: ubuntu-24-04-arm # There is no "latest" tag available (yet) as ARM runners are still in public preview
+              name: ubuntu-24.04-arm # There is no "latest" tag available (yet) as ARM runners are still in public preview
             java-version: 11
             java-distribution: corretto
             container: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"
@@ -99,7 +99,7 @@ jobs:
 
         if: always() # we always want to upload test logs, especially when tests fail
         with:
-          name: test-logs-${{ matrix.runson.name }}-${{ matrix.java-version }}
+          name: test-logs-${{ matrix.runson.display }}-${{ matrix.java-version }}
           path: |
             build/test/logs/
             hs_err*.log
@@ -107,7 +107,7 @@ jobs:
         uses: actions/upload-artifact@v4
 
         with:
-          name: test-coverage-${{ matrix.runson.name }}-${{ matrix.java-version }}
+          name: test-coverage-${{ matrix.runson.display }}-${{ matrix.java-version }}
           path: build/test/coverage/
       - name: Test macOS x64
         if: ${{ matrix.runson.name == 'macos-14' }}


### PR DESCRIPTION
### Description
After the latest commit merge, the "publish" step fails for nightly build. Ref: https://github.com/async-profiler/async-profiler/pull/1154#issuecomment-2692474105 

Root cause: While downloading artifacts in the workflow, we filter the test files via `*.*` regex. In the above PR, the name of the test artifacts uploaded contained `24.04` in the string (since it uses display.runson and we are forced to use `24.04` there). Thus, these test logs were not getting filtered and as a result, the Javascript which only expected files, also started seeing directories (of test artifacts) and thus the failure. 

This PR uses `runson.display` instead of `runson.name` to circumvent the issue.

### Related issues
https://github.com/async-profiler/async-profiler/pull/1154#issuecomment-2692474105

### Motivation and context
In the PR #1154 we moved to GH hosted runners. After the merge, the publish step fails as noted in the link above. 
This PR aims to fix that.

### How has this been tested?
A successful run was tested here (in my fork branch): https://github.com/visheshruparelia/async-profiler/actions/runs/13634688113/job/38110523750

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
