### PR TITLE
Add functionality to get unique stacktraces count from JFR output

### DIFF
--- a/src/converter/one/jfr/Dictionary.java
+++ b/src/converter/one/jfr/Dictionary.java
@@ -32,6 +32,10 @@ public class Dictionary<T> {
         size = 0;
     }
 
+    public int getSize() {
+       return size;
+    }
+
     public void put(long key, T value) {
         if (key == 0) {
             throw new IllegalArgumentException("Zero key not allowed");

--- a/src/converter/one/jfr/Dictionary.java
+++ b/src/converter/one/jfr/Dictionary.java
@@ -32,7 +32,7 @@ public class Dictionary<T> {
         size = 0;
     }
 
-    public int getSize() {
+    public int size() {
        return size;
     }
 

--- a/src/converter/one/jfr/JfrReader.java
+++ b/src/converter/one/jfr/JfrReader.java
@@ -208,10 +208,6 @@ public class JfrReader implements Closeable {
         return null;
     }
 
-    public int stackTracesSize() {
-       return stackTraces.getSize();
-    }
-
     private ExecutionSample readExecutionSample(boolean hasSamples) {
         long time = getVarlong();
         int tid = getVarint();

--- a/src/converter/one/jfr/JfrReader.java
+++ b/src/converter/one/jfr/JfrReader.java
@@ -208,7 +208,7 @@ public class JfrReader implements Closeable {
         return null;
     }
 
-    public int stackTracesSize() throws IOException {
+    public int stackTracesSize() {
        return stackTraces.getSize();
     }
 

--- a/src/converter/one/jfr/JfrReader.java
+++ b/src/converter/one/jfr/JfrReader.java
@@ -208,6 +208,10 @@ public class JfrReader implements Closeable {
         return null;
     }
 
+    public int stackTracesSize() throws IOException {
+       return stackTraces.getSize();
+    }
+
     private ExecutionSample readExecutionSample(boolean hasSamples) {
         long time = getVarlong();
         int tid = getVarint();


### PR DESCRIPTION
### Description
The commit includes the following changes:

* Adding a size method for the custom Dictionary implemetnation.

### Related issues
https://github.com/async-profiler/async-profiler/issues/1170

### Motivation and context
Ability to easily retrieve unique stacktraces in a profiled jfr output

### How has this been tested?
Tested with a crash reproducer generating a jfr output and using JfrReader to get the unique stacktraces count.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
