### PR TITLE
Mention libstdc++-static as a build requirement in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Find more details in the [Getting started guide](docs/GettingStarted.md).
 
 - make
 - GCC 7.5.0+ or Clang 7.0.0+
+- Static version of libstdc++ (e.g. on Amazon Linux 2023: `yum install libstdc++-static`)
 - JDK 11+
 
 ### How to build


### PR DESCRIPTION
On some Linux systems like for example Amazon Linux 2023, the static version of `libstdc++` doesn't get installed by default. Mention it as a build requirement in `Readme.md`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
