### PR TITLE
Add support for truncated stacktraces

### DIFF
--- a/src/callTraceStorage.cpp
+++ b/src/callTraceStorage.cpp
@@ -79,7 +79,7 @@ class LongHashTable {
     }
 };
 
-CallTrace CallTraceStorage::_overflow_trace = {1, {BCI_ERROR, LP64_ONLY(0 COMMA) (jmethodID)"storage_overflow"}};
+CallTrace CallTraceStorage::_overflow_trace = {false, 1, {BCI_ERROR, LP64_ONLY(0 COMMA) (jmethodID)"storage_overflow"}};
 
 CallTraceStorage::CallTraceStorage() : _allocator(CALL_TRACE_CHUNK) {
     _current_table = LongHashTable::allocate(NULL, INITIAL_CAPACITY);
@@ -167,12 +167,12 @@ void CallTraceStorage::collectSamples(std::map<u64, CallTraceSample>& map) {
 }
 
 // Adaptation of MurmurHash64A by Austin Appleby
-u64 CallTraceStorage::calcHash(int num_frames, ASGCT_CallFrame* frames) {
+u64 CallTraceStorage::calcHash(int num_frames, ASGCT_CallFrame* frames, bool truncated) {
     const u64 M = 0xc6a4a7935bd1e995ULL;
     const int R = 47;
 
     int len = num_frames * sizeof(ASGCT_CallFrame);
-    u64 h = len * M;
+    u64 h = len * M * (truncated ? 1 : 2);
 
     const u64* data = (const u64*)frames;
     const u64* end = data + len / 8;
@@ -198,7 +198,7 @@ u64 CallTraceStorage::calcHash(int num_frames, ASGCT_CallFrame* frames) {
     return h;
 }
 
-CallTrace* CallTraceStorage::storeCallTrace(int num_frames, ASGCT_CallFrame* frames) {
+CallTrace* CallTraceStorage::storeCallTrace(int num_frames, ASGCT_CallFrame* frames, bool truncated) {
     const size_t header_size = sizeof(CallTrace) - sizeof(ASGCT_CallFrame);
     CallTrace* buf = (CallTrace*)_allocator.alloc(header_size + num_frames * sizeof(ASGCT_CallFrame));
     if (buf != NULL) {
@@ -207,6 +207,7 @@ CallTrace* CallTraceStorage::storeCallTrace(int num_frames, ASGCT_CallFrame* fra
         for (int i = 0; i < num_frames; i++) {
             buf->frames[i] = frames[i];
         }
+        buf->truncated = truncated;
     }
     return buf;
 }
@@ -230,8 +231,8 @@ CallTrace* CallTraceStorage::findCallTrace(LongHashTable* table, u64 hash) {
     return table->values()[slot].trace;
 }
 
-u32 CallTraceStorage::put(int num_frames, ASGCT_CallFrame* frames, u64 counter) {
-    u64 hash = calcHash(num_frames, frames);
+u32 CallTraceStorage::put(int num_frames, ASGCT_CallFrame* frames, bool truncated, u64 counter) {
+    u64 hash = calcHash(num_frames, frames, truncated);
 
     LongHashTable* table = _current_table;
     u64* keys = table->keys();
@@ -256,7 +257,7 @@ u32 CallTraceStorage::put(int num_frames, ASGCT_CallFrame* frames, u64 counter) 
             // Migrate from a previous table to save space
             CallTrace* trace = table->prev() == NULL ? NULL : findCallTrace(table->prev(), hash);
             if (trace == NULL) {
-                trace = storeCallTrace(num_frames, frames);
+                trace = storeCallTrace(num_frames, frames, truncated);
             }
             table->values()[slot].setTrace(trace);
             break;

--- a/src/callTraceStorage.h
+++ b/src/callTraceStorage.h
@@ -16,6 +16,7 @@
 class LongHashTable;
 
 struct CallTrace {
+    bool truncated;
     int num_frames;
     ASGCT_CallFrame frames[1];
 };
@@ -49,8 +50,8 @@ class CallTraceStorage {
     LongHashTable* _current_table;
     u64 _overflow;
 
-    u64 calcHash(int num_frames, ASGCT_CallFrame* frames);
-    CallTrace* storeCallTrace(int num_frames, ASGCT_CallFrame* frames);
+    u64 calcHash(int num_frames, ASGCT_CallFrame* frames, bool truncated);
+    CallTrace* storeCallTrace(int num_frames, ASGCT_CallFrame* frames, bool truncated);
     CallTrace* findCallTrace(LongHashTable* table, u64 hash);
 
   public:
@@ -65,7 +66,7 @@ class CallTraceStorage {
     void collectSamples(std::vector<CallTraceSample*>& samples);
     void collectSamples(std::map<u64, CallTraceSample>& map);
 
-    u32 put(int num_frames, ASGCT_CallFrame* frames, u64 counter);
+    u32 put(int num_frames, ASGCT_CallFrame* frames, bool truncated, u64 counter);
     void add(u32 call_trace_id, u64 samples, u64 counter);
     void resetCounters();
 };

--- a/src/cpuEngine.cpp
+++ b/src/cpuEngine.cpp
@@ -125,8 +125,9 @@ void CpuEngine::signalHandlerJ9(int signo, siginfo_t* siginfo, void* ucontext) {
 
     J9StackTraceNotification notif;
     StackContext java_ctx;
+    bool truncated = false;
     notif.num_frames = _cstack == CSTACK_NO ? 0 : _cstack == CSTACK_DWARF
-        ? StackWalker::walkDwarf(ucontext, notif.addr, MAX_J9_NATIVE_FRAMES, &java_ctx)
-        : StackWalker::walkFP(ucontext, notif.addr, MAX_J9_NATIVE_FRAMES, &java_ctx);
+        ? StackWalker::walkDwarf(ucontext, notif.addr, MAX_J9_NATIVE_FRAMES, &java_ctx, &truncated)
+        : StackWalker::walkFP(ucontext, notif.addr, MAX_J9_NATIVE_FRAMES, &java_ctx, &truncated);
     J9StackTraces::checkpoint(_interval, &notif);
 }

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -1095,7 +1095,7 @@ class Recording {
         for (std::map<u32, CallTrace*>::const_iterator it = traces.begin(); it != traces.end(); ++it) {
             CallTrace* trace = it->second;
             buf->putVar32(it->first);
-            buf->putVar32(0);  // truncated
+            buf->put8(trace->truncated);
             buf->putVar32(trace->num_frames);
             for (int i = 0; i < trace->num_frames; i++) {
                 MethodInfo* mi = lookup->resolveMethod(trace->frames[i]);

--- a/src/perfEvents.h
+++ b/src/perfEvents.h
@@ -43,7 +43,7 @@ class PerfEvents : public CpuEngine {
     const char* title();
     const char* units();
 
-    static int walk(int tid, void* ucontext, const void** callchain, int max_depth, StackContext* java_ctx);
+    static int walk(int tid, void* ucontext, const void** callchain, int max_depth, StackContext* java_ctx, bool* truncated);
     static void resetBuffer(int tid);
 
     static bool supported();
@@ -64,7 +64,7 @@ class PerfEvents : public CpuEngine {
         return Error("PerfEvents are not supported on this platform");
     }
 
-    static int walk(int tid, void* ucontext, const void** callchain, int max_depth, StackContext* java_ctx) {
+    static int walk(int tid, void* ucontext, const void** callchain, int max_depth, StackContext* java_ctx, bool* truncated) {
         return 0;
     }
 

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -114,9 +114,9 @@ class Profiler {
     const char* asgctError(int code);
     u32 getLockIndex(int tid);
     jmethodID getCurrentCompileTask();
-    int getNativeTrace(void* ucontext, ASGCT_CallFrame* frames, EventType event_type, int tid, StackContext* java_ctx);
-    int getJavaTraceAsync(void* ucontext, ASGCT_CallFrame* frames, int max_depth, StackContext* java_ctx);
-    int getJavaTraceJvmti(jvmtiFrameInfo* jvmti_frames, ASGCT_CallFrame* frames, int start_depth, int max_depth);
+    int getNativeTrace(void* ucontext, ASGCT_CallFrame* frames, int max_depth, EventType event_type, int tid, StackContext* java_ctx, bool* truncated);
+    int getJavaTraceAsync(void* ucontext, ASGCT_CallFrame* frames, int max_depth, StackContext* java_ctx, bool* truncated);
+    int getJavaTraceJvmti(jvmtiFrameInfo* jvmti_frames, ASGCT_CallFrame* frames, int start_depth, int max_depth, bool* truncated);
     void fillFrameTypes(ASGCT_CallFrame* frames, int num_frames, NMethod* nmethod);
     void setThreadInfo(int tid, const char* name, jlong java_thread_id);
     void updateThreadName(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread);

--- a/src/stackWalker.h
+++ b/src/stackWalker.h
@@ -34,13 +34,13 @@ enum StackDetail {
 class StackWalker {
   private:
     static int walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
-                      StackDetail detail, const void* pc, uintptr_t sp, uintptr_t fp);
+                      StackDetail detail, const void* pc, uintptr_t sp, uintptr_t fp, bool* truncated);
 
   public:
-    static int walkFP(void* ucontext, const void** callchain, int max_depth, StackContext* java_ctx);
-    static int walkDwarf(void* ucontext, const void** callchain, int max_depth, StackContext* java_ctx);
-    static int walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, StackDetail detail);
-    static int walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, JavaFrameAnchor* anchor);
+    static int walkFP(void* ucontext, const void** callchain, int max_depth, StackContext* java_ctx, bool* truncated);
+    static int walkDwarf(void* ucontext, const void** callchain, int max_depth, StackContext* java_ctx, bool* truncated);
+    static int walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, StackDetail detail, bool* truncated);
+    static int walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, JavaFrameAnchor* anchor, bool* truncated);
 
     static void checkFault();
 };

--- a/test/test/stack/StackTests.java
+++ b/test/test/stack/StackTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package test.stack;
+
+import test.cstack.LongInitializer;
+
+import one.profiler.test.Jvm;
+import one.profiler.test.Os;
+import one.profiler.test.Output;
+import one.profiler.test.Test;
+import one.profiler.test.TestProcess;
+
+public final class StackTests {
+    private static final int TRUNCATING_STACK_DEPTH = 5;
+    private static final int NON_TRUNCATING_STACK_DEPTH = 4096;
+    private static final String PROFILE_COMMAND = "-e cpu -i 10ms -d 1 -a -o traces ";
+
+    @Test(mainClass = LongInitializer.class, jvm = Jvm.HOTSPOT, os = Os.LINUX)
+    public void truncated(TestProcess p) throws Exception {
+        for (String mode : new String[]{"no", "fp", "dwarf", "vm", "vmx"}) {
+            System.out.println("=== Testing cstack mode: " + mode);
+            Output out = p.profile(PROFILE_COMMAND + "-j " + TRUNCATING_STACK_DEPTH +" --cstack " + mode);
+            long nonTruncatedTraces = out.stream("\\[ " + TRUNCATING_STACK_DEPTH + "\\]").filter(l -> !l.endsWith("[truncated]")).count();
+
+            assert nonTruncatedTraces == 0 : "Expected all traces to be truncated, but found: " + nonTruncatedTraces + " non-truncated traces";
+        }
+    }
+
+    @Test(mainClass = LongInitializer.class, jvm = Jvm.HOTSPOT, os = Os.LINUX)
+    public void nonTruncated(TestProcess p) throws Exception {
+        for (String mode : new String[]{"no", "fp", "dwarf", "vm", "vmx"}) {
+            System.out.println("=== Testing cstack mode: " + mode);
+            Output out = p.profile(PROFILE_COMMAND + "-j " + NON_TRUNCATING_STACK_DEPTH +" --cstack " + mode);
+            long truncatedTraces = out.stream("\\[ " + NON_TRUNCATING_STACK_DEPTH + "\\]").filter(l -> l.endsWith("[truncated]")).count();
+
+            assert truncatedTraces == 0 : "Expected no traces to be truncated, but found: " + truncatedTraces + " truncated traces";
+        }
+    }
+}


### PR DESCRIPTION
### Description
This change adds the ability to set the 'truncated' flag of a stacktrace when we bail out of the stackwalking before reaching the root.

### Related issues
Save information about truncated stacktraces #1230 

### Motivation and context
The 'truncated' flag is already present in the `Stacktrace` datatype but we are not using it. 
However, having the information that a particular stacktrace is not completely unwound can be useful to have - to let the user know that the information is not complete or to help efficiently store such truncated stacktraces in a long-term aggregated format.

The 'traces' output has been extended to show `[truncated]` as the root frame if the trace was truncated. For JFR files we are using the already existing flag. Other outputs have not been modified yet - mostly because the 'traces' was necessary for running tests and the rest is more or less optional. I can add the modifications, if it is desired, before finishing this PR.

### How has this been tested?
Added tests to validate the truncation on various modes of stackwalking.

The existing tests are passing fine. 


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
