### PR TITLE
Add nativemem test with dlopen after profiler start.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,7 @@ build-test-libs:
 
 ifeq ($(OS_TAG),linux)
 	$(CC) -shared -fPIC -o $(TEST_LIB_DIR)/libreladyn.$(SOEXT) test/native/libs/reladyn.c
+	$(CC) -shared -fPIC -o $(TEST_LIB_DIR)/libcallsmalloc.$(SOEXT) test/native/libs/callsmalloc.c
 	$(CC) -shared -fPIC $(INCLUDES) -Isrc -o $(TEST_LIB_DIR)/libjnimalloc.$(SOEXT) test/native/libs/jnimalloc.c
 
 	$(CC) -c -shared -fPIC -o $(TEST_LIB_DIR)/vaddrdif.o test/native/libs/vaddrdif.c
@@ -214,8 +215,6 @@ ifeq ($(OS_TAG),linux)
 
 	$(AS) -o $(TEST_LIB_DIR)/twiceatzero.o test/native/libs/twiceatzero.s
 	$(LD) -shared -o $(TEST_LIB_DIR)/libtwiceatzero.$(SOEXT) $(TEST_LIB_DIR)/twiceatzero.o --section-start=.seg1=0x4000 -z max-page-size=0x1000
-
-	$(CC) -shared -fPIC -o $(TEST_LIB_DIR)/libcallsmalloc.$(SOEXT) test/native/libs/callsmalloc.c
 endif
 
 build-test-bins:
@@ -223,7 +222,6 @@ build-test-bins:
 	gcc -o $(TEST_BIN_DIR)/malloc_plt_dyn test/test/nativemem/malloc_plt_dyn.c
 	gcc -o $(TEST_BIN_DIR)/native_api -Isrc test/test/c/native_api.c -ldl
 	gcc -o $(TEST_BIN_DIR)/profile_with_dlopen -Isrc test/test/nativemem/profile_with_dlopen.c -ldl
-
 	$(CXX) -o $(TEST_BIN_DIR)/non_java_app $(INCLUDES) $(CPP_TEST_INCLUDES) test/test/nonjava/non_java_app.cpp $(LIBS)
 
 test-cpp: build-test-cpp

--- a/Makefile
+++ b/Makefile
@@ -214,12 +214,16 @@ ifeq ($(OS_TAG),linux)
 
 	$(AS) -o $(TEST_LIB_DIR)/twiceatzero.o test/native/libs/twiceatzero.s
 	$(LD) -shared -o $(TEST_LIB_DIR)/libtwiceatzero.$(SOEXT) $(TEST_LIB_DIR)/twiceatzero.o --section-start=.seg1=0x4000 -z max-page-size=0x1000
+
+	$(CC) -shared -fPIC -o $(TEST_LIB_DIR)/libcallsmalloc.$(SOEXT) test/native/libs/callsmalloc.c
 endif
 
 build-test-bins:
 	@mkdir -p $(TEST_BIN_DIR)
 	gcc -o $(TEST_BIN_DIR)/malloc_plt_dyn test/test/nativemem/malloc_plt_dyn.c
 	gcc -o $(TEST_BIN_DIR)/native_api -Isrc test/test/c/native_api.c -ldl
+	gcc -o $(TEST_BIN_DIR)/profile_with_dlopen -Isrc test/test/nativemem/profile_with_dlopen.c -ldl
+
 	$(CXX) -o $(TEST_BIN_DIR)/non_java_app $(INCLUDES) $(CPP_TEST_INCLUDES) test/test/nonjava/non_java_app.cpp $(LIBS)
 
 test-cpp: build-test-cpp

--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -810,11 +810,10 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
 
             // Protect library from unloading while parsing in-memory ELF program headers.
             // Also, dlopen() ensures the library is fully loaded.
-            // Main executable and ld-linux interpreter cannot be dlopen'ed, but dlerror() "in some cases" returns NULL for them.
+            // Main executable and ld-linux interpreter cannot be dlopen'ed, but dlerror() returns NULL for them on some systems.
             void* handle = dlopen(lib.file, RTLD_LAZY | RTLD_NOLOAD);
 
-            // Main executable will return NULL from handle, we need to parse it anyway.
-            // dlopen is not required in this case as the main exe cannot be unloaded.
+            // Parse main executable regardless of dlopen result, since it cannot be unloaded.
             bool is_main_exe = main_phdr >= lib.image_base && main_phdr < lib.map_end;
             if (handle != NULL || dlerror() == NULL || is_main_exe) {
                 ElfParser::parseProgramHeaders(cc, lib.image_base, lib.map_end, OS::isMusl());

--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -812,13 +812,11 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
             // Also, dlopen() ensures the library is fully loaded.
             // Main executable and ld-linux interpreter cannot be dlopen'ed, but dlerror() "in some cases" returns NULL for them.
             void* handle = dlopen(lib.file, RTLD_LAZY | RTLD_NOLOAD);
-            const char* dlerror_str = dlerror();
 
             // Main executable will return NULL from handle, we need to parse it anyway.
             // dlopen is not required in this case as the main exe cannot be unloaded.
-            bool isMainExe = handle == NULL && main_phdr >= lib.image_base && main_phdr < lib.map_end;
-            bool dlopenSuccess = handle != NULL || dlerror_str == NULL;
-            if (isMainExe || dlopenSuccess) {
+            bool is_main_exe = main_phdr >= lib.image_base && main_phdr < lib.map_end;
+            if (handle != NULL || dlerror() == NULL || is_main_exe) {
                 ElfParser::parseProgramHeaders(cc, lib.image_base, lib.map_end, OS::isMusl());
             }
 

--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -775,6 +775,19 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
     std::unordered_map<u64, SharedLibrary> libs;
     collectSharedLibraries(libs, MAX_NATIVE_LIBS - array->count());
 
+    char* exePath = realpath("/proc/self/exe", NULL);
+    if (exePath == NULL) {
+        char buf[PATH_MAX];
+
+        // realpath() may fail for a path like /proc/[pid]/root/bin/asprof
+        // In this case, resolve the link as is.
+        ssize_t size = readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+        if (size >= 0) {
+            buf[size] = 0;
+            exePath = buf;
+        }
+    }
+
     for (auto& it : libs) {
         u64 inode = it.first;
         _parsed_inodes.insert(inode);
@@ -804,13 +817,20 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
 
             // Protect library from unloading while parsing in-memory ELF program headers.
             // Also, dlopen() ensures the library is fully loaded.
-            // Main executable and ld-linux interpreter cannot be dlopen'ed, but dlerror() returns NULL for them.
+            // Main executable and ld-linux interpreter cannot be dlopen'ed, but dlerror() "in some cases" returns NULL for them.
             void* handle = dlopen(lib.file, RTLD_LAZY | RTLD_NOLOAD);
-            if (handle != NULL || dlerror() == NULL || OS::isMusl()) {
+            const char* dlerror_str = dlerror();
+
+            // Main executable will return NULL from handle, we need to parse it anyway.
+            // dlopen is not required in this case as the main exe cannot be unloaded.
+            bool isMainExe = handle == NULL && exePath != NULL && strcmp(lib.file, exePath) == 0;
+            bool dlopenSuccess = handle != NULL || dlerror_str == NULL || OS::isMusl();
+            if (isMainExe || dlopenSuccess) {
                 ElfParser::parseProgramHeaders(cc, lib.image_base, lib.map_end, OS::isMusl());
-                if (handle != NULL) {
-                    dlclose(handle);
-                }
+            }
+
+            if (handle != NULL) {
+                dlclose(handle);
             }
         }
 
@@ -820,6 +840,8 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
         applyPatch(cc);
         array->add(cc);
     }
+
+    free(exePath);
 
     if (array->count() >= MAX_NATIVE_LIBS && !_libs_limit_reported) {
         Log::warn("Number of parsed libraries reached the limit of %d", MAX_NATIVE_LIBS);

--- a/test/native/libs/callsmalloc.c
+++ b/test/native/libs/callsmalloc.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdlib.h>
+
+__attribute__((visibility("default"))) void* call_malloc(size_t size) {
+    return malloc(size);
+}

--- a/test/native/libs/callsmalloc.c
+++ b/test/native/libs/callsmalloc.c
@@ -5,6 +5,7 @@
 
 #include <stdlib.h>
 
-__attribute__((visibility("default"))) void* call_malloc(size_t size) {
+__attribute__((visibility("default")))
+void* call_malloc(size_t size) {
     return malloc(size);
 }

--- a/test/one/profiler/test/RunnableTest.java
+++ b/test/one/profiler/test/RunnableTest.java
@@ -25,7 +25,9 @@ public class RunnableTest {
     }
 
     public String testName() {
-        return className() + '.' + m.getName();
+        return test.nameSuffix().isEmpty()
+            ? className() + '.' + m.getName()
+            : className() + '.' + m.getName() + ' ' + test.nameSuffix();
     }
 
     public String className() {

--- a/test/one/profiler/test/RunnableTest.java
+++ b/test/one/profiler/test/RunnableTest.java
@@ -27,7 +27,7 @@ public class RunnableTest {
     public String testName() {
         return test.nameSuffix().isEmpty()
             ? className() + '.' + m.getName()
-            : className() + '.' + m.getName() + ' ' + test.nameSuffix();
+            : className() + '.' + m.getName() + '/' + test.nameSuffix();
     }
 
     public String className() {

--- a/test/one/profiler/test/Test.java
+++ b/test/one/profiler/test/Test.java
@@ -46,4 +46,6 @@ public @interface Test {
 
     // Optional inputs to the test method.
     String[] inputs() default {};
+
+    String nameSuffix() default "";
 }

--- a/test/test/nativemem/NativememTests.java
+++ b/test/test/nativemem/NativememTests.java
@@ -181,8 +181,8 @@ public class NativememTests {
 
     @Test(os = Os.LINUX, sh = "%testbin/profile_with_dlopen dlopen_first %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "dlopen_first")
     @Test(os = Os.LINUX, sh = "%testbin/profile_with_dlopen profile_first %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "profile_first")
-    @Test(os = Os.LINUX, sh = "LD_PRELOAD=%lib %testbin/profile_with_dlopen dlopen_first %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "dlopen_first with LD_PRELOAD")
-    @Test(os = Os.LINUX, sh = "LD_PRELOAD=%lib %testbin/profile_with_dlopen profile_first %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "profile_first with LD_PRELOAD")
+    @Test(os = Os.LINUX, sh = "LD_PRELOAD=%lib %testbin/profile_with_dlopen dlopen_first %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "dlopen_first+LD_PRELOAD")
+    @Test(os = Os.LINUX, sh = "LD_PRELOAD=%lib %testbin/profile_with_dlopen profile_first %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "profile_first+LD_PRELOAD")
     public void dlopenCustomLib(TestProcess p) throws Exception {
         Map<Long, Long> sizeCounts = assertNoLeaks(p);
 

--- a/test/test/nativemem/NativememTests.java
+++ b/test/test/nativemem/NativememTests.java
@@ -178,4 +178,14 @@ public class NativememTests {
         Assert.isEqual(sizeCounts.getOrDefault((long) MALLOC_SIZE, 0L), 1);
         Assert.isEqual(sizeCounts.getOrDefault((long) MALLOC_DYN_SIZE, 0L), 1);
     }
+
+    @Test(os = Os.LINUX, sh = "%testbin/profile_with_dlopen dlopen_first %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "dlopen_first")
+    @Test(os = Os.LINUX, sh = "%testbin/profile_with_dlopen profile_first %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "profile_first")
+    @Test(os = Os.LINUX, sh = "LD_PRELOAD=%lib %testbin/profile_with_dlopen dlopen_first %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "dlopen_first with LD_PRELOAD")
+    @Test(os = Os.LINUX, sh = "LD_PRELOAD=%lib %testbin/profile_with_dlopen profile_first %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "profile_first with LD_PRELOAD")
+    public void dlopenCustomLib(TestProcess p) throws Exception {
+        Map<Long, Long> sizeCounts = assertNoLeaks(p);
+
+        Assert.isEqual(sizeCounts.getOrDefault((long) MALLOC_SIZE, 0L), 1);
+    }
 }

--- a/test/test/nativemem/profile_with_dlopen.c
+++ b/test/test/nativemem/profile_with_dlopen.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "asprof.h"
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define ASSERT_NO_DLERROR()  \
+    err = dlerror();         \
+    if (err != NULL) {       \
+        printf("%s\n", err); \
+        exit(1);             \
+    }
+
+#define ASSERT_NO_ASPROF_ERR(err)               \
+    if (err != NULL) {                          \
+        printf("%s\n", _asprof_error_str(err)); \
+        exit(1);                                \
+    }
+
+asprof_error_str_t _asprof_error_str;
+
+typedef void* (*call_malloc_t)(size_t);
+
+void outputCallback(const char* buffer, size_t size) {
+    fwrite(buffer, sizeof(char), size, stdout);
+}
+
+int main(int argc, char** argv) {
+    char* err = NULL;
+    void* lib = NULL;
+
+    // first arg is the filename and required.
+    if (argc < 3) {
+        printf("Usage: %s <dlopen_first | profile_first> <output.jfr>\n", argv[0]);
+        exit(1);
+    }
+
+    int dlopenFirst = strcmp(argv[1], "dlopen_first") == 0 ? 1 : 0;
+    const char* filename = argv[2];
+
+    void* libprof = dlopen("libasyncProfiler.so", RTLD_NOW);
+    ASSERT_NO_DLERROR();
+
+    ((asprof_init_t)dlsym(libprof, "asprof_init"))();
+    ASSERT_NO_DLERROR();
+
+    asprof_execute_t asprof_execute = (asprof_execute_t)dlsym(libprof, "asprof_execute");
+    ASSERT_NO_DLERROR();
+
+    _asprof_error_str = (asprof_error_str_t)dlsym(libprof, "asprof_error_str");
+    ASSERT_NO_DLERROR();
+
+    // Load libcallsmalloc.so before or after starting the profiler, based on args.
+    if (dlopenFirst) {
+        lib = dlopen("libcallsmalloc.so", RTLD_NOW);
+        ASSERT_NO_DLERROR();
+    }
+
+    // Start profiler.
+    char start_cmd[2048] = {0};
+    snprintf(start_cmd, sizeof(start_cmd), "start,nativemem,cstack=dwarf,file=%s", filename);
+
+    asprof_error_t asprof_err = asprof_execute(start_cmd, outputCallback);
+    ASSERT_NO_ASPROF_ERR(asprof_err);
+
+    if (!dlopenFirst) {
+        lib = dlopen("libcallsmalloc.so", RTLD_NOW);
+        ASSERT_NO_DLERROR();
+    }
+
+    call_malloc_t call_malloc = (call_malloc_t)dlsym(lib, "call_malloc");
+    ASSERT_NO_DLERROR();
+
+    free(call_malloc(1999993));
+
+    asprof_err = asprof_execute("stop", NULL);
+    ASSERT_NO_ASPROF_ERR(err);
+}

--- a/test/test/nativemem/profile_with_dlopen.c
+++ b/test/test/nativemem/profile_with_dlopen.c
@@ -38,7 +38,7 @@ int main(int argc, char** argv) {
         exit(1);
     }
 
-    int dlopenFirst = strcmp(argv[1], "dlopen_first") == 0 ? 1 : 0;
+    int dlopen_first = strcmp(argv[1], "dlopen_first") == 0 ? 1 : 0;
     const char* filename = argv[2];
 
     void* libprof = dlopen("libasyncProfiler.so", RTLD_NOW);
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
     ASSERT_NO_DLERROR();
 
     // Load libcallsmalloc.so before or after starting the profiler, based on args.
-    if (dlopenFirst) {
+    if (dlopen_first) {
         lib = dlopen("libcallsmalloc.so", RTLD_NOW);
         ASSERT_NO_DLERROR();
     }
@@ -66,7 +66,7 @@ int main(int argc, char** argv) {
     asprof_error_t asprof_err = asprof_execute(start_cmd, outputCallback);
     ASSERT_NO_ASPROF_ERR(asprof_err);
 
-    if (!dlopenFirst) {
+    if (!dlopen_first) {
         lib = dlopen("libcallsmalloc.so", RTLD_NOW);
         ASSERT_NO_DLERROR();
     }

--- a/test/test/nativemem/profile_with_dlopen.c
+++ b/test/test/nativemem/profile_with_dlopen.c
@@ -9,20 +9,18 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define ASSERT_NO_DLERROR()  \
-    err = dlerror();         \
-    if (err != NULL) {       \
-        printf("%s\n", err); \
-        exit(1);             \
+#define ASSERT_NO_DLERROR()           \
+    err = dlerror();                  \
+    if (err != NULL) {                \
+        fprintf(stderr, "%s\n", err); \
+        exit(1);                      \
     }
 
-#define ASSERT_NO_ASPROF_ERR(err)               \
-    if (err != NULL) {                          \
-        printf("%s\n", _asprof_error_str(err)); \
-        exit(1);                                \
+#define ASSERT_NO_ASPROF_ERR(err)                       \
+    if (err != NULL) {                                  \
+        fprintf(stderr, "%s\n", asprof_error_str(err)); \
+        exit(1);                                        \
     }
-
-asprof_error_str_t _asprof_error_str;
 
 typedef void* (*call_malloc_t)(size_t);
 
@@ -36,7 +34,7 @@ int main(int argc, char** argv) {
 
     // first arg is the filename and required.
     if (argc < 3) {
-        printf("Usage: %s <dlopen_first | profile_first> <output.jfr>\n", argv[0]);
+        fprintf(stderr, "Usage: %s <dlopen_first | profile_first> <output.jfr>\n", argv[0]);
         exit(1);
     }
 
@@ -52,7 +50,7 @@ int main(int argc, char** argv) {
     asprof_execute_t asprof_execute = (asprof_execute_t)dlsym(libprof, "asprof_execute");
     ASSERT_NO_DLERROR();
 
-    _asprof_error_str = (asprof_error_str_t)dlsym(libprof, "asprof_error_str");
+    asprof_error_str_t asprof_error_str = (asprof_error_str_t)dlsym(libprof, "asprof_error_str");
     ASSERT_NO_DLERROR();
 
     // Load libcallsmalloc.so before or after starting the profiler, based on args.


### PR DESCRIPTION
### Description
Parse symbols and hook functions of the main executable, when profiler is *not* loaded via `LD_PRELOAD`.

Without this fix, profiler is unable to hook non-java executables if `dlopen` is called after starting the profiler. 

### Related issues
Issue was introduced in https://github.com/async-profiler/async-profiler/pull/1220 as `dlerror` may *not* return `NULL` for the main executable.

Thanks for the repro in https://github.com/async-profiler/async-profiler/issues/1241 @Baraa-Hasheesh  and for discussions @fandreuz and @Baraa-Hasheesh.

Fixes https://github.com/async-profiler/async-profiler/issues/1233 and https://github.com/async-profiler/async-profiler/issues/1241.

### How has this been tested?
`make test-java TESTS=nativemem`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
