### PR TITLE
Ignore raw call trace id when it is greater than total capacity of table in callTraceStorage.

### DIFF
--- a/src/callTraceStorage.cpp
+++ b/src/callTraceStorage.cpp
@@ -279,6 +279,10 @@ void CallTraceStorage::add(u32 call_trace_id, u64 samples, u64 counter) {
         return;
     }
 
+    if (call_trace_id >= _current_table->capacity() * 2 - INITIAL_CAPACITY) {
+        return;
+    }
+
     call_trace_id += (INITIAL_CAPACITY - 1);
     for (LongHashTable* table = _current_table; table != NULL; table = table->prev()) {
         if (call_trace_id >= table->capacity()) {

--- a/src/callTraceStorage.cpp
+++ b/src/callTraceStorage.cpp
@@ -101,6 +101,12 @@ void CallTraceStorage::clear() {
     _overflow = 0;
 }
 
+u32 CallTraceStorage::capacity() {
+    // As capacity of each subsequent table doubles,
+    // total capacity is a sum of geometric series: 64K + 128K + 256K...
+    return _current_table->capacity() * 2 - INITIAL_CAPACITY;
+}
+
 size_t CallTraceStorage::usedMemory() {
     size_t bytes = _allocator.usedMemory();
     for (LongHashTable* table = _current_table; table != NULL; table = table->prev()) {
@@ -275,10 +281,7 @@ u32 CallTraceStorage::put(int num_frames, ASGCT_CallFrame* frames, u64 counter) 
 }
 
 void CallTraceStorage::add(u32 call_trace_id, u64 samples, u64 counter) {
-    const bool is_overflow = (call_trace_id == OVERFLOW_TRACE_ID);
-    const bool exceeds_capacity = (call_trace_id >= _current_table->capacity() * 2 - INITIAL_CAPACITY);
-
-    if (is_overflow || exceeds_capacity) {
+    if (call_trace_id >= capacity()) {  // this also includes call_trace_id == OVERFLOW_TRACE_ID
         return;
     }
 

--- a/src/callTraceStorage.cpp
+++ b/src/callTraceStorage.cpp
@@ -281,7 +281,7 @@ u32 CallTraceStorage::put(int num_frames, ASGCT_CallFrame* frames, u64 counter) 
 }
 
 void CallTraceStorage::add(u32 call_trace_id, u64 samples, u64 counter) {
-    if (call_trace_id >= capacity()) {  // this also covers call_trace_id == OVERFLOW_TRACE_ID
+    if (call_trace_id > capacity()) {  // this also covers call_trace_id == OVERFLOW_TRACE_ID
         return;
     }
 

--- a/src/callTraceStorage.cpp
+++ b/src/callTraceStorage.cpp
@@ -275,11 +275,10 @@ u32 CallTraceStorage::put(int num_frames, ASGCT_CallFrame* frames, u64 counter) 
 }
 
 void CallTraceStorage::add(u32 call_trace_id, u64 samples, u64 counter) {
-    if (call_trace_id == OVERFLOW_TRACE_ID) {
-        return;
-    }
+    const bool is_overflow = (call_trace_id == OVERFLOW_TRACE_ID);
+    const bool exceeds_capacity = (call_trace_id >= _current_table->capacity() * 2 - INITIAL_CAPACITY);
 
-    if (call_trace_id >= _current_table->capacity() * 2 - INITIAL_CAPACITY) {
+    if (is_overflow || exceeds_capacity) {
         return;
     }
 

--- a/src/callTraceStorage.cpp
+++ b/src/callTraceStorage.cpp
@@ -281,7 +281,7 @@ u32 CallTraceStorage::put(int num_frames, ASGCT_CallFrame* frames, u64 counter) 
 }
 
 void CallTraceStorage::add(u32 call_trace_id, u64 samples, u64 counter) {
-    if (call_trace_id >= capacity()) {  // this also includes call_trace_id == OVERFLOW_TRACE_ID
+    if (call_trace_id >= capacity()) {  // this also covers call_trace_id == OVERFLOW_TRACE_ID
         return;
     }
 

--- a/src/callTraceStorage.h
+++ b/src/callTraceStorage.h
@@ -58,6 +58,7 @@ class CallTraceStorage {
     ~CallTraceStorage();
 
     void clear();
+    u32 capacity();
     size_t usedMemory();
 
     void collectTraces(std::map<u32, CallTrace*>& map);


### PR DESCRIPTION
### Description
Ignore raw call trace id when it is greater than total capacity of table in callTraceStorage.

### Related issues
https://github.com/async-profiler/async-profiler/issues/1206

### Motivation and context
Prevent a crash during wall clock profiling in the rarest of rare case of delayed signal delivery used by asprof.

### How has this been tested?
Working on a reproducer to reliably crash and always reliably test. At this point, this is a non breaking logical change to just return and not add call trace id in case it is greater than the total capacity of the hashtable in callTraceStorage

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
