### PR TITLE
Remove waiting time comparison in `LockTests#raceToLocks`

### DIFF
--- a/test/test/lock/LockTests.java
+++ b/test/test/lock/LockTests.java
@@ -40,7 +40,5 @@ public class LockTests {
             double sharedDiff = (double) Math.abs(shared1 - shared2) / Math.max(shared1, shared2);
             Assert.isLess(sharedDiff, 0.1, "sharedDiff < 0.1");
         }
-
-        Assert.isGreater(stdout.samples("sharedWaitTime"), stdout.samples("randomWaitTime"), "sharedWaitTime > randomWaitTime");
     }
 }


### PR DESCRIPTION
### Description
This PR removes the comparison between waiting time for shared and random locks in `RaceToLock`.

### Related issues
#1199

### Motivation and context
The removed check is not always successful, and this does not depend on Async-Profiler.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
