### PR TITLE
Fix compilation with source merging disabled

### DIFF
--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -22,7 +22,7 @@
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
-#include <cerrno>
+#include <errno.h>
 #include "os.h"
 
 

--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -22,6 +22,7 @@
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
+#include <cerrno>
 #include "os.h"
 
 

--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -8,6 +8,7 @@
 #include <arpa/inet.h>
 #include <byteswap.h>
 #include <dirent.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <sched.h>
 #include <stdio.h>
@@ -22,7 +23,6 @@
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
-#include <errno.h>
 #include "os.h"
 
 

--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -22,6 +22,7 @@
 #include "dwarf.h"
 #include "fdtransferClient.h"
 #include "log.h"
+#include "os.h"
 
 
 #ifdef __x86_64__


### PR DESCRIPTION
### Description

```bash
$ make MERGE=false
mkdir -p build/bin
mkdir -p build/lib
g++  -O3 -fno-exceptions -fno-omit-frame-pointer -fvisibility=hidden -std=c++11  -U_FORTIFY_SOURCE -Wl,-z,defs -Wl,--exclude-libs,ALL -static-libstdc++ -static-libgcc -fdata-sections -ffunction-sections -Wl,--gc-sections -momit-leaf-frame-pointer -DPROFILER_VERSION=\"3.0\" -I/usr/lib/jvm/java-21-openjdk-amd64/include -Isrc/helper -I/usr/lib/jvm/java-21-openjdk-amd64/include/linux -fPIC -shared -o build/lib/libasyncProfiler.so src/allocTracer.cpp src/arguments.cpp src/asprof.cpp src/callTraceStorage.cpp src/chk.cpp src/codeCache.cpp src/cpuEngine.cpp src/ctimer_linux.cpp src/demangle.cpp src/dictionary.cpp src/dwarf.cpp src/engine.cpp src/fdtransferClient_linux.cpp src/flameGraph.cpp src/flightRecorder.cpp src/frameName.cpp src/hooks.cpp src/instrument.cpp src/itimer.cpp src/j9Ext.cpp src/j9ObjectSampler.cpp src/j9StackTraces.cpp src/j9WallClock.cpp src/javaApi.cpp src/jfrMetadata.cpp src/linearAllocator.cpp src/lockTracer.cpp src/log.cpp src/mallocTracer.cpp src/mutex.cpp src/objectSampler.cpp src/os_linux.cpp src/os_macos.cpp src/perfEvents_linux.cpp src/profiler.cpp src/rustDemangle.cpp src/stackFrame_aarch64.cpp src/stackFrame_arm.cpp src/stackFrame_i386.cpp src/stackFrame_loongarch64.cpp src/stackFrame_ppc64.cpp src/stackFrame_riscv64.cpp src/stackFrame_x64.cpp src/stackWalker.cpp src/symbols_linux.cpp src/symbols_macos.cpp src/threadFilter.cpp src/threadLocalData.cpp src/trap.cpp src/tsc.cpp src/vmEntry.cpp src/vmStructs.cpp src/wallClock.cpp src/writer.cpp src/zInit.cpp -ldl -lpthread -lrt
src/os_linux.cpp:236:73: error: ‘errno’ was not declared in this scope
  236 | const static bool musl = confstr(_CS_GNU_LIBC_VERSION, NULL, 0) == 0 && errno != 0;
      |                                                                         ^~~~~
src/os_linux.cpp:26:1: note: ‘errno’ is defined in header ‘<cerrno>’; did you forget to ‘#include <cerrno>’?
   25 | #include "os.h"
  +++ |+#include <cerrno>
   26 | 
src/symbols_linux.cpp: In function ‘int parseLibrariesCallback(dl_phdr_info*, size_t, void*)’:
src/symbols_linux.cpp:752:73: error: ‘OS’ has not been declared
  752 |                 ElfParser::parseProgramHeaders(cc, image_base, map_end, OS::isMusl());
      |                                                                         ^~
make: *** [Makefile:171: build/lib/libasyncProfiler.so] Error 1
```

### How has this been tested?
`make MERGE=false` works fine with these additions.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
