### PR TITLE
Fix musl-specific problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 CFLAGS_EXTRA ?=
 CXXFLAGS_EXTRA ?=
 CFLAGS=-O3 -fno-exceptions $(CFLAGS_EXTRA)
-CXXFLAGS=-O3 -fno-exceptions -fno-omit-frame-pointer -fno-optimize-sibling-calls -fvisibility=hidden -std=c++11 $(CXXFLAGS_EXTRA)
+CXXFLAGS=-O3 -fno-exceptions -fno-omit-frame-pointer -fvisibility=hidden -std=c++11 $(CXXFLAGS_EXTRA)
 CPPFLAGS=
 DEFS=-DPROFILER_VERSION=\"$(PROFILER_VERSION)\"
 INCLUDES=-I$(JAVA_HOME)/include -Isrc/helper

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 CFLAGS_EXTRA ?=
 CXXFLAGS_EXTRA ?=
 CFLAGS=-O3 -fno-exceptions $(CFLAGS_EXTRA)
-CXXFLAGS=-O3 -fno-exceptions -fno-omit-frame-pointer -fvisibility=hidden -std=c++11 $(CXXFLAGS_EXTRA)
+CXXFLAGS=-O3 -fno-exceptions -fno-omit-frame-pointer -fno-optimize-sibling-calls -fvisibility=hidden -std=c++11 $(CXXFLAGS_EXTRA)
 CPPFLAGS=
 DEFS=-DPROFILER_VERSION=\"$(PROFILER_VERSION)\"
 INCLUDES=-I$(JAVA_HOME)/include -Isrc/helper

--- a/src/mallocTracer.cpp
+++ b/src/mallocTracer.cpp
@@ -62,6 +62,7 @@ extern "C" void* calloc_hook(size_t num, size_t size) {
     return ret;
 }
 
+// Make sure this is not optimized away (function-scoped -fno-optimize-sibling-calls)
 extern "C" __attribute__((optimize("O1")))
 void* calloc_hook_dummy(size_t num, size_t size) {
     return _orig_calloc(num, size);
@@ -95,6 +96,7 @@ extern "C" int posix_memalign_hook(void** memptr, size_t alignment, size_t size)
     return ret;
 }
 
+// Make sure this is not optimized away (function-scoped -fno-optimize-sibling-calls)
 extern "C" __attribute__((optimize("O1")))
 int posix_memalign_hook_dummy(void** memptr, size_t alignment, size_t size) {
     return _orig_posix_memalign(memptr, alignment, size);

--- a/src/mallocTracer.cpp
+++ b/src/mallocTracer.cpp
@@ -62,7 +62,8 @@ extern "C" void* calloc_hook(size_t num, size_t size) {
     return ret;
 }
 
-extern "C" void* calloc_hook_dummy(size_t num, size_t size) {
+extern "C" __attribute__((optimize("O1")))
+void* calloc_hook_dummy(size_t num, size_t size) {
     return _orig_calloc(num, size);
 }
 
@@ -94,7 +95,8 @@ extern "C" int posix_memalign_hook(void** memptr, size_t alignment, size_t size)
     return ret;
 }
 
-extern "C" int posix_memalign_hook_dummy(void** memptr, size_t alignment, size_t size) {
+extern "C" __attribute__((optimize("O1")))
+int posix_memalign_hook_dummy(void** memptr, size_t alignment, size_t size) {
     return _orig_posix_memalign(memptr, alignment, size);
 }
 

--- a/src/mallocTracer.cpp
+++ b/src/mallocTracer.cpp
@@ -62,6 +62,10 @@ extern "C" void* calloc_hook(size_t num, size_t size) {
     return ret;
 }
 
+extern "C" void* calloc_hook_dummy(size_t num, size_t size) {
+    return _orig_calloc(num, size);
+}
+
 extern "C" void* realloc_hook(void* addr, size_t size) {
     void* ret = _orig_realloc(addr, size);
     if (MallocTracer::running() && ret) {
@@ -88,6 +92,10 @@ extern "C" int posix_memalign_hook(void** memptr, size_t alignment, size_t size)
         MallocTracer::recordMalloc(*memptr, size);
     }
     return ret;
+}
+
+extern "C" int posix_memalign_hook_dummy(void** memptr, size_t alignment, size_t size) {
+    return _orig_posix_memalign(memptr, alignment, size);
 }
 
 extern "C" void* aligned_alloc_hook(size_t alignment, size_t size) {
@@ -141,9 +149,13 @@ void MallocTracer::patchLibraries() {
         cc->patchImport(im_free, (void*)free_hook);
         cc->patchImport(im_aligned_alloc, (void*)aligned_alloc_hook);
 
-        if (!OS::isMusl()) {
+        if (OS::isMusl()) {
             // On musl, calloc() calls malloc() internally, and posix_memalign() calls aligned_alloc().
-            // Skip the following hooks to prevent double-accounting.
+            // Use dummy hooks to prevent double-accounting. Dummy frames from AP are introduced
+            // to preserve the frame link to the original caller (see #1226).
+            cc->patchImport(im_calloc, (void*)calloc_hook_dummy);
+            cc->patchImport(im_posix_memalign, (void*)posix_memalign_hook_dummy);
+        } else {
             cc->patchImport(im_calloc, (void*)calloc_hook);
             cc->patchImport(im_posix_memalign, (void*)posix_memalign_hook);
         }

--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -811,7 +811,7 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
                 // returns NULL for them. musl does not support library unloading, thus we can
                 // safely ignore dlerror().
                 if (dlerror_output != NULL) {
-                    Log::info(buffer, "dlerror '%s': '%s'", lib.file, dlerror_output);
+                    Log::info("dlerror '%s': '%s'", lib.file, dlerror_output);
                     continue;
                 }
             }

--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -805,12 +805,12 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
             // Protect library from unloading while parsing in-memory ELF program headers.
             // Also, dlopen() ensures the library is fully loaded.
             void* handle = dlopen(lib.file, RTLD_LAZY | RTLD_NOLOAD);
-            if (handle == NULL) {
+            if (handle == NULL && !OS::isMusl()) {
                 char *dlerror_output = dlerror();
                 // Main executable and ld-linux interpreter cannot be dlopen'ed, but dlerror()
                 // returns NULL for them. musl does not support library unloading, thus we can
                 // safely ignore dlerror().
-                if (dlerror_output != NULL && !OS::isMusl()) {
+                if (dlerror_output != NULL) {
                     Log::info(buffer, "dlerror '%s': '%s'", lib.file, dlerror_output);
                     continue;
                 }

--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -808,15 +808,11 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
             if (handle == NULL) {
                 char *dlerror_output = dlerror();
                 // Main executable and ld-linux interpreter cannot be dlopen'ed, but dlerror()
-                // returns NULL for them.
-                if (dlerror_output != NULL) {
-                    char buffer[1024];
-                    // https://git.musl-libc.org/cgit/musl/tree/ldso/dynlink.c?h=v1.2.5#n2167
-                    sprintf(buffer, "Library %s is not already loaded", lib.file);
-                    if (strcmp(dlerror_output, buffer) != 0) {
-                        Log::info(buffer, "dlerror '%s': '%s'", lib.file, dlerror_output);
-                        continue;
-                    }
+                // returns NULL for them. musl does not support library unloading, thus we can
+                // safely ignore dlerror().
+                if (dlerror_output != NULL && !OS::isMusl()) {
+                    Log::info(buffer, "dlerror '%s': '%s'", lib.file, dlerror_output);
+                    continue;
                 }
             }
 

--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -814,8 +814,7 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
                     // https://git.musl-libc.org/cgit/musl/tree/ldso/dynlink.c?h=v1.2.5#n2167
                     sprintf(buffer, "Library %s is not already loaded", lib.file);
                     if (strcmp(dlerror_output, buffer) != 0) {
-                        sprintf(buffer, "dlerror '%s': '%s'", lib.file, dlerror_output);
-                        Log::info(buffer);
+                        Log::info(buffer, "dlerror '%s': '%s'", lib.file, dlerror_output);
                         continue;
                     }
                 }


### PR DESCRIPTION
### Description
Fixing several issues which I encountered while working on #1226:
- https://github.com/async-profiler/async-profiler/pull/1226#issuecomment-2797294532
- `malloc` is not properly hooked sometimes, thus native memory profiling does not work properly. The problem is not malloc-specific, other similar functions are affected as well

### Related issues
#1136 

### Motivation and context
We want to fully support Alpine and other musl-based environment.

### How has this been tested?
`docker run --privileged -it --rm -v $(pwd):/async-profiler amazoncorretto:11-alpine-jdk sh -c 'apk add --no-cache musl-dev util-linux make gcc g++ linux-headers && cd /async-profiler && rm -rf build && make -j test'`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
