### PR TITLE
Enable CTests on MacOs

### DIFF
--- a/test/test/c/CTests.java
+++ b/test/test/c/CTests.java
@@ -12,8 +12,7 @@ import one.profiler.test.TestProcess;
 
 public class CTests {
 
-    // TODO: Make the test work on macOS
-    @Test(sh = "%testbin/native_api %f.jfr", output = true, os = Os.LINUX)
+    @Test(sh = "%testbin/native_api %f.jfr", output = true)
     public void nativeApi(TestProcess p) throws Exception {
         Output out = p.waitForExit(TestProcess.STDOUT);
         assert p.exitCode() == 0;

--- a/test/test/c/native_api.c
+++ b/test/test/c/native_api.c
@@ -10,6 +10,13 @@
 #include <time.h>
 #include "asprof.h"
 
+#ifdef __linux__
+const char profiler_lib_path[] = "build/lib/libasyncProfiler.so";
+const char profiler_start_cmd[] = "start,event=cpu,interval=1ms,wall=10ms,cstack=dwarf,loglevel=debug,file=%s";
+#else
+const char profiler_lib_path[] = "build/lib/libasyncProfiler.dylib";
+const char profiler_start_cmd[] = "start,event=cpu,interval=1ms,cstack=dwarf,loglevel=debug,file=%s";
+#endif
 
 static void fail(const char* msg) {
     fprintf(stderr, "%s\n", msg);
@@ -27,16 +34,16 @@ int main(int argc, char** argv) {
         fail("Too few arguments");
     }
 
-    void* lib = dlopen("build/lib/libasyncProfiler.so", RTLD_NOW);
+    void* lib = dlopen(profiler_lib_path, RTLD_NOW);
     if (lib == NULL) {
-        fail("Failed to load libasyncProfiler.so");
+        fail("Failed to load libasyncProfiler Lib");
     }
 
     asprof_init_t asprof_init = dlsym(lib, "asprof_init");
     asprof_init();
 
     char cmd[4096];
-    snprintf(cmd, sizeof(cmd), "start,event=cpu,interval=1ms,wall=10ms,cstack=dwarf,loglevel=debug,file=%s", argv[1]);
+    snprintf(cmd, sizeof(cmd), profiler_start_cmd, argv[1]);
 
     printf("Starting profiler\n");
     asprof_execute_t asprof_execute = dlsym(lib, "asprof_execute");


### PR DESCRIPTION
### Description
Enable the tests in the `CTests` class on MacOs

### Related issues
N/A

### Motivation and context
Enable more tests on MacOs which enables catching more bugs on MacOs

### How has this been tested?
The test in question now runs on MacOs

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
