### PR TITLE
test with Corretto 24 instead of 23, now that it is out

### DIFF
--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -31,7 +31,7 @@ jobs:
         runson:
           - display: linux-x64
             name: ubuntu-latest # Using "latest" here as the build and test will any ways run inside a container which we control
-        java-version: [11, 17, 21, 23]
+        java-version: [11, 17, 21, 24]
         java-distribution: [corretto]
         container: ["public.ecr.aws/async-profiler/asprof-builder-x86:latest"]
         include:


### PR DESCRIPTION
Test with the latest corretto release 24, instead of 23.

### Motivation and context
Keep LTS releases + latest major.

### How has this been tested?
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
