### PR TITLE
Always sort sources so zInit is last.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ LOG_LEVEL=
 SKIP=
 TEST_FLAGS=-DlogDir=$(LOG_DIR) -DlogLevel=$(LOG_LEVEL) -Dskip=$(SKIP)
 
-SOURCES := $(wildcard src/*.cpp)
+# always sort SOURCES so zInit is last.
+SOURCES := $(sort $(wildcard src/*.cpp))
 HEADERS := $(wildcard src/*.h)
 RESOURCES := $(wildcard src/res/*)
 JAVA_HELPER_CLASSES := $(wildcard src/helper/one/profiler/*.class)


### PR DESCRIPTION
### Description
Sort sources to zInit is last, ensuring its statics are initialized last - this works in gcc versions after 4.7.0 (related https://gcc.gnu.org/bugzilla/show_bug.cgi?id=46770).

### Related issues
https://github.com/async-profiler/async-profiler/issues/1214


### How has this been tested?
```
make MERGE=false
```

and starting the profiler with any target, as in https://github.com/async-profiler/async-profiler/issues/1214.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
