### PR TITLE
Skip compiler optimizations for dummy malloc hooks

### DIFF
--- a/src/mallocTracer.cpp
+++ b/src/mallocTracer.cpp
@@ -18,10 +18,10 @@
     addr != NULL ? (sym##_t)addr : sym;  \
 })
 
-#if defined(__clang__)
-#define NO_OPTIMIZE __attribute__((optnone))
-#elif defined(__GNUC__)
-#define NO_OPTIMIZE __attribute__((optimize("O1")))
+#ifdef __clang__
+#  define NO_OPTIMIZE __attribute__((optnone))
+#else
+#  define NO_OPTIMIZE __attribute__((optimize("O1")))
 #endif
 
 typedef void* (*malloc_t)(size_t);
@@ -68,7 +68,7 @@ extern "C" void* calloc_hook(size_t num, size_t size) {
     return ret;
 }
 
-// Make sure this is not optimized away (function-scoped -fno-optimize-sibling-calls).
+// Make sure this is not optimized away (function-scoped -fno-optimize-sibling-calls)
 extern "C" NO_OPTIMIZE
 void* calloc_hook_dummy(size_t num, size_t size) {
     return _orig_calloc(num, size);

--- a/src/mallocTracer.cpp
+++ b/src/mallocTracer.cpp
@@ -62,8 +62,9 @@ extern "C" void* calloc_hook(size_t num, size_t size) {
     return ret;
 }
 
-// Make sure this is not optimized away (function-scoped -fno-optimize-sibling-calls)
-extern "C" __attribute__((optimize("O1")))
+// Make sure this is not optimized away (function-scoped -fno-optimize-sibling-calls).
+// optimize("O0") is supported both by GCC and clang.
+extern "C" __attribute__((optimize("O0")))
 void* calloc_hook_dummy(size_t num, size_t size) {
     return _orig_calloc(num, size);
 }
@@ -97,7 +98,7 @@ extern "C" int posix_memalign_hook(void** memptr, size_t alignment, size_t size)
 }
 
 // Make sure this is not optimized away (function-scoped -fno-optimize-sibling-calls)
-extern "C" __attribute__((optimize("O1")))
+extern "C" __attribute__((optimize("O0")))
 int posix_memalign_hook_dummy(void** memptr, size_t alignment, size_t size) {
     return _orig_posix_memalign(memptr, alignment, size);
 }

--- a/src/mallocTracer.cpp
+++ b/src/mallocTracer.cpp
@@ -18,6 +18,14 @@
     addr != NULL ? (sym##_t)addr : sym;  \
 })
 
+#if defined(__clang__)
+  #define NO_OPTIMIZE __attribute__((optnone))
+#elif defined(__GNUC__)
+  #define NO_OPTIMIZE __attribute__((optimize("O0")))
+#else
+  #define NO_OPTIMIZE
+#endif
+
 typedef void* (*malloc_t)(size_t);
 static malloc_t _orig_malloc = NULL;
 
@@ -63,8 +71,7 @@ extern "C" void* calloc_hook(size_t num, size_t size) {
 }
 
 // Make sure this is not optimized away (function-scoped -fno-optimize-sibling-calls).
-// optimize("O0") is supported both by GCC and clang.
-extern "C" __attribute__((optimize("O0")))
+extern "C" NO_OPTIMIZE
 void* calloc_hook_dummy(size_t num, size_t size) {
     return _orig_calloc(num, size);
 }
@@ -98,7 +105,7 @@ extern "C" int posix_memalign_hook(void** memptr, size_t alignment, size_t size)
 }
 
 // Make sure this is not optimized away (function-scoped -fno-optimize-sibling-calls)
-extern "C" __attribute__((optimize("O0")))
+extern "C" NO_OPTIMIZE
 int posix_memalign_hook_dummy(void** memptr, size_t alignment, size_t size) {
     return _orig_posix_memalign(memptr, alignment, size);
 }

--- a/src/mallocTracer.cpp
+++ b/src/mallocTracer.cpp
@@ -21,7 +21,7 @@
 #if defined(__clang__)
   #define NO_OPTIMIZE __attribute__((optnone))
 #elif defined(__GNUC__)
-  #define NO_OPTIMIZE __attribute__((optimize("O0")))
+  #define NO_OPTIMIZE __attribute__((optimize("O1")))
 #else
   #define NO_OPTIMIZE
 #endif

--- a/src/mallocTracer.cpp
+++ b/src/mallocTracer.cpp
@@ -19,9 +19,9 @@
 })
 
 #if defined(__clang__)
-  #define NO_OPTIMIZE __attribute__((optnone))
+#define NO_OPTIMIZE __attribute__((optnone))
 #elif defined(__GNUC__)
-  #define NO_OPTIMIZE __attribute__((optimize("O1")))
+#define NO_OPTIMIZE __attribute__((optimize("O1")))
 #endif
 
 typedef void* (*malloc_t)(size_t);

--- a/src/mallocTracer.cpp
+++ b/src/mallocTracer.cpp
@@ -22,8 +22,6 @@
   #define NO_OPTIMIZE __attribute__((optnone))
 #elif defined(__GNUC__)
   #define NO_OPTIMIZE __attribute__((optimize("O1")))
-#else
-  #define NO_OPTIMIZE
 #endif
 
 typedef void* (*malloc_t)(size_t);


### PR DESCRIPTION
### Description
In this PR I change the enforced optimizaton level to `O0` for dummy hooks.

### Related issues
#1235 

### Motivation and context
Clang does not support `O1`. https://reviews.llvm.org/D126984

### How has this been tested?

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
