### PR TITLE
Enable running integration tests against a pre-built artifact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,14 @@ test-java: build-test-java
 	echo "Running tests against $(LIB_PROFILER)"
 	$(JAVA) "-Djava.library.path=$(TEST_LIB_DIR)" $(TEST_FLAGS) -ea -cp "build/test.jar:build/jar/*:build/lib/*" one.profiler.test.Runner $(TESTS)
 
+test-java-from-release:
+	mkdir -p build/jar
+	cp $(JARS_DIRECTORY)/* build/jar
+	$(MAKE) build/$(TEST_JAR)
+	cp -r $(RELEASE_DIRECTORY)/bin build
+	cp -r $(RELEASE_DIRECTORY)/lib build
+	$(JAVA) "-Djava.library.path=$(TEST_LIB_DIR)" $(TEST_FLAGS) -ea -cp "build/test.jar:build/jar/*:build/lib/*" one.profiler.test.Runner $(TESTS)
+
 coverage: override FAT_BINARY=false
 coverage: clean-coverage
 	$(MAKE) test-cpp CXXFLAGS_EXTRA="-fprofile-arcs -ftest-coverage -fPIC -O0 --coverage"


### PR DESCRIPTION
### Description
In this PR I introduce an optional parameter `BINARIES_DIRECTORY` to enable running integration tests against a pre-built AP artifact.

### Related issues
Changes in GHA to simplify build/testing.

### Motivation and context
This is the first step towards testing AP on the binaries released via GHA.

### How has this been tested?
`make release -j && rm -rf build && tar xvf async-profiler-4.0-linux-x64.tar.gz && make test-java BINARIES_DIRECTORY=async-profiler-4.0-linux-x64`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
