### PR TITLE
LockTests - use 3 locks for random threads instead of 2 to improve UT stability

### DIFF
--- a/test/test/lock/RaceToLock.java
+++ b/test/test/lock/RaceToLock.java
@@ -16,8 +16,11 @@ public class RaceToLock {
     private long sharedWaitTime = 0;
 
     private final Random random = new Random();
-    private final Lock lock1 = new ReentrantLock(true);
-    private final Lock lock2 = new ReentrantLock(true);
+    private final Lock[] locks = {
+            new ReentrantLock(true),
+            new ReentrantLock(true),
+            new ReentrantLock(true)
+    };
     private volatile long randomWaitTime;
 
     private volatile boolean exitRequested;
@@ -42,7 +45,7 @@ public class RaceToLock {
 
     private void runRandomCounter() {
         while (!exitRequested) {
-            Lock lock = random.nextBoolean() ? lock1 : lock2;
+            Lock lock = locks[random.nextInt(locks.length)];
 
             long start = System.nanoTime();
             lock.lock();


### PR DESCRIPTION
### Description
After migrating to GH Runners for CI, we started seeing that the `raceToLocks` test in `LockTests` class started failing intermittently. The test fails because sometimes the wait time for threads with "shared lock" is lesser than that of threads using "random lock" - the thread randomly chooses one lock from the two available locks. To stabilize this, instead of using two locks, we use three. See below on how was this tested.

### Related issues
N/A

### How has this been tested?
#### Scenario 1
Available locks: 2
Test run count: 10
Total failures: 2
Total success: 8
PR: https://github.com/visheshruparelia/async-profiler/pull/4 (See diff)
Builds: https://github.com/visheshruparelia/async-profiler/actions/runs/13686306015 (Notice that Attempt 6 and Attempt 8 failed - attached screenshot)
![image](https://github.com/user-attachments/assets/dc406dff-34ea-4b56-8ba4-af6ba13b1d56)

#### Scenario 2
Available locks: 3
Test run count: 10
Total failures: 0
Total success: 10
PR: https://github.com/visheshruparelia/async-profiler/pull/3 (See diff)
Builds: https://github.com/visheshruparelia/async-profiler/actions/runs/13686282839 (Notice that all the runs passed - attached screenshot)
![image](https://github.com/user-attachments/assets/9a465b6c-8cb7-45e9-86d6-9e01f072ceff)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
