### PR TITLE
Check that reading integer from the pos is within limit

### DIFF
--- a/src/converter/one/jfr/JfrReader.java
+++ b/src/converter/one/jfr/JfrReader.java
@@ -158,7 +158,7 @@ public class JfrReader implements Closeable {
             int size = getVarint();
             int type = getVarint();
 
-            if (type == 'L' && buf.getInt(pos) == CHUNK_SIGNATURE) {
+            if (pos+4 <= buf.limit() && type == 'L' && buf.getInt(pos) == CHUNK_SIGNATURE) {
                 if (state != STATE_NEW_CHUNK && stopAtNewChunk) {
                     buf.position(pos);
                     state = STATE_NEW_CHUNK;


### PR DESCRIPTION
### Description
In `readEvent` method, we attempt to read an integer without checking that there are 4 bytes available from `pos`.

This PR adds the check so that we don't get exception reading the integer.

### Related issues


### Motivation and context
I was reading `readEvent` method and found the check missing.

### How has this been tested?


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
