### PR TITLE
add support for user JFR events

### DIFF
--- a/src/asprof.cpp
+++ b/src/asprof.cpp
@@ -63,8 +63,8 @@ DLLEXPORT asprof_jfr_event_key asprof_register_jfr_event(const char* name) {
 #define asprof_str(s) #s
 
 DLLEXPORT asprof_error_t asprof_emit_jfr_event(asprof_jfr_event_key type, const uint8_t* data, size_t len) {
-    if (len > ASPROF_MAX_USER_JFR_LENGTH) {
-        return asprof_error("unable to emit JFR event larger than " asprof_str(ASPROF_MAX_USER_JFR_LENGTH) " bytes");
+    if (len > ASPROF_MAX_JFR_EVENT_LENGTH) {
+        return asprof_error("Unable to emit JFR event larger than " asprof_str(ASPROF_MAX_JFR_EVENT_LENGTH) " bytes");
     }
 
     UserEvent event;

--- a/src/asprof.cpp
+++ b/src/asprof.cpp
@@ -56,16 +56,22 @@ DLLEXPORT asprof_thread_local_data* asprof_get_thread_local_data(void) {
     return ThreadLocalData::getThreadLocalData();
 }
 
-DLLEXPORT asprof_user_jfr_key asprof_create_user_jfr_key(const char* name) {
+DLLEXPORT asprof_jfr_event_key asprof_register_jfr_event(const char* name) {
     return UserEvents::registerEvent(name);
 }
 
-DLLEXPORT int asprof_emit_user_jfr(asprof_user_jfr_key type, const uint8_t* data, size_t len, uint64_t _flags) {
+#define asprof_str(s) #s
+
+DLLEXPORT asprof_error_t asprof_emit_jfr_event(asprof_jfr_event_key type, const uint8_t* data, size_t len) {
+    if (len > ASPROF_MAX_USER_JFR_LENGTH) {
+        return asprof_error("unable to emit JFR event larger than " asprof_str(ASPROF_MAX_USER_JFR_LENGTH) " bytes");
+    }
+
     UserEvent event;
     event._start_time = TSC::ticks();
     event._type = type;
     event._data = data;
     event._len = len;
     Profiler::instance()->recordEventOnly(USER_EVENT, &event);
-    return 0;
+    return NULL;
 }

--- a/src/asprof.cpp
+++ b/src/asprof.cpp
@@ -56,14 +56,14 @@ DLLEXPORT asprof_thread_local_data* asprof_get_thread_local_data(void) {
     return ThreadLocalData::getThreadLocalData();
 }
 
-DLLEXPORT asprof_user_jfr_key asprof_create_user_jfr_key(const char *name) {
+DLLEXPORT asprof_user_jfr_key asprof_create_user_jfr_key(const char* name) {
     return UserEvents::registerEvent(name);
 }
 
-DLLEXPORT int asprof_emit_user_jfr(asprof_user_jfr_key key, const uint8_t *data, size_t len) {
+DLLEXPORT int asprof_emit_user_jfr(asprof_user_jfr_key type, const uint8_t* data, size_t len, uint64_t _flags) {
     UserEvent event;
     event._start_time = TSC::ticks();
-    event._key = key;
+    event._type = type;
     event._data = data;
     event._len = len;
     Profiler::instance()->recordEventOnly(USER_EVENT, &event);

--- a/src/asprof.h
+++ b/src/asprof.h
@@ -78,7 +78,7 @@ DLLEXPORT asprof_jfr_event_key asprof_register_jfr_event(const char* name);
 typedef asprof_jfr_event_key (*asprof_register_jfr_event_t)(const char* name);
 
 
-#define ASPROF_MAX_USER_JFR_LENGTH 4000
+#define ASPROF_MAX_USER_JFR_LENGTH 2048
 
 // This API is UNSTABLE and might change or be removed in the next version of async-profiler.
 //

--- a/src/asprof.h
+++ b/src/asprof.h
@@ -63,6 +63,30 @@ typedef struct {
 DLLEXPORT asprof_thread_local_data* asprof_get_thread_local_data(void);
 typedef asprof_thread_local_data* (*asprof_get_thread_local_data_t)(void);
 
+
+typedef int asprof_user_jfr_key;
+
+// This API is UNSTABLE and might change or be removed in the next version of async-profiler.
+//
+// Return a asprof_user_jfr_key identifier for a user-defined JFR key.
+// That identifier can then be used in `asprof_emit_user_jfr
+//
+// Returns -1 on failure.
+DLLEXPORT asprof_user_jfr_key asprof_create_user_jfr_key(const char *name);
+typedef asprof_user_jfr_key (*asprof_create_user_jfr_key_t)(const char *name);
+
+
+#define ASPROF_MAX_USER_JFR_LENGTH 8191
+
+// This API is UNSTABLE and might change or be removed in the next version of async-profiler.
+//
+// Emits user-defined JFR data. The key should be created via `asprof_create_user_jfr_key`.
+// The data can be arbitrary binary data, with size <= ASPROF_MAX_USER_JFR_LENGTH.
+//
+// returns 0 on success, -1 on failure
+DLLEXPORT int asprof_emit_user_jfr(asprof_user_jfr_key key, const uint8_t *data, size_t len);
+typedef int (*asprof_emit_user_jfr_t)(asprof_user_jfr_key key, const uint8_t *data, size_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/asprof.h
+++ b/src/asprof.h
@@ -78,24 +78,24 @@ DLLEXPORT asprof_jfr_event_key asprof_register_jfr_event(const char* name);
 typedef asprof_jfr_event_key (*asprof_register_jfr_event_t)(const char* name);
 
 
-#define ASPROF_MAX_USER_JFR_LENGTH 2048
+#define ASPROF_MAX_JFR_EVENT_LENGTH 2048
 
 // This API is UNSTABLE and might change or be removed in the next version of async-profiler.
 //
 // Emits a custom, user-defined JFR event. The key should be created via `asprof_register_jfr_event`.
-// The data can be arbitrary binary data, with size <= ASPROF_MAX_USER_JFR_LENGTH.
+// The data can be arbitrary binary data, with size <= ASPROF_MAX_JFR_EVENT_LENGTH.
 //
 // User-defined events are included in the JFR under a `profiler.UserEvent` event type. That type will contain
 // (at least) the following fields:
 // 1. `startTime` [Long] - the emitted event's time in ticks.
 // 2. `eventThread` [java.lang.Thread] - the thread that emitted the events.
-// 3. `type` [profiler.types.UserEventType] - the event's type.
-//    A `profiler.types.UserEventType` contains a single `name` field of type String.
+// 3. `type` [profiler.types.UserEventType] - the event's type,
+//    where `profiler.types.UserEventType` is an indexed string from the JFR constant pool.
 // 4. `data` [String] - the event data. This is the Latin-1 encoded version of the inputted data.
 //    The Latin-1 encoding is used as a way to stuff the arbitrary byte input into something
 //    that JFR supports (JFR technically supports byte arrays, but `jfr print` doesn't).
 //
-// returns an error code or NULL on success.
+// Returns an error code or NULL on success.
 DLLEXPORT asprof_error_t asprof_emit_jfr_event(asprof_jfr_event_key type, const uint8_t* data, size_t len);
 typedef asprof_error_t (*asprof_emit_jfr_event_t)(asprof_jfr_event_key type, const uint8_t* data, size_t len);
 

--- a/src/asprof.h
+++ b/src/asprof.h
@@ -64,25 +64,25 @@ DLLEXPORT asprof_thread_local_data* asprof_get_thread_local_data(void);
 typedef asprof_thread_local_data* (*asprof_get_thread_local_data_t)(void);
 
 
-typedef int asprof_user_jfr_key;
+typedef int asprof_jfr_event_key;
 
 // This API is UNSTABLE and might change or be removed in the next version of async-profiler.
 //
-// Return a asprof_user_jfr_key identifier for a user-defined JFR key.
-// That identifier can then be used in `asprof_emit_user_jfr`
+// Return a asprof_jfr_event_key identifier for a user-defined JFR key.
+// That identifier can then be used in `asprof_emit_jfr_event`
 //
 // The name is required to be valid (since it's a C string, NUL-free) UTF-8.
 //
 // Returns -1 on failure.
-DLLEXPORT asprof_user_jfr_key asprof_create_user_jfr_key(const char* name);
-typedef asprof_user_jfr_key (*asprof_create_user_jfr_key_t)(const char* name);
+DLLEXPORT asprof_jfr_event_key asprof_register_jfr_event(const char* name);
+typedef asprof_jfr_event_key (*asprof_register_jfr_event_t)(const char* name);
 
 
-#define ASPROF_MAX_USER_JFR_LENGTH 8191
+#define ASPROF_MAX_USER_JFR_LENGTH 4000
 
 // This API is UNSTABLE and might change or be removed in the next version of async-profiler.
 //
-// Emits a custom, user-defined JFR event. The key should be created via `asprof_create_user_jfr_key`.
+// Emits a custom, user-defined JFR event. The key should be created via `asprof_register_jfr_event`.
 // The data can be arbitrary binary data, with size <= ASPROF_MAX_USER_JFR_LENGTH.
 //
 // User-defined events are included in the JFR under a `profiler.UserEvent` event type. That type will contain
@@ -95,9 +95,9 @@ typedef asprof_user_jfr_key (*asprof_create_user_jfr_key_t)(const char* name);
 //    The Latin-1 encoding is used as a way to stuff the arbitrary byte input into something
 //    that JFR supports (JFR technically supports byte arrays, but `jfr print` doesn't).
 //
-// returns 0 on success, -1 on failure
-DLLEXPORT int asprof_emit_user_jfr(asprof_user_jfr_key type, const uint8_t* data, size_t len, uint64_t flags);
-typedef int (*asprof_emit_user_jfr_t)(asprof_user_jfr_key type, const uint8_t* data, size_t len, uint64_t flags);
+// returns an error code or NULL on success.
+DLLEXPORT asprof_error_t asprof_emit_jfr_event(asprof_jfr_event_key type, const uint8_t* data, size_t len);
+typedef asprof_error_t (*asprof_emit_jfr_event_t)(asprof_jfr_event_key type, const uint8_t* data, size_t len);
 
 #ifdef __cplusplus
 }

--- a/src/asprof.h
+++ b/src/asprof.h
@@ -69,23 +69,35 @@ typedef int asprof_user_jfr_key;
 // This API is UNSTABLE and might change or be removed in the next version of async-profiler.
 //
 // Return a asprof_user_jfr_key identifier for a user-defined JFR key.
-// That identifier can then be used in `asprof_emit_user_jfr
+// That identifier can then be used in `asprof_emit_user_jfr`
+//
+// The name is required to be valid (since it's a C string, NUL-free) UTF-8.
 //
 // Returns -1 on failure.
-DLLEXPORT asprof_user_jfr_key asprof_create_user_jfr_key(const char *name);
-typedef asprof_user_jfr_key (*asprof_create_user_jfr_key_t)(const char *name);
+DLLEXPORT asprof_user_jfr_key asprof_create_user_jfr_key(const char* name);
+typedef asprof_user_jfr_key (*asprof_create_user_jfr_key_t)(const char* name);
 
 
 #define ASPROF_MAX_USER_JFR_LENGTH 8191
 
 // This API is UNSTABLE and might change or be removed in the next version of async-profiler.
 //
-// Emits user-defined JFR data. The key should be created via `asprof_create_user_jfr_key`.
+// Emits a custom, user-defined JFR event. The key should be created via `asprof_create_user_jfr_key`.
 // The data can be arbitrary binary data, with size <= ASPROF_MAX_USER_JFR_LENGTH.
 //
+// User-defined events are included in the JFR under a `profiler.UserEvent` event type. That type will contain
+// (at least) the following fields:
+// 1. `startTime` [Long] - the emitted event's time in ticks.
+// 2. `eventThread` [java.lang.Thread] - the thread that emitted the events.
+// 3. `type` [profiler.types.UserEventType] - the event's type.
+//    A `profiler.types.UserEventType` contains a single `name` field of type String.
+// 4. `data` [String] - the event data. This is the Latin-1 encoded version of the inputted data.
+//    The Latin-1 encoding is used as a way to stuff the arbitrary byte input into something
+//    that JFR supports (JFR technically supports byte arrays, but `jfr print` doesn't).
+//
 // returns 0 on success, -1 on failure
-DLLEXPORT int asprof_emit_user_jfr(asprof_user_jfr_key key, const uint8_t *data, size_t len);
-typedef int (*asprof_emit_user_jfr_t)(asprof_user_jfr_key key, const uint8_t *data, size_t len);
+DLLEXPORT int asprof_emit_user_jfr(asprof_user_jfr_key type, const uint8_t* data, size_t len, uint64_t flags);
+typedef int (*asprof_emit_user_jfr_t)(asprof_user_jfr_key type, const uint8_t* data, size_t len, uint64_t flags);
 
 #ifdef __cplusplus
 }

--- a/src/event.h
+++ b/src/event.h
@@ -7,6 +7,7 @@
 #define _EVENT_H
 
 #include <stdint.h>
+#include "asprof.h"
 #include "os.h"
 
 
@@ -23,6 +24,7 @@ enum EventType {
     LOCK_SAMPLE,
     PARK_SAMPLE,
     PROFILING_WINDOW,
+    USER_EVENT,
 };
 
 class Event {
@@ -81,6 +83,14 @@ class MallocEvent : public Event {
     u64 _start_time;
     uintptr_t _address;
     u64 _size;
+};
+
+class UserEvent : public Event {
+  public:
+    u64 _start_time;
+    asprof_user_jfr_key _key;
+    const uint8_t *_data;
+    size_t _len;
 };
 
 #endif // _EVENT_H

--- a/src/event.h
+++ b/src/event.h
@@ -88,8 +88,8 @@ class MallocEvent : public Event {
 class UserEvent : public Event {
   public:
     u64 _start_time;
-    asprof_user_jfr_key _key;
-    const uint8_t *_data;
+    asprof_user_jfr_key _type;
+    const uint8_t* _data;
     size_t _len;
 };
 

--- a/src/event.h
+++ b/src/event.h
@@ -88,7 +88,7 @@ class MallocEvent : public Event {
 class UserEvent : public Event {
   public:
     u64 _start_time;
-    asprof_user_jfr_key _type;
+    asprof_jfr_event_key _type;
     const uint8_t* _data;
     size_t _len;
 };

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -392,11 +392,10 @@ class Buffer {
         put(v, len);
     }
 
-    void putByteString(const uint8_t* v, size_t len) {
+    void putByteString(const char* v, u32 len) {
         put8(5); // STRING_ENCODING_LATIN1_BYTE_ARRAY
-        u32 truncated_len = len < MAX_STRING_LENGTH ? len : MAX_STRING_LENGTH;
-        putVar32(truncated_len);
-        put((const char*)v, truncated_len);
+        putVar32(len);
+        put(v, len);
     }
 
     void put8(int offset, char v) {
@@ -1287,7 +1286,7 @@ class Recording {
         buf->putVar64(event->_start_time);
         buf->putVar32(tid);
         buf->putVar32(event->_type);
-        buf->putByteString(event->_data,
+        buf->putByteString((const char*)event->_data,
             event->_len > ASPROF_MAX_USER_JFR_LENGTH ? ASPROF_MAX_USER_JFR_LENGTH : event->_len);
         buf->putVar32(start, buf->offset() - start);
     }

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -1276,9 +1276,9 @@ class Recording {
     void recordUserEvent(Buffer* buf, int tid, UserEvent* event) {
         // estimate of size of non-string fields of this event
         const size_t event_non_string_size_limit = 64;
-        // when calling recordUserEvent, the buffer can be up to RECORDING_BUFFER_LIMIT bytes
-        // full. Check that the buffer is not exceeded.
-        static_assert(RECORDING_BUFFER_LIMIT + event_non_string_size_limit + ASPROF_MAX_USER_JFR_LENGTH
+        // When calling recordUserEvent, the buffer can be up to RECORDING_BUFFER_LIMIT bytes full.
+        // Check that the buffer is not exceeded.
+        static_assert(RECORDING_BUFFER_LIMIT + event_non_string_size_limit + ASPROF_MAX_JFR_EVENT_LENGTH
             <= RECORDING_BUFFER_SIZE, "output must fit within recording buffer");
 
         int start = buf->skip(5);
@@ -1287,7 +1287,7 @@ class Recording {
         buf->putVar32(tid);
         buf->putVar32(event->_type);
         buf->putByteString((const char*)event->_data,
-            event->_len > ASPROF_MAX_USER_JFR_LENGTH ? ASPROF_MAX_USER_JFR_LENGTH : event->_len);
+            event->_len > ASPROF_MAX_JFR_EVENT_LENGTH ? ASPROF_MAX_JFR_EVENT_LENGTH : event->_len);
         buf->putVar32(start, buf->offset() - start);
     }
 

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -26,6 +26,7 @@
 #include "threadFilter.h"
 #include "threadLocalData.h"
 #include "tsc.h"
+#include "userEvents.h"
 #include "vmStructs.h"
 
 
@@ -389,6 +390,13 @@ class Buffer {
         put8(3);
         putVar32(len);
         put(v, len);
+    }
+
+    void putByteString(const uint8_t *v, size_t len) {
+        put8(5); // STRING_ENCODING_LATIN1_BYTE_ARRAY
+        u32 truncated_len = len < MAX_STRING_LENGTH ? len : MAX_STRING_LENGTH;
+        putVar32(truncated_len);
+        put((const char *)v, truncated_len);
     }
 
     void put8(int offset, char v) {
@@ -993,7 +1001,7 @@ class Recording {
         buf->putVar32(0);
         buf->putVar32(1);
 
-        buf->putVar32(10);
+        buf->putVar32(11);
 
         Lookup lookup(&_method_map, Profiler::instance()->classMap());
         writeFrameTypes(buf);
@@ -1006,6 +1014,7 @@ class Recording {
         writePackages(buf, &lookup);
         writeSymbols(buf, &lookup);
         writeLogLevels(buf);
+        writeUserEventTypes(buf);
     }
 
     void writePoolHeader(Buffer* buf, JfrType type, u32 size) {
@@ -1193,6 +1202,18 @@ class Recording {
         }
     }
 
+    void writeUserEventTypes(Buffer* buf) {
+        std::map<u32, const char*> events;
+        UserEvents::collect(events);
+
+        writePoolHeader(buf, T_USER_EVENT_TYPE, events.size());
+        for (std::map<u32, const char*>::const_iterator it = events.begin(); it != events.end(); ++it) {
+            flushIfNeeded(buf, RECORDING_BUFFER_LIMIT - MAX_STRING_LENGTH);
+            buf->putVar64(it->first);
+            buf->putUtf8(it->second);
+        }
+    }
+
     void recordExecutionSample(Buffer* buf, int tid, u32 call_trace_id, ExecutionEvent* event) {
         int start = buf->skip(1);
         buf->put8(T_EXECUTION_SAMPLE);
@@ -1248,6 +1269,16 @@ class Recording {
             buf->putVar64(event->_size);
         }
         buf->put8(start, buf->offset() - start);
+    }
+
+    void recordUserEvent(Buffer* buf, int tid, UserEvent *event) {
+        int start = buf->skip(5);
+        buf->put8(T_USER_EVENT);
+        buf->putVar64(event->_start_time);
+        buf->putVar32(tid);
+        buf->putVar64(event->_key);
+        buf->putByteString(event->_data, event->_len);
+        buf->putVar32(start, buf->offset() - start);
     }
 
     void recordLiveObject(Buffer* buf, int tid, u32 call_trace_id, LiveObject* event) {
@@ -1527,6 +1558,9 @@ void FlightRecorder::recordEvent(int lock_index, int tid, u32 call_trace_id,
                 break;
             case PROFILING_WINDOW:
                 _rec->recordWindow(buf, tid, (ProfilingWindow*)event);
+                break;
+            case USER_EVENT:
+                _rec->recordUserEvent(buf, tid, (UserEvent*)event);
                 break;
         }
         _rec->flushIfNeeded(buf);

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -1191,7 +1191,7 @@ class Recording {
         writePoolHeader(buf, T_SYMBOL, symbols.size());
         for (std::map<u32, const char*>::const_iterator it = symbols.begin(); it != symbols.end(); ++it) {
             flushIfNeeded(buf, RECORDING_BUFFER_LIMIT - MAX_STRING_LENGTH);
-            buf->putVar32(it->first | _base_id);
+            buf->putVar64(it->first | _base_id);
             buf->putUtf8(it->second);
         }
     }
@@ -1212,7 +1212,7 @@ class Recording {
         writePoolHeader(buf, T_USER_EVENT_TYPE, events.size());
         for (std::map<u32, const char*>::const_iterator it = events.begin(); it != events.end(); ++it) {
             flushIfNeeded(buf, RECORDING_BUFFER_LIMIT - MAX_STRING_LENGTH);
-            buf->putVar64(it->first);
+            buf->putVar32(it->first);
             buf->putUtf8(it->second);
         }
     }

--- a/src/jfrMetadata.cpp
+++ b/src/jfrMetadata.cpp
@@ -85,7 +85,6 @@ JfrMetadata::JfrMetadata() : Element("root") {
                 << field("name", T_STRING, "Name"))
 
             << (type("profiler.types.UserEventType", T_USER_EVENT_TYPE, "User-Defined Event Type", true)
-                << category("Profiler")
                 << field("name", T_STRING, "Name"))
 
             << (type("jdk.ExecutionSample", T_EXECUTION_SAMPLE, "Method Profiling Sample")
@@ -253,7 +252,7 @@ JfrMetadata::JfrMetadata() : Element("root") {
                 << field("startTime", T_LONG, "Start Time", F_TIME_TICKS)
                 << field("eventThread", T_THREAD, "Event Thread", F_CPOOL)
                 << field("type", T_USER_EVENT_TYPE, "User Event Type", F_CPOOL)
-                // Using T_STRING with a Latin-1 string to encode raw bytes as user data.q
+                // Using T_STRING with a Latin-1 string to encode raw bytes as user data.
                 // This is not type-correct, but `jfr print` has a NullPointerException
                 // when encountering a T_BYTE/F_ARRAY.
                 << field("data", T_STRING, "User Data"))

--- a/src/jfrMetadata.cpp
+++ b/src/jfrMetadata.cpp
@@ -84,6 +84,10 @@ JfrMetadata::JfrMetadata() : Element("root") {
             << (type("profiler.types.LogLevel", T_LOG_LEVEL, "Log Level", true)
                 << field("name", T_STRING, "Name"))
 
+            << (type("profiler.types.UserEventType", T_USER_EVENT_TYPE, "User-Defined Event Type", true)
+                << category("Profiler")
+                << field("name", T_STRING, "Name"))
+
             << (type("jdk.ExecutionSample", T_EXECUTION_SAMPLE, "Method Profiling Sample")
                 << category("Java Virtual Machine", "Profiling")
                 << field("startTime", T_LONG, "Start Time", F_TIME_TICKS)
@@ -244,13 +248,10 @@ JfrMetadata::JfrMetadata() : Element("root") {
                 << field("stackTrace", T_STACK_TRACE, "Stack Trace", F_CPOOL)
                 << field("address", T_LONG, "Address", F_ADDRESS))
 
-            << (type("profiler.UserEventType", T_USER_EVENT_TYPE, "User Event Type", true)
-                << field("string", T_STRING, "String"))
-
-            << (type("profiler.UserEvent", T_USER_EVENT, "User Event")
-                << category("Java Virtual Machine", "Profiling")
+            << (type("profiler.UserEvent", T_USER_EVENT, "User-Defined Event")
+                << category("Profiler")
                 << field("startTime", T_LONG, "Start Time", F_TIME_TICKS)
-                << field("sampledThread", T_THREAD, "Thread", F_CPOOL)
+                << field("eventThread", T_THREAD, "Event Thread", F_CPOOL)
                 << field("type", T_USER_EVENT_TYPE, "User Event Type", F_CPOOL)
                 // Using T_STRING with a Latin-1 string to encode raw bytes as user data.q
                 // This is not type-correct, but `jfr print` has a NullPointerException

--- a/src/jfrMetadata.cpp
+++ b/src/jfrMetadata.cpp
@@ -244,6 +244,19 @@ JfrMetadata::JfrMetadata() : Element("root") {
                 << field("stackTrace", T_STACK_TRACE, "Stack Trace", F_CPOOL)
                 << field("address", T_LONG, "Address", F_ADDRESS))
 
+            << (type("profiler.UserEventType", T_USER_EVENT_TYPE, "User Event Type", true)
+                << field("string", T_STRING, "String"))
+
+            << (type("profiler.UserEvent", T_USER_EVENT, "User Event")
+                << category("Java Virtual Machine", "Profiling")
+                << field("startTime", T_LONG, "Start Time", F_TIME_TICKS)
+                << field("sampledThread", T_THREAD, "Thread", F_CPOOL)
+                << field("type", T_USER_EVENT_TYPE, "User Event Type", F_CPOOL)
+                // Using T_STRING with a Latin-1 string to encode raw bytes as user data.q
+                // This is not type-correct, but `jfr print` has a NullPointerException
+                // when encountering a T_BYTE/F_ARRAY.
+                << field("data", T_STRING, "User Data"))
+
             << (type("jdk.jfr.Label", T_LABEL, NULL)
                 << field("value", T_STRING))
 

--- a/src/jfrMetadata.h
+++ b/src/jfrMetadata.h
@@ -40,7 +40,9 @@ enum JfrType {
     T_SYMBOL = 31,
     T_GC_WHEN = 32,
     T_LOG_LEVEL = 33,
+    T_USER_EVENT_TYPE = 34,
 
+    // types between T_EVENT and T_ANNOTATION inherit from jdk.jfr.Event, see JfrMetadata::type
     T_EVENT = 100,
     T_EXECUTION_SAMPLE = 101,
     T_ALLOC_IN_NEW_TLAB = 102,
@@ -62,9 +64,9 @@ enum JfrType {
     T_WALL_CLOCK_SAMPLE = 118,
     T_MALLOC = 119,
     T_FREE = 120,
-    T_USER_EVENT_TYPE = 121,
-    T_USER_EVENT = 122,
+    T_USER_EVENT = 121,
 
+    // types after T_ANNOTATION inherit from java.lang.annotation.Annotation, see JfrMetadata::type
     T_ANNOTATION = 200,
     T_LABEL = 201,
     T_CATEGORY = 202,

--- a/src/jfrMetadata.h
+++ b/src/jfrMetadata.h
@@ -62,6 +62,8 @@ enum JfrType {
     T_WALL_CLOCK_SAMPLE = 118,
     T_MALLOC = 119,
     T_FREE = 120,
+    T_USER_EVENT_TYPE = 121,
+    T_USER_EVENT = 122,
 
     T_ANNOTATION = 200,
     T_LABEL = 201,

--- a/src/userEvents.cpp
+++ b/src/userEvents.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "userEvents.h"
+
+Dictionary UserEvents::_dict;
+Mutex UserEvents::_state_lock;
+
+int UserEvents::registerEvent(const char *event) {
+    MutexLocker locker(_state_lock);
+    return _dict.lookup(event);
+}
+
+void UserEvents::collect(std::map<unsigned int, const char*>& map) {
+    MutexLocker locker(_state_lock);
+    _dict.collect(map);
+}

--- a/src/userEvents.cpp
+++ b/src/userEvents.cpp
@@ -7,7 +7,7 @@
 
 Dictionary UserEvents::_dict;
 
-// no (extra) lock is needed here since Dictionary is thread-safe.
+// No (extra) lock is needed here since Dictionary is thread-safe.
 
 int UserEvents::registerEvent(const char* event) {
     return _dict.lookup(event);

--- a/src/userEvents.cpp
+++ b/src/userEvents.cpp
@@ -6,14 +6,13 @@
 #include "userEvents.h"
 
 Dictionary UserEvents::_dict;
-Mutex UserEvents::_state_lock;
 
-int UserEvents::registerEvent(const char *event) {
-    MutexLocker locker(_state_lock);
+// no (extra) lock is needed here since Dictionary is thread-safe.
+
+int UserEvents::registerEvent(const char* event) {
     return _dict.lookup(event);
 }
 
 void UserEvents::collect(std::map<unsigned int, const char*>& map) {
-    MutexLocker locker(_state_lock);
     _dict.collect(map);
 }

--- a/src/userEvents.h
+++ b/src/userEvents.h
@@ -3,19 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef _USEREVENT_H
-#define _USEREVENT_H
+#ifndef _USEREVENTS_H
+#define _USEREVENTS_H
 
 #include <map>
-#include <stddef.h>
 #include "dictionary.h"
 
 class UserEvents {
+  private:
+    static Dictionary _dict;
+
   public:
     static int registerEvent(const char* event);
     static void collect(std::map<unsigned int, const char*>& map);
-  private:
-    static Dictionary _dict;
 };
 
-#endif
+#endif // _USEREVENTS_H

--- a/src/userEvents.h
+++ b/src/userEvents.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _USEREVENT_H
+#define _USEREVENT_H
+ 
+#include <map>
+#include <stddef.h>
+#include "mutex.h"
+#include "dictionary.h"
+
+class UserEvents {
+  public:
+    static int registerEvent(const char *event);
+    static void collect(std::map<unsigned int, const char*>& map);
+  private:
+    static Mutex _state_lock;
+    static Dictionary _dict;
+};
+
+#endif

--- a/src/userEvents.h
+++ b/src/userEvents.h
@@ -5,18 +5,16 @@
 
 #ifndef _USEREVENT_H
 #define _USEREVENT_H
- 
+
 #include <map>
 #include <stddef.h>
-#include "mutex.h"
 #include "dictionary.h"
 
 class UserEvents {
   public:
-    static int registerEvent(const char *event);
+    static int registerEvent(const char* event);
     static void collect(std::map<unsigned int, const char*>& map);
   private:
-    static Mutex _state_lock;
     static Dictionary _dict;
 };
 


### PR DESCRIPTION
This adds an (unstable) `profiler.UserEvent` JFR event, that can be emitted by user native code and contain custom data.

Using T_STRING for the data instead of T_BYTE/F_ARRAY due to a bug in `jfr print`:

```
java.lang.NullPointerException
        at jdk.jfr/jdk.jfr.internal.tool.PrettyWriter.printValue(PrettyWriter.java:357)
        at jdk.jfr/jdk.jfr.internal.tool.PrettyWriter.printArray(PrettyWriter.java:281)
        at jdk.jfr/jdk.jfr.internal.tool.PrettyWriter.printValue(PrettyWriter.java:325)
        at jdk.jfr/jdk.jfr.internal.tool.PrettyWriter.printFieldValue(PrettyWriter.java:273)
        at jdk.jfr/jdk.jfr.internal.tool.PrettyWriter.print(PrettyWriter.java:213)
        at jdk.jfr/jdk.jfr.internal.tool.PrettyWriter.print(PrettyWriter.java:76)
        at jdk.jfr/jdk.jfr.internal.tool.EventPrintWriter.print(EventPrintWriter.java:79)
        at jdk.jfr/jdk.jfr.internal.tool.Print.execute(Print.java:165)
        at jdk.jfr/jdk.jfr.internal.tool.Main.main(Main.java:84)
```
The relevant code is at
https://github.com/openjdk/jdk/blob/965e330cb4a972fd96ff04e149029d1ee0561940/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java#L357

`printArray` calls `printValue` with a `null` `field`, and `printValue` only supports a `null` `field` with a value of type `Byte`.

### Description


### Related issues


### Motivation and context


### How has this been tested?


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
