### PR TITLE
Wait for warmup phase completion in time-to-safepoint tests

### DIFF
--- a/test/one/profiler/test/Test.java
+++ b/test/one/profiler/test/Test.java
@@ -32,6 +32,8 @@ public @interface Test {
 
     boolean output() default false;
 
+    String waitWarmupOutput() default "";
+
     boolean error() default false;
 
     Os[] os() default {};

--- a/test/one/profiler/test/Test.java
+++ b/test/one/profiler/test/Test.java
@@ -32,8 +32,6 @@ public @interface Test {
 
     boolean output() default false;
 
-    String waitWarmupOutput() default "";
-
     boolean error() default false;
 
     Os[] os() default {};

--- a/test/one/profiler/test/TestProcess.java
+++ b/test/one/profiler/test/TestProcess.java
@@ -73,13 +73,8 @@ public class TestProcess implements Closeable {
         log.log(Level.FINE, "Running " + cmd);
 
         ProcessBuilder pb = new ProcessBuilder(cmd).inheritIO();
-        if (test.output()) {
-            if (!test.waitWarmupOutput().isEmpty()) {
-                throw new IllegalArgumentException("TODO");
-            }
+        if (test.output() || !test.waitWarmupOutput().isEmpty()) {
             pb.redirectOutput(createTempFile(STDOUT));
-        } else if (!test.waitWarmupOutput().isEmpty()) {
-            pb.redirectOutput(ProcessBuilder.Redirect.PIPE);
         }
 
         if (test.error()) {
@@ -96,7 +91,7 @@ public class TestProcess implements Closeable {
         this.p = pb.start();
 
         if (!test.waitWarmupOutput().isEmpty()) {
-            try (InputStream is = p.getInputStream();
+            try (InputStream is = new FileInputStream(getFile(STDOUT));
                  InputStreamReader isr = new InputStreamReader(is);
                  BufferedReader br = new BufferedReader(isr)
             ) {

--- a/test/one/profiler/test/TestProcess.java
+++ b/test/one/profiler/test/TestProcess.java
@@ -73,10 +73,9 @@ public class TestProcess implements Closeable {
         log.log(Level.FINE, "Running " + cmd);
 
         ProcessBuilder pb = new ProcessBuilder(cmd).inheritIO();
-        if (test.output() || !test.waitWarmupOutput().isEmpty()) {
+        if (test.output()) {
             pb.redirectOutput(createTempFile(STDOUT));
         }
-
         if (test.error()) {
             pb.redirectError(createTempFile(STDERR));
         }
@@ -90,17 +89,7 @@ public class TestProcess implements Closeable {
 
         this.p = pb.start();
 
-        if (!test.waitWarmupOutput().isEmpty()) {
-            try (InputStream is = new FileInputStream(getFile(STDOUT));
-                 InputStreamReader isr = new InputStreamReader(is);
-                 BufferedReader br = new BufferedReader(isr)
-            ) {
-                String output = br.readLine();
-                if (!test.waitWarmupOutput().equals(output)) {
-                    throw new AssertionError("Warmup did not complete: " + output);
-                }
-            }
-        } else if (cmd.get(0).endsWith("java")) {
+        if (cmd.get(0).endsWith("java")) {
             // Give the JVM some time to initialize
             Thread.sleep(700);
         }
@@ -288,6 +277,10 @@ public class TestProcess implements Closeable {
 
     public int exitCode() {
         return p.exitValue();
+    }
+
+    public boolean processIsAlive() {
+        return p.isAlive();
     }
 
     public void waitForExit() throws TimeoutException, InterruptedException {

--- a/test/test/jfr/JfrTests.java
+++ b/test/test/jfr/JfrTests.java
@@ -12,6 +12,9 @@ import one.profiler.test.Output;
 import one.profiler.test.Test;
 import one.profiler.test.TestProcess;
 
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -84,7 +87,7 @@ public class JfrTests {
      * @param p The test process to profile with.
      * @throws Exception Any exception thrown during profiling JFR output parsing.
      */
-    @Test(mainClass = Ttsp.class)
+    @Test(mainClass = Ttsp.class, waitWarmupOutput = Ttsp.WARMUP_COMPLETED_OUTPUT)
     public void ttsp(TestProcess p) throws Exception {
         p.profile("-d 3 -i 1ms --ttsp -f %f.jfr");
         assert !containsSamplesOutsideWindow(p) : "Expected no samples outside of ttsp window";
@@ -99,7 +102,7 @@ public class JfrTests {
      * @param p The test process to profile with.
      * @throws Exception Any exception thrown during profiling JFR output parsing.
      */
-    @Test(mainClass = Ttsp.class)
+    @Test(mainClass = Ttsp.class, waitWarmupOutput = Ttsp.WARMUP_COMPLETED_OUTPUT)
     public void ttspNostop(TestProcess p) throws Exception {
         p.profile("-d 3 -i 1ms --ttsp --nostop -f %f.jfr");
         assert containsSamplesOutsideWindow(p) : "Expected to find samples outside of ttsp window";

--- a/test/test/jfr/JfrTests.java
+++ b/test/test/jfr/JfrTests.java
@@ -19,6 +19,7 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.io.*;
 
 public class JfrTests {
 
@@ -81,14 +82,35 @@ public class JfrTests {
         Assert.isGreater(eventsCount.get("jdk.ObjectAllocationInNewTLAB"), 50);
     }
 
+    private static void waitTtspWarmupOutput(TestProcess p) throws Exception {
+        while (true) {
+            try (FileReader isr = new FileReader(p.getFile(TestProcess.STDOUT));
+                BufferedReader br = new BufferedReader(isr)
+            ) {
+                String output = br.readLine();
+                if (output == null && p.processIsAlive()) {
+                    // File is empty, but the process may still output something
+                    Thread.sleep(200);
+                    continue;
+                }
+                if (Ttsp.WARMUP_COMPLETED_OUTPUT.equals(output)) {
+                    break;
+                }
+                throw new AssertionError("Warmup did not complete: " + output);
+            }
+        }
+    }
+
     /**
      * Test to validate time to safepoint profiling
      *
      * @param p The test process to profile with.
      * @throws Exception Any exception thrown during profiling JFR output parsing.
      */
-    @Test(mainClass = Ttsp.class, waitWarmupOutput = Ttsp.WARMUP_COMPLETED_OUTPUT)
+    @Test(mainClass = Ttsp.class, output = true)
     public void ttsp(TestProcess p) throws Exception {
+        waitTtspWarmupOutput(p);
+
         p.profile("-d 3 -i 1ms --ttsp -f %f.jfr");
         assert !containsSamplesOutsideWindow(p) : "Expected no samples outside of ttsp window";
 
@@ -102,8 +124,10 @@ public class JfrTests {
      * @param p The test process to profile with.
      * @throws Exception Any exception thrown during profiling JFR output parsing.
      */
-    @Test(mainClass = Ttsp.class, waitWarmupOutput = Ttsp.WARMUP_COMPLETED_OUTPUT)
+    @Test(mainClass = Ttsp.class, output = true)
     public void ttspNostop(TestProcess p) throws Exception {
+        waitTtspWarmupOutput(p);
+
         p.profile("-d 3 -i 1ms --ttsp --nostop -f %f.jfr");
         assert containsSamplesOutsideWindow(p) : "Expected to find samples outside of ttsp window";
     }

--- a/test/test/jfr/JfrTests.java
+++ b/test/test/jfr/JfrTests.java
@@ -12,9 +12,6 @@ import one.profiler.test.Output;
 import one.profiler.test.Test;
 import one.profiler.test.TestProcess;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;

--- a/test/test/jfr/Ttsp.java
+++ b/test/test/jfr/Ttsp.java
@@ -9,6 +9,8 @@ import java.lang.management.ManagementFactory;
 import java.util.Arrays;
 
 public class Ttsp {
+    public static final String WARMUP_COMPLETED_OUTPUT = "warmup completed";
+
     static volatile int sink;
 
     // String.indexOf is a JVM intrinsic. When JIT-compiled, it has no safepoint check inside
@@ -34,6 +36,7 @@ public class Ttsp {
     public static void main(String[] args) throws Exception {
         // Warmup with small input to force JIT-compilation of indexOfTest
         spoiler(10, 1000000);
+        System.out.println(WARMUP_COMPLETED_OUTPUT);
 
         // Run actual workload with large input to cause long time-to-safepoint pauses
         new Thread(() -> spoiler(1000, Long.MAX_VALUE)).start();


### PR DESCRIPTION
### Description
In this PR I add some logic to `JfrTests` to make sure the warmup is over when we start time-to-safepoint tests.

### Related issues
#1208 

### Motivation and context
I noticed that in some special conditions (i.e. M1 MacOS with x64 JDK) the warmup phase can take as much as 20 seconds. We have some hardcoded wait time in `TestProcess` to let the Java process under test prepare for the run, but that's not enough (`700ms`) and does not accomodate platform differences.

### How has this been tested?
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
