### PR TITLE
Amend `LockTests#raceToLocks` to test profiling results of contended locks

### DIFF
--- a/test/test/lock/LockTests.java
+++ b/test/test/lock/LockTests.java
@@ -27,12 +27,15 @@ public class LockTests {
     public void raceToLocks(TestProcess p) throws Exception {
         int interval = Integer.parseInt(p.inputs()[0]);
         Output out = p.profile("--lock " + interval + " --threads -o collapsed");
-        Output stdout = p.readFile(TestProcess.STDOUT);
 
         Assert.isGreater(out.samples("\\[random1"), 0, "sampled all threads 1/4");
         Assert.isGreater(out.samples("\\[random2"), 0, "sampled all threads 2/4");
         Assert.isGreater(out.samples("\\[shared1"), 0, "sampled all threads 3/4");
         Assert.isGreater(out.samples("\\[shared2"), 0, "sampled all threads 4/4");
+
+        long maxSamplesRandom = Math.min(out.samples("\\[random1"), out.samples("\\[random2"));
+        long minSamplesShared = Math.min(out.samples("\\[shared1"), out.samples("\\[shared2"));
+        Assert.isGreater(minSamplesShared, maxSamplesRandom, "threads with shared lock are sampled more frequently");
 
         if (interval == 0) {
             long shared1 = out.samples("\\[shared1");

--- a/test/test/lock/LockTests.java
+++ b/test/test/lock/LockTests.java
@@ -28,14 +28,14 @@ public class LockTests {
         int interval = Integer.parseInt(p.inputs()[0]);
         Output out = p.profile("--lock " + interval + " --threads -o collapsed");
 
-        Assert.isGreater(out.samples("\\[random1"), 0, "sampled all threads 1/4");
-        Assert.isGreater(out.samples("\\[random2"), 0, "sampled all threads 2/4");
         Assert.isGreater(out.samples("\\[shared1"), 0, "sampled all threads 3/4");
         Assert.isGreater(out.samples("\\[shared2"), 0, "sampled all threads 4/4");
+        Assert.isGreater(out.samples("\\[semiShared1"), 0, "sampled all threads 1/4");
+        Assert.isGreater(out.samples("\\[semiShared2"), 0, "sampled all threads 2/4");
 
-        long maxSamplesRandom = Math.min(out.samples("\\[random1"), out.samples("\\[random2"));
+        long maxSamplesSemiShared = Math.min(out.samples("\\[semiShared1"), out.samples("\\[semiShared2"));
         long minSamplesShared = Math.min(out.samples("\\[shared1"), out.samples("\\[shared2"));
-        Assert.isGreater(minSamplesShared, maxSamplesRandom, "threads with shared lock are sampled more frequently");
+        Assert.isGreater(minSamplesShared, maxSamplesSemiShared, "threads with shared lock are sampled more frequently");
 
         if (interval == 0) {
             long shared1 = out.samples("\\[shared1");

--- a/test/test/lock/LockTests.java
+++ b/test/test/lock/LockTests.java
@@ -28,10 +28,10 @@ public class LockTests {
         int interval = Integer.parseInt(p.inputs()[0]);
         Output out = p.profile("--lock " + interval + " --threads -o collapsed");
 
-        Assert.isGreater(out.samples("\\[shared1"), 0, "sampled all threads 3/4");
-        Assert.isGreater(out.samples("\\[shared2"), 0, "sampled all threads 4/4");
-        Assert.isGreater(out.samples("\\[semiShared1"), 0, "sampled all threads 1/4");
-        Assert.isGreater(out.samples("\\[semiShared2"), 0, "sampled all threads 2/4");
+        Assert.isGreater(out.samples("\\[shared1"), 0, "sampled all threads");
+        Assert.isGreater(out.samples("\\[shared2"), 0, "sampled all threads");
+        Assert.isGreater(out.samples("\\[semiShared1"), 0, "sampled all threads");
+        Assert.isGreater(out.samples("\\[semiShared2"), 0, "sampled all threads");
 
         long maxSamplesSemiShared = Math.min(out.samples("\\[semiShared1"), out.samples("\\[semiShared2"));
         long minSamplesShared = Math.min(out.samples("\\[shared1"), out.samples("\\[shared2"));

--- a/test/test/lock/LockTests.java
+++ b/test/test/lock/LockTests.java
@@ -21,9 +21,9 @@ public class LockTests {
         assert out.contains("sun/nio/ch/DatagramChannelImpl.send");
     }
 
-    @Test(mainClass = RaceToLock.class, inputs = "0", output = true)
-    @Test(mainClass = RaceToLock.class, inputs = "10000", output = true)
-    @Test(mainClass = RaceToLock.class, inputs = "1000000", output = true)
+    @Test(mainClass = RaceToLock.class, inputs = "0")
+    @Test(mainClass = RaceToLock.class, inputs = "10000")
+    @Test(mainClass = RaceToLock.class, inputs = "1000000")
     public void raceToLocks(TestProcess p) throws Exception {
         int interval = Integer.parseInt(p.inputs()[0]);
         Output out = p.profile("--lock " + interval + " --threads -o collapsed");

--- a/test/test/lock/RaceToLock.java
+++ b/test/test/lock/RaceToLock.java
@@ -17,7 +17,7 @@ public class RaceToLock {
 
     private static final Lock sharedLock = new ReentrantLock(true);
 
-    private static volatile boolean exitRequested = false;
+    private static volatile boolean exitRequested;
 
     private static void doWork() {
         LockSupport.parkNanos(1);

--- a/test/test/lock/RaceToLock.java
+++ b/test/test/lock/RaceToLock.java
@@ -8,7 +8,6 @@ package test.lock;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.LockSupport;
-import java.util.concurrent.ThreadLocalRandom;
 
 public class RaceToLock {
 

--- a/test/test/lock/RaceToLock.java
+++ b/test/test/lock/RaceToLock.java
@@ -25,8 +25,8 @@ public class RaceToLock {
 
     private static void runShared() {
         while (!exitRequested) {
+            sharedLock.lock();
             try {
-                sharedLock.lock();
                 doWork();
             } finally {
                 sharedLock.unlock();
@@ -40,8 +40,8 @@ public class RaceToLock {
         while (!exitRequested) {
             Lock lock = count % SHARED_LOCK_INTERVAL == 0 ? sharedLock : nonsharedLock;
 
+            lock.lock();
             try {
-                lock.lock();
                 doWork();
             } finally {
                 lock.unlock();

--- a/test/test/lock/RaceToLock.java
+++ b/test/test/lock/RaceToLock.java
@@ -13,8 +13,8 @@ import java.util.concurrent.ThreadLocalRandom;
 public class RaceToLock {
 
     // Every SHARED_LOCK_INTERVAL iterations of the loop in runSemiShared, we try to lock a shared lock instead of an uncontended lock
-    private static final long SHARED_LOCK_INTERVAL = 5;
-    private static final long DURATION_MS = 2000;
+    private static final long SHARED_LOCK_INTERVAL = 10;
+    private static final long DURATION_MS = 4000;
 
     private static final Lock sharedLock = new ReentrantLock(true);
 


### PR DESCRIPTION
### Description
In this PR, I amend the test `LockTests#raceToLocks` to add a new check to assert that threads locking with strong contention are sampled more frequently than threads locking with light contention. 

The idea is that `semiShared` threads always lock an uncontended (thread-local) lock except for a minority of the cases, i.e. once every `SHARED_LOCK_INTERVAL`. `shared` threads always lock on the contended lock.

### Related issues
#1199 

### Motivation and context
The test needs to be fixed to make sure profiling locks works properly.

### How has this been tested?
`make test` both locally and in CI.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
