### PR TITLE
Replace `std::map` with `std::unordered_map`

### DIFF
--- a/src/callTraceStorage.cpp
+++ b/src/callTraceStorage.cpp
@@ -109,7 +109,7 @@ size_t CallTraceStorage::usedMemory() {
     return bytes;
 }
 
-void CallTraceStorage::collectTraces(std::map<u32, CallTrace*>& map) {
+void CallTraceStorage::collectTraces(std::unordered_map<u32, CallTrace*>& map) {
     for (LongHashTable* table = _current_table; table != NULL; table = table->prev()) {
         u64* keys = table->keys();
         CallTraceSample* values = table->values();
@@ -146,7 +146,7 @@ void CallTraceStorage::collectSamples(std::vector<CallTraceSample*>& samples) {
     }
 }
 
-void CallTraceStorage::collectSamples(std::map<u64, CallTraceSample>& map) {
+void CallTraceStorage::collectSamples(std::unordered_map<u64, CallTraceSample>& map) {
     for (LongHashTable* table = _current_table; table != NULL; table = table->prev()) {
         u64* keys = table->keys();
         CallTraceSample* values = table->values();

--- a/src/callTraceStorage.h
+++ b/src/callTraceStorage.h
@@ -6,7 +6,7 @@
 #ifndef _CALLTRACESTORAGE_H
 #define _CALLTRACESTORAGE_H
 
-#include <map>
+#include <unordered_map>
 #include <vector>
 #include "arch.h"
 #include "linearAllocator.h"
@@ -60,9 +60,9 @@ class CallTraceStorage {
     void clear();
     size_t usedMemory();
 
-    void collectTraces(std::map<u32, CallTrace*>& map);
+    void collectTraces(std::unordered_map<u32, CallTrace*>& map);
     void collectSamples(std::vector<CallTraceSample*>& samples);
-    void collectSamples(std::map<u64, CallTraceSample>& map);
+    void collectSamples(std::unordered_map<u64, CallTraceSample>& map);
 
     u32 put(int num_frames, ASGCT_CallFrame* frames, u64 counter);
     void add(u32 call_trace_id, u64 samples, u64 counter);

--- a/src/dictionary.cpp
+++ b/src/dictionary.cpp
@@ -111,11 +111,11 @@ unsigned int Dictionary::lookup(const char* key, size_t length) {
     }
 }
 
-void Dictionary::collect(std::map<unsigned int, const char*>& map) {
+void Dictionary::collect(std::unordered_map<unsigned int, const char*>& map) {
     collect(map, _table);
 }
 
-void Dictionary::collect(std::map<unsigned int, const char*>& map, DictTable* table) {
+void Dictionary::collect(std::unordered_map<unsigned int, const char*>& map, DictTable* table) {
     for (int i = 0; i < ROWS; i++) {
         DictRow* row = &table->rows[i];
         for (int j = 0; j < CELLS; j++) {

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -6,7 +6,7 @@
 #ifndef _DICTIONARY_H
 #define _DICTIONARY_H
 
-#include <map>
+#include <unordered_map>
 #include <stddef.h>
 
 
@@ -43,7 +43,7 @@ class Dictionary {
 
     static unsigned int hash(const char* key, size_t length);
 
-    static void collect(std::map<unsigned int, const char*>& map, DictTable* table);
+    static void collect(std::unordered_map<unsigned int, const char*>& map, DictTable* table);
 
   public:
     Dictionary();
@@ -55,7 +55,7 @@ class Dictionary {
     unsigned int lookup(const char* key);
     unsigned int lookup(const char* key, size_t length);
 
-    void collect(std::map<unsigned int, const char*>& map);
+    void collect(std::unordered_map<unsigned int, const char*>& map);
 };
 
 #endif // _DICTIONARY_H

--- a/src/flameGraph.cpp
+++ b/src/flameGraph.cpp
@@ -131,7 +131,7 @@ void FlameGraph::dump(Writer& out, bool tree) {
         tail = printTill(out, tail, "/*tree:*/");
 
         const char** names = new const char*[_cpool.size() + 1];
-        for (std::map<std::string, u32>::const_iterator it = _cpool.begin(); it != _cpool.end(); ++it) {
+        for (std::unordered_map<std::string, u32>::const_iterator it = _cpool.begin(); it != _cpool.end(); ++it) {
             names[it->second] = it->first.c_str();
         }
         printTreeFrame(out, _root, 0, names);
@@ -203,7 +203,7 @@ void FlameGraph::printFrame(Writer& out, u32 key, const Trie& f, int level, u64 
 
     std::vector<Node> children;
     children.reserve(f._children.size());
-    for (std::map<u32, Trie>::const_iterator it = f._children.begin(); it != f._children.end(); ++it) {
+    for (std::unordered_map<u32, Trie>::const_iterator it = f._children.begin(); it != f._children.end(); ++it) {
         children.push_back(Node(it->first, _name_order[f.nameIndex(it->first)], it->second));
     }
     std::sort(children.begin(), children.end(), Node::orderByName);
@@ -222,7 +222,7 @@ void FlameGraph::printFrame(Writer& out, u32 key, const Trie& f, int level, u64 
 void FlameGraph::printTreeFrame(Writer& out, const Trie& f, int level, const char** names) {
     std::vector<Node> children;
     children.reserve(f._children.size());
-    for (std::map<u32, Trie>::const_iterator it = f._children.begin(); it != f._children.end(); ++it) {
+    for (std::unordered_map<u32, Trie>::const_iterator it = f._children.begin(); it != f._children.end(); ++it) {
         children.push_back(Node(it->first, 0, it->second));
     }
     std::sort(children.begin(), children.end(), Node::orderByTotal);
@@ -271,7 +271,7 @@ void FlameGraph::printCpool(Writer& out) {
 
     std::string prev;
     u32 index = 0;
-    for (std::map<std::string, u32>::const_iterator it = _cpool.begin(); it != _cpool.end(); ++it) {
+    for (std::unordered_map<std::string, u32>::const_iterator it = _cpool.begin(); it != _cpool.end(); ++it) {
         if (_name_order[it->second]) {
             _name_order[it->second] = ++index;
 
@@ -291,7 +291,7 @@ void FlameGraph::printCpool(Writer& out) {
     }
 
     // Release cpool memory, since frame names are never used beyond this point
-    _cpool = std::map<std::string, u32>();
+    _cpool = std::unordered_map<std::string, u32>();
 }
 
 const char* FlameGraph::printTill(Writer& out, const char* data, const char* till) {

--- a/src/flameGraph.h
+++ b/src/flameGraph.h
@@ -6,7 +6,7 @@
 #ifndef _FLAMEGRAPH_H
 #define _FLAMEGRAPH_H
 
-#include <map>
+#include <unordered_map>
 #include <string>
 #include "arch.h"
 #include "arguments.h"
@@ -16,7 +16,7 @@
 
 class Trie {
   public:
-    std::map<u32, Trie> _children;
+    std::unordered_map<u32, Trie> _children;
     u64 _total;
     u64 _self;
     u64 _inlined, _c1_compiled, _interpreted;
@@ -46,7 +46,7 @@ class Trie {
 
     int depth(u64 cutoff, u32* name_order) const {
         int max_depth = 0;
-        for (std::map<u32, Trie>::const_iterator it = _children.begin(); it != _children.end(); ++it) {
+        for (std::unordered_map<u32, Trie>::const_iterator it = _children.begin(); it != _children.end(); ++it) {
             if (it->second._total >= cutoff) {
                 name_order[nameIndex(it->first)] = 1;
                 int d = it->second.depth(cutoff, name_order);
@@ -61,7 +61,7 @@ class Trie {
 class FlameGraph {
   private:
     Trie _root;
-    std::map<std::string, u32> _cpool;
+    std::unordered_map<std::string, u32> _cpool;
     u32* _name_order;
     u64 _mintotal;
     char _buf[4096];

--- a/src/frameName.cpp
+++ b/src/frameName.cpp
@@ -304,8 +304,8 @@ const char* FrameName::name(ASGCT_CallFrame& frame, bool for_matching) {
         default: {
             const char* type_suffix = typeSuffix(FrameType::decode(frame.bci));
 
-            JMethodCache::iterator it = _cache.lower_bound(frame.method_id);
-            if (it != _cache.end() && it->first == frame.method_id) {
+            JMethodCache::iterator it = _cache.find(frame.method_id);
+            if (it != _cache.end()) {
                 it->second[0] = _cache_epoch;
                 const char* name = it->second.c_str() + 1;
                 if (type_suffix != NULL) {

--- a/src/frameName.h
+++ b/src/frameName.h
@@ -8,7 +8,7 @@
 
 #include <jvmti.h>
 #include <locale.h>
-#include <map>
+#include <unordered_map>
 #include <vector>
 #include <string>
 #include "arguments.h"
@@ -20,9 +20,9 @@
 #endif
 
 
-typedef std::map<jmethodID, std::string> JMethodCache;
-typedef std::map<int, std::string> ThreadMap;
-typedef std::map<unsigned int, const char*> ClassMap;
+typedef std::unordered_map<jmethodID, std::string> JMethodCache;
+typedef std::unordered_map<int, std::string> ThreadMap;
+typedef std::unordered_map<unsigned int, const char*> ClassMap;
 
 
 enum MatchType {

--- a/src/j9StackTraces.cpp
+++ b/src/j9StackTraces.cpp
@@ -8,7 +8,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <map>
+#include <unordered_map>
 #include "j9StackTraces.h"
 #include "j9Ext.h"
 #include "profiler.h"
@@ -84,7 +84,7 @@ void J9StackTraces::timerLoop() {
 
     jvmtiEnv* jvmti = VM::jvmti();
     char notification_buf[65536];
-    std::map<void*, jthread> known_threads;
+    std::unordered_map<void*, jthread> known_threads;
 
     int max_frames = _max_stack_depth + MAX_J9_NATIVE_FRAMES + RESERVED_FRAMES;
     ASGCT_CallFrame* frames = (ASGCT_CallFrame*)malloc(max_frames * sizeof(ASGCT_CallFrame));

--- a/src/jfrMetadata.cpp
+++ b/src/jfrMetadata.cpp
@@ -6,7 +6,7 @@
 #include "jfrMetadata.h"
 
 
-std::map<std::string, int> Element::_string_map;
+std::unordered_map<std::string, int> Element::_string_map;
 std::vector<std::string> Element::_strings;
 
 JfrMetadata JfrMetadata::_root;

--- a/src/jfrMetadata.h
+++ b/src/jfrMetadata.h
@@ -7,7 +7,7 @@
 #define _JFRMETADATA_H
 
 #include <string>
-#include <map>
+#include <unordered_map>
 #include <vector>
 #include <stdio.h>
 #include <string.h>
@@ -89,7 +89,7 @@ class Attribute {
 
 class Element {
   protected:
-    static std::map<std::string, int> _string_map;
+    static std::unordered_map<std::string, int> _string_map;
     static std::vector<std::string> _strings;
 
     static int getId(const char* s) {

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -6,7 +6,7 @@
 #ifndef _PROFILER_H
 #define _PROFILER_H
 
-#include <map>
+#include <unordered_map>
 #include <string>
 #include <time.h>
 #include "arch.h"
@@ -57,8 +57,8 @@ class Profiler {
     bool _nostop;
     Mutex _thread_names_lock;
     // TODO: single map?
-    std::map<int, std::string> _thread_names;
-    std::map<int, jlong> _thread_ids;
+    std::unordered_map<int, std::string> _thread_names;
+    std::unordered_map<int, jlong> _thread_ids;
     Dictionary _class_map;
     Dictionary _symbol_map;
     ThreadFilter _thread_filter;

--- a/src/wallClock.cpp
+++ b/src/wallClock.cpp
@@ -37,7 +37,7 @@ struct ThreadSleepState {
     u32 counter;
 };
 
-typedef std::map<int, ThreadSleepState> ThreadSleepMap;
+typedef std::unordered_map<int, ThreadSleepState> ThreadSleepMap;
 
 struct ThreadCpuTime {
     u64 cpu_time;

--- a/test/native/testRunner.hpp
+++ b/test/native/testRunner.hpp
@@ -17,7 +17,7 @@ struct TestCase;
 
 class TestRunner {
   private:
-    std::map<std::string, TestCase> _test_cases;
+    std::unordered_map<std::string, TestCase> _test_cases;
 
     TestRunner(const TestRunner&) = delete;
     TestRunner& operator=(const TestRunner&) = delete;
@@ -28,7 +28,7 @@ class TestRunner {
 
     static TestRunner* instance();
 
-    inline std::map<std::string, TestCase>& testCases() {
+    inline std::unordered_map<std::string, TestCase>& testCases() {
         return _test_cases;
     }
 


### PR DESCRIPTION
### Description
In this PR I replace usages of `std::map` with `std::unordered_map`, since no ordering is required in most cases.

### Motivation and context
Modernization and performance improvements.

### How has this been tested?
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
