### PR TITLE
Replace flamegraph with html in ConverterUsage.md

### DIFF
--- a/docs/ConverterUsage.md
+++ b/docs/ConverterUsage.md
@@ -29,9 +29,9 @@ Conversion options:
                list of frames followed by a counter. This is used by the FlameGraph script to
                generate the FlameGraph visualization of the profile data.
 
-  # flamegraph: FlameGraph is a hierarchical representation of call traces of the profiled
-                software in a color coded format that helps to identify a particular resource
-                usage like CPU and memory for the application.
+  # html: FlameGraph is a hierarchical representation of call traces of the profiled
+          software in a color coded format that helps to identify a particular resource
+          usage like CPU and memory for the application.
 
   # pprof: pprof is a profiling visualization and analysis tool from Google. More details on
            pprof  on the official github page https://github.com/google/pprof.
@@ -108,7 +108,7 @@ during a conversion.
 jfrconv --cpu foo.jfr
 
 # which is equivalent to:
-# jfrconv --cpu -o flamegraph foo.jfr foo.html
+# jfrconv --cpu -o html foo.jfr foo.html
 ```
 
 for HTML output as HTML is the default format for conversion from JFR.


### PR DESCRIPTION
This adheres to the current naming of the output option

### Description
Tiny documentation fix to make the documentation valid, as `-o flamegraph` has been changed to `-o html` when the new binary converter has been added.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
