### PR TITLE
Improve CPUTests.itimer test for systems under load

### DIFF
--- a/test/test/cpu/CPUTimeService.java
+++ b/test/test/cpu/CPUTimeService.java
@@ -1,0 +1,45 @@
+package test.cpu;
+
+import com.sun.tools.attach.AttachNotSupportedException;
+import com.sun.tools.attach.VirtualMachine;
+
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Obtain the CPU time of a process using the Attach API
+ */
+class CPUTimeService implements AutoCloseable {
+
+    private final VirtualMachine vm;
+    private final MBeanServerConnection mbeanServer;
+    private final JMXConnector jmxConnector;
+
+    CPUTimeService(long pid) throws IOException, AttachNotSupportedException {
+        vm = VirtualMachine.attach(pid + "");
+        String connectorAddress = vm.startLocalManagementAgent();
+        JMXServiceURL url = new JMXServiceURL(connectorAddress);
+        jmxConnector = JMXConnectorFactory.connect(url);
+        mbeanServer = jmxConnector.getMBeanServerConnection();
+    }
+
+    long getProcessCPUTimeNanos() throws Exception {
+        Set<ObjectName> mbeans = mbeanServer.queryNames(new ObjectName("java.lang:type=OperatingSystem"), null);
+        if (mbeans.isEmpty()) {
+            throw new Exception("No OperatingSystem MBean found");
+        }
+        ObjectName osMBean = mbeans.iterator().next();
+        return (long) mbeanServer.getAttribute(osMBean, "ProcessCpuTime");
+    }
+
+    @Override
+    public void close() throws IOException {
+        jmxConnector.close();
+        vm.detach();
+    }
+}

--- a/test/test/cpu/CPUTimeService.java
+++ b/test/test/cpu/CPUTimeService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package test.cpu;
 
 import com.sun.tools.attach.AttachNotSupportedException;

--- a/test/test/cpu/CpuBurner.java
+++ b/test/test/cpu/CpuBurner.java
@@ -12,7 +12,7 @@ public class CpuBurner {
 
     static void burn() {
         long n = random.nextLong();
-        if (Long.toString(n).hashCode() == 0) {
+        if (Math.pow(n, Math.log(Math.abs(n) + 1)) == 0) {
             System.out.println(n);
         }
     }

--- a/test/test/cpu/CpuTests.java
+++ b/test/test/cpu/CpuTests.java
@@ -29,7 +29,13 @@ public class CpuTests {
 
     @Test(mainClass = CpuBurner.class)
     public void itimerTotal(TestProcess p) throws Exception {
-        Output out = p.profile("-d 2 -e itimer -i 100ms --total -o collapsed");
-        assertCloseTo(out.total(), 2_000_000_000, "itimer total should match profiling duration");
+        Output out;
+        long cpuTime;
+        try (CPUTimeService timeService = new CPUTimeService(p.pid())) {
+            cpuTime = timeService.getProcessCPUTimeNanos();
+            out = p.profile("-d 2 -e itimer -i 100ms --total -o collapsed");
+            cpuTime = timeService.getProcessCPUTimeNanos() - cpuTime;
+        }
+        assertCloseTo(out.total(), cpuTime, "itimer total should match CPU time spent in the process during profiling");
     }
 }

--- a/test/test/cpu/CpuTests.java
+++ b/test/test/cpu/CpuTests.java
@@ -31,10 +31,10 @@ public class CpuTests {
     public void itimerTotal(TestProcess p) throws Exception {
         Output out;
         long cpuTime;
-        try (CPUTimeService timeService = new CPUTimeService(p.pid())) {
-            cpuTime = timeService.getProcessCPUTimeNanos();
+        try (CpuTimeService timeService = new CpuTimeService(p.pid())) {
+            cpuTime = timeService.getProcessCpuTimeNanos();
             out = p.profile("-d 2 -e itimer -i 100ms --total -o collapsed");
-            cpuTime = timeService.getProcessCPUTimeNanos() - cpuTime;
+            cpuTime = timeService.getProcessCpuTimeNanos() - cpuTime;
         }
         assertCloseTo(out.total(), cpuTime, "itimer total should match CPU time spent in the process during profiling");
     }

--- a/test/test/cpu/CpuTests.java
+++ b/test/test/cpu/CpuTests.java
@@ -44,6 +44,7 @@ public class CpuTests {
             System.err.println("Warning: CPU time / wall time ratio is too low: " + ratio);
             System.err.println("Your system has too high load to run the itimer test properly");
             System.err.println("Therefore the test is skipped");
+            return;
         }
         long actual = out.total() + 100_000_000; // include the end of the last slice, as the total time is always 100ms less than the actual profiling duration
         assertCloseTo(actual, (long)(2_000_000_000 * ratio), "itimer total should match CPU time spent in the process during profiling");

--- a/test/test/cpu/CpuTests.java
+++ b/test/test/cpu/CpuTests.java
@@ -14,7 +14,7 @@ import one.profiler.test.TestProcess;
 public class CpuTests {
 
     private static void assertCloseTo(long value, long target, String message) {
-        Assert.isGreaterOrEqual(value, target * 0.75, message);
+        Assert.isGreaterOrEqual(value, target * 0.6, message);
         Assert.isLessOrEqual(value, target * 1.25, message);
     }
 

--- a/test/test/cpu/CpuTests.java
+++ b/test/test/cpu/CpuTests.java
@@ -40,7 +40,7 @@ public class CpuTests {
             wallTime = System.nanoTime() - wallTime;
         }
         double ratio = (double)cpuTime / wallTime;
-        long actual = out.total();
+        long actual = out.total() + 100_000_000; // include the end of the last slice, as the total time is always 100ms less than the actual profiling duration
         System.out.println("CPU time / wall time ratio: " + ratio);
         System.out.println("itimer total: " + actual / 1_000_000 + " cpu " + cpuTime / 1_000_000 + " wall " + wallTime / 1_000_000 + " expected " + (long)(2_000 * ratio));
 

--- a/test/test/cpu/CpuTests.java
+++ b/test/test/cpu/CpuTests.java
@@ -46,9 +46,6 @@ public class CpuTests {
             System.err.println("Therefore the test is skipped");
         }
         long actual = out.total() + 100_000_000; // include the end of the last slice, as the total time is always 100ms less than the actual profiling duration
-        System.out.println("CPU time / wall time ratio: " + ratio);
-        System.out.println("itimer total: " + actual / 1_000_000 + " cpu " + cpuTime / 1_000_000 + " wall " + wallTime / 1_000_000 + " expected " + (long)(2_000 * ratio));
-
         assertCloseTo(actual, (long)(2_000_000_000 * ratio), "itimer total should match CPU time spent in the process during profiling");
     }
 }

--- a/test/test/cpu/CpuTimeService.java
+++ b/test/test/cpu/CpuTimeService.java
@@ -14,7 +14,6 @@ import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 import java.io.IOException;
-import java.util.Set;
 
 /**
  * Obtain the CPU time of a process using the Attach API
@@ -34,12 +33,7 @@ class CpuTimeService implements AutoCloseable {
     }
 
     long getProcessCpuTimeNanos() throws Exception {
-        Set<ObjectName> mbeans = mbeanServer.queryNames(new ObjectName("java.lang:type=OperatingSystem"), null);
-        if (mbeans.isEmpty()) {
-            throw new Exception("No OperatingSystem MBean found");
-        }
-        ObjectName osMBean = mbeans.iterator().next();
-        return (long) mbeanServer.getAttribute(osMBean, "ProcessCpuTime");
+       return (long)mbeanServer.getAttribute(new ObjectName("java.lang:type=OperatingSystem"), "ProcessCpuTime");
     }
 
     @Override

--- a/test/test/cpu/CpuTimeService.java
+++ b/test/test/cpu/CpuTimeService.java
@@ -19,13 +19,13 @@ import java.util.Set;
 /**
  * Obtain the CPU time of a process using the Attach API
  */
-class CPUTimeService implements AutoCloseable {
+class CpuTimeService implements AutoCloseable {
 
     private final VirtualMachine vm;
     private final MBeanServerConnection mbeanServer;
     private final JMXConnector jmxConnector;
 
-    CPUTimeService(long pid) throws IOException, AttachNotSupportedException {
+    CpuTimeService(long pid) throws IOException, AttachNotSupportedException {
         vm = VirtualMachine.attach(pid + "");
         String connectorAddress = vm.startLocalManagementAgent();
         JMXServiceURL url = new JMXServiceURL(connectorAddress);
@@ -33,7 +33,7 @@ class CPUTimeService implements AutoCloseable {
         mbeanServer = jmxConnector.getMBeanServerConnection();
     }
 
-    long getProcessCPUTimeNanos() throws Exception {
+    long getProcessCpuTimeNanos() throws Exception {
         Set<ObjectName> mbeans = mbeanServer.queryNames(new ObjectName("java.lang:type=OperatingSystem"), null);
         if (mbeans.isEmpty()) {
             throw new Exception("No OperatingSystem MBean found");


### PR DESCRIPTION
### Description

Change the test to check that the CPU time of the profiled process (via a [MBean](https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/OperatingSystemMXBean.html)) is similar to what can be computed from the samples.

Additionally: Make the profiled program not allocate all the time.

### Motivation and context

The test doesn't work when the system is under load.

### How has this been tested?

Ran on multiple platforms.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
