### PR TITLE
Separate jobs for build/unit tests and integration tests

### DIFF
--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -94,14 +94,11 @@ jobs:
             # Using "latest" here as the build and test will any ways run inside a container which we control
             name: ubuntu-latest
         java-version: [11, 17, 21, 24]
-        java-distribution: [corretto]
         image: ["public.ecr.aws/async-profiler/asprof-builder-x86:latest"]
         include:
           - runson:
               display: macos-arm64
               name: macos-15
-            java-version: 11
-            java-distribution: corretto
             # Not using container for mac-os as we have images only for linux
             image: ""
             # ARM MacOS should take fat binaries built on ARM
@@ -109,8 +106,6 @@ jobs:
           - runson:
               display: macos-x64
               name: macos-13
-            java-version: 11
-            java-distribution: corretto
             architecture: x64
             image: ""
             # x64 MacOS should take fat binaries built on ARM
@@ -119,8 +114,6 @@ jobs:
               display: linux-arm64
               # There is no "latest" tag available (yet) as ARM runners are still in public preview
               name: ubuntu-24.04-arm
-            java-version: 11
-            java-distribution: corretto
             image: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"
     runs-on: ${{ matrix.runson.name }}
     container:
@@ -131,8 +124,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          distribution: ${{ matrix.java-distribution }}
-          java-version: ${{ matrix.java-version }}
+          distribution: ${{ matrix.java-distribution || env.java_default_distribution }}
+          java-version: ${{ matrix.java-version || env.java_default_version }}
           architecture: ${{ matrix.architecture }}
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -91,7 +91,8 @@ jobs:
       matrix:
         runson:
           - display: linux-x64
-            name: ubuntu-latest # Using "latest" here as the build and test will any ways run inside a container which we control
+            # Using "latest" here as the build and test will any ways run inside a container which we control
+            name: ubuntu-latest
         java-version: [11, 17, 21, 24]
         java-distribution: [corretto]
         container: ["public.ecr.aws/async-profiler/asprof-builder-x86:latest"]
@@ -101,7 +102,8 @@ jobs:
               name: macos-14
             java-version: 11
             java-distribution: corretto
-            container: ""  # Not using container for mac-os as we have images only for linux
+            # Not using container for mac-os as we have images only for linux
+            container: ""
             # ARM MacOS should take fat binaries built on ARM
             asprof-binaries-job: macos
           - runson:
@@ -115,7 +117,8 @@ jobs:
             asprof-binaries-job: macos
           - runson:
               display: linux-arm64
-              name: ubuntu-24.04-arm # There is no "latest" tag available (yet) as ARM runners are still in public preview
+              # There is no "latest" tag available (yet) as ARM runners are still in public preview
+              name: ubuntu-24.04-arm
             java-version: 11
             java-distribution: corretto
             container: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"
@@ -173,7 +176,8 @@ jobs:
           make test-java -j
       - name: Upload integration test logs
         uses: actions/upload-artifact@v4
-        if: always() # we always want to upload test logs, especially when tests fail
+        # Always upload, especially after test failure
+        if: always()
         with:
           name: integration-test-logs-${{ matrix.runson.display }}-${{ matrix.java-version }}
           path: |

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -69,7 +69,7 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
       - name: Set artifact name
         id: set_artifact_name
-        run: echo "artifact_name=async-profiler-${GITHUB_SHA:0:7}-${{ matrix.runson.display }}" >> $GITHUB_OUTPUT
+        run: echo "artifact_name=async-profiler-${{ matrix.runson.display }}-${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
         shell: bash
         env:
           GITHUB_SHA: ${{ github.sha }}
@@ -131,7 +131,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set artifact name
         id: set_artifact_name
-        run: echo "artifact_name=async-profiler-${GITHUB_SHA:0:7}-${{ matrix.asprof-binaries-job || matrix.runson.display }}" >> $GITHUB_OUTPUT
+        run: echo "artifact_name=async-profiler-${{ matrix.asprof-binaries-job || matrix.runson.display }}-${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
         shell: bash
         env:
           GITHUB_SHA: ${{ github.sha }}

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -36,11 +36,8 @@ jobs:
               name: ubuntu-latest
             container: public.ecr.aws/async-profiler/asprof-builder-x86:latest
           - runson:
-              display: macos-arm64
+              display: macos
               name: macos-14
-          - runson:
-              display: macos-x64
-              name: macos-13
     runs-on: ${{ matrix.runson.name }}
     container:
       image: ${{ matrix.container }}
@@ -105,6 +102,8 @@ jobs:
             java-version: 11
             java-distribution: corretto
             container: ""  # Not using container for mac-os as we have images only for linux
+            # ARM MacOS should take fat binaries built on ARM
+            asprof-binaries-job: macos
           - runson:
               display: macos-x64
               name: macos-13
@@ -112,6 +111,8 @@ jobs:
             java-distribution: corretto
             architecture: x64
             container: ""
+            # x64 MacOS should take fat binaries built on ARM
+            asprof-binaries-job: macos
           - runson:
               display: linux-arm64
               name: ubuntu-24.04-arm # There is no "latest" tag available (yet) as ARM runners are still in public preview
@@ -134,7 +135,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set artifact name
         id: set_artifact_name
-        run: echo "artifact_name=async-profiler-${GITHUB_SHA:0:7}-${{ matrix.runson.display }}" >> $GITHUB_OUTPUT
+        run: echo "artifact_name=async-profiler-${GITHUB_SHA:0:7}-${{ matrix.asprof-binaries-job || matrix.runson.display }}" >> $GITHUB_OUTPUT
         shell: bash
         env:
           GITHUB_SHA: ${{ github.sha }}

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ matrix.runson.name }}
     container:
       image: ${{ matrix.container }}
-    name: "Build (${{ matrix.runson.display }})"
+    name: "Build and unit test (${{ matrix.runson.display }})"
     steps:
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -53,7 +53,7 @@ jobs:
           java-version: ${{ matrix.java-version || env.java_default_version }}
       - name: Checkout sources
         uses: actions/checkout@v4
-      - name: Build and test
+      - name: Build and unit test
         id: build
         run: |
           set -x

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -30,17 +30,17 @@ jobs:
           - runson:
               display: linux-arm64
               name: ubuntu-24.04-arm
-            container: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"
+            image: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"
           - runson:
               display: linux-x64
               name: ubuntu-latest
-            container: public.ecr.aws/async-profiler/asprof-builder-x86:latest
+            image: public.ecr.aws/async-profiler/asprof-builder-x86:latest
           - runson:
               display: macos
               name: macos-14
     runs-on: ${{ matrix.runson.name }}
     container:
-      image: ${{ matrix.container }}
+      image: ${{ matrix.image }}
     name: "Build and unit test (${{ matrix.runson.display }})"
     steps:
       - name: Setup Java
@@ -95,7 +95,7 @@ jobs:
             name: ubuntu-latest
         java-version: [11, 17, 21, 24]
         java-distribution: [corretto]
-        container: ["public.ecr.aws/async-profiler/asprof-builder-x86:latest"]
+        image: ["public.ecr.aws/async-profiler/asprof-builder-x86:latest"]
         include:
           - runson:
               display: macos-arm64
@@ -103,7 +103,7 @@ jobs:
             java-version: 11
             java-distribution: corretto
             # Not using container for mac-os as we have images only for linux
-            container: ""
+            image: ""
             # ARM MacOS should take fat binaries built on ARM
             asprof-binaries-job: macos
           - runson:
@@ -112,7 +112,7 @@ jobs:
             java-version: 11
             java-distribution: corretto
             architecture: x64
-            container: ""
+            image: ""
             # x64 MacOS should take fat binaries built on ARM
             asprof-binaries-job: macos
           - runson:
@@ -121,10 +121,10 @@ jobs:
               name: ubuntu-24.04-arm
             java-version: 11
             java-distribution: corretto
-            container: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"
+            image: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"
     runs-on: ${{ matrix.runson.name }}
     container:
-      image: ${{ matrix.container }}
+      image: ${{ matrix.image }}
       options: --privileged
     name: "Integration test (${{ matrix.runson.display }}, ${{ matrix.java-distribution }} ${{ matrix.java-version }})"
     steps:

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -161,9 +161,9 @@ jobs:
             ;;
           esac
           echo "jars_directory=jar_artifacts" >> $GITHUB_OUTPUT
-          echo "binaries_directory=$(basename $(find . -type d -iname "async-profiler-*" ))" >> $GITHUB_OUTPUT
+          echo "release_directory=$(basename $(find . -type d -iname "async-profiler-*" ))" >> $GITHUB_OUTPUT
       - name: Run integration tests
-        run: make test-java-from-release -j BINARIES_DIRECTORY=${{ steps.extract_artifact.outputs.binaries_directory }} JARS_DIRECTORY=${{ steps.extract_artifact.outputs.jars_directory }}
+        run: make test-java-from-release -j RELEASE_DIRECTORY=${{ steps.extract_artifact.outputs.release_directory }} JARS_DIRECTORY=${{ steps.extract_artifact.outputs.jars_directory }}
       - name: Upload integration test logs
         uses: actions/upload-artifact@v4
         if: always() # we always want to upload test logs, especially when tests fail

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -119,7 +119,7 @@ jobs:
     container:
       image: ${{ matrix.image }}
       options: --privileged
-    name: "Integration test (${{ matrix.runson.display }}, ${{ matrix.java-distribution }} ${{ matrix.java-version }})"
+    name: "Integration test (${{ matrix.runson.display }}, ${{ matrix.java-distribution || env.java_default_distribution }} ${{ matrix.java-version || env.java_default_version }})"
     steps:
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -174,7 +174,7 @@ jobs:
         # Always upload, especially after test failure
         if: always()
         with:
-          name: integration-test-logs-${{ matrix.runson.display }}-${{ matrix.java-version }}-${{ steps.set_variables.outputs.short_sha }}
+          name: integration-test-logs-${{ matrix.runson.display }}-${{ matrix.java-version || env.java_default_version }}-${{ steps.set_variables.outputs.short_sha }}
           path: |
             build/test/logs/
             hs_err*.log

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -4,25 +4,92 @@ on:  # We are very liberal in terms of triggering builds. This should be revisit
   - push
   - pull_request
 
+env:
+  java_default_distribution: corretto
+  java_default_version: 11
+
 jobs:
   build-jars:
     runs-on: ubuntu-latest
+    name: Build JARs
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-      - name: Build jars
+      - name: Build JARs
         run: make jar
-      - name: Upload async-profiler.jar
+      - name: Upload JARs
         uses: actions/upload-artifact@v4
         with:
-          name: async-profiler.jar
-          path: build/jar/async-profiler.jar
-      - name: Upload jfr-converter.jar
+          name: async-profiler-jars
+          path: build/jar/*
+          if-no-files-found: error
+  build-and-upload-binaries:
+    strategy:
+      matrix:
+        include:
+          - runson:
+              display: linux-arm64
+              name: ubuntu-24.04-arm # There is no "latest" tag available (yet) as ARM runners are still in public preview
+            container: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"
+          - runson:
+              display: linux-x64
+              name: ubuntu-latest # Using "latest" here as the build and test will any ways run inside a container which we control
+            container: public.ecr.aws/async-profiler/asprof-builder-x86:latest
+          - runson:
+              display: macos-arm64
+              name: macos-14
+          - runson:
+              display: macos-x64
+              name: macos-13
+    runs-on: ${{ matrix.runson.name }}
+    container:
+      image: ${{ matrix.container }}
+    name: "Build (${{ matrix.runson.display }})"
+    steps:
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: ${{ matrix.java-distribution || env.java_default_distribution }}
+          java-version: ${{ matrix.java-version || env.java_default_version }}
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Build and test
+        id: build
+        run: |
+          set -x
+          case "${{ matrix.runson.name }}" in
+            macos*)
+              brew install gcovr
+              make COMMIT_TAG=${GITHUB_SHA:0:7} FAT_BINARY=true release coverage -j
+            ;;
+            *)
+              make COMMIT_TAG=${GITHUB_SHA:0:7} CC=/usr/local/musl/bin/musl-gcc release coverage -j
+            ;;
+          esac
+          echo "archive=$(basename $(find . -type f -iname "async-profiler-*" ))" >> $GITHUB_OUTPUT
+        shell: bash
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+      - name: Set artifact name
+        id: set_artifact_name
+        run: echo "artifact_name=async-profiler-${GITHUB_SHA:0:7}-${{ matrix.runson.display }}" >> $GITHUB_OUTPUT
+        shell: bash
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+      - name: Upload binaries
         uses: actions/upload-artifact@v4
         with:
-          name: jfr-converter.jar
-          path: build/jar/jfr-converter.jar
-  build-binaries-and-test:
+          name: ${{ steps.set_artifact_name.outputs.artifact_name }}
+          path: ${{ steps.build.outputs.archive }}
+          if-no-files-found: error
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-coverage-${{ matrix.runson.display }}
+          path: build/test/coverage/
+          if-no-files-found: error
+  test:
+    needs: build-and-upload-binaries
     strategy:
       matrix:
         runson:
@@ -55,7 +122,7 @@ jobs:
     container:
       image: ${{ matrix.container }}
       options: --privileged
-    name: "test (${{ matrix.runson.display }}, ${{ matrix.java-distribution }} ${{ matrix.java-version }})"
+    name: "Integration test (${{ matrix.runson.display }}, ${{ matrix.java-distribution }} ${{ matrix.java-version }})"
     steps:
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -65,65 +132,51 @@ jobs:
           architecture: ${{ matrix.architecture }}
       - name: Checkout sources
         uses: actions/checkout@v4
-      - name: Build and test
-        id: build
+      - name: Set artifact name
+        id: set_artifact_name
+        run: echo "artifact_name=async-profiler-${GITHUB_SHA:0:7}-${{ matrix.runson.display }}" >> $GITHUB_OUTPUT
+        shell: bash
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+      - name: Download async-profiler binary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.set_artifact_name.outputs.artifact_name }}
+          path: binary_artifacts
+      - name: Download async-profiler JAR artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: async-profiler-jars
+          path: jar_artifacts
+      - name: Extract async-profiler artifact
+        id: extract_artifact
         run: |
-          HASH=$(echo ${{ github.sha }} | cut -c-7)
+          archive=$(basename $(find binary_artifacts -type f -iname "async-profiler-*" ))
           case "${{ matrix.runson.name }}" in
             macos*)
-              make COMMIT_TAG=$HASH FAT_BINARY=true release test -j
+              unzip binary_artifacts/$archive
             ;;
             *)
-              make COMMIT_TAG=$HASH CC=/usr/local/musl/bin/musl-gcc release test -j
+              tar xvf binary_artifacts/$archive
             ;;
           esac
-          echo "archive=$(basename $(find . -type f -iname "async-profiler-*" ))" >> $GITHUB_OUTPUT
-      - name: Coverage
-        id: coverage
-        run: |
-          HASH=$(echo ${{ github.sha }} | cut -c-7)
-          case "${{ matrix.runson.name }}" in
-            macos*)
-              brew install gcovr
-              make COMMIT_TAG=$HASH FAT_BINARY=true coverage -j
-            ;;
-            *)
-              make COMMIT_TAG=$HASH CC=/usr/local/musl/bin/musl-gcc coverage -j
-            ;;
-          esac
-      - name: Upload test logs
+          echo "jars_directory=jar_artifacts" >> $GITHUB_OUTPUT
+          echo "binaries_directory=$(basename $(find . -type d -iname "async-profiler-*" ))" >> $GITHUB_OUTPUT
+      - name: Run integration tests
+        run: make test-java-from-release -j BINARIES_DIRECTORY=${{ steps.extract_artifact.outputs.binaries_directory }} JARS_DIRECTORY=${{ steps.extract_artifact.outputs.jars_directory }}
+      - name: Upload integration test logs
         uses: actions/upload-artifact@v4
-
         if: always() # we always want to upload test logs, especially when tests fail
         with:
-          name: test-logs-${{ matrix.runson.display }}-${{ matrix.java-version }}
+          name: integration-test-logs-${{ matrix.runson.display }}-${{ matrix.java-version }}
           path: |
             build/test/logs/
             hs_err*.log
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v4
-
-        with:
-          name: test-coverage-${{ matrix.runson.display }}-${{ matrix.java-version }}
-          path: build/test/coverage/
-      - name: Upload async-profiler binaries to workflow
-        uses: actions/upload-artifact@v4
-
-        if: |
-          matrix.java-version == 11 &&
-          (
-            matrix.runson.display == 'linux-x64' ||
-            matrix.runson.display == 'linux-arm64' ||
-            matrix.runson.display == 'macos-arm64'
-          )
-        with:
-          name: ${{ steps.build.outputs.archive }}
-          path: ${{ steps.build.outputs.archive }}
   publish-only-on-push:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     name: publish (nightly)
     runs-on: ubuntu-latest
-    needs: [build-jars, build-binaries-and-test]
+    needs: [build-jars, test]
     steps:
       - name: Download async-profiler binaries and jars
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -163,7 +163,13 @@ jobs:
           echo "jars_directory=jar_artifacts" >> $GITHUB_OUTPUT
           echo "release_directory=$(basename $(find . -type d -iname "async-profiler-*" ))" >> $GITHUB_OUTPUT
       - name: Run integration tests
-        run: make test-java-from-release -j RELEASE_DIRECTORY=${{ steps.extract_artifact.outputs.release_directory }} JARS_DIRECTORY=${{ steps.extract_artifact.outputs.jars_directory }}
+        run: |
+          mkdir -p build/jar
+          cp ${{ steps.extract_artifact.outputs.jars_directory }}/* build/jar
+          make build/test.jar
+          cp -r ${{ steps.extract_artifact.outputs.release_directory }}/bin build
+          cp -r ${{ steps.extract_artifact.outputs.release_directory }}/lib build
+          make test-java -j
       - name: Upload integration test logs
         uses: actions/upload-artifact@v4
         if: always() # we always want to upload test logs, especially when tests fail

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -138,11 +138,11 @@ jobs:
         shell: bash
         env:
           GITHUB_SHA: ${{ github.sha }}
-      - name: Download async-profiler binary artifact
+      - name: Download async-profiler release artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ steps.set_artifact_name.outputs.artifact_name }}
-          path: binary_artifacts
+          path: async_profiler_release
       - name: Download async-profiler JAR artifacts
         uses: actions/download-artifact@v4
         with:
@@ -151,13 +151,13 @@ jobs:
       - name: Extract async-profiler artifact
         id: extract_artifact
         run: |
-          archive=$(basename $(find binary_artifacts -type f -iname "async-profiler-*" ))
+          release_archive=$(basename $(find async_profiler_release -type f -iname "async-profiler-*" ))
           case "${{ matrix.runson.name }}" in
             macos*)
-              unzip binary_artifacts/$archive
+              unzip async_profiler_release/$release_archive
             ;;
             *)
-              tar xvf binary_artifacts/$archive
+              tar xvf async_profiler_release/$release_archive
             ;;
           esac
           echo "jars_directory=jar_artifacts" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -37,7 +37,7 @@ jobs:
             image: public.ecr.aws/async-profiler/asprof-builder-x86:latest
           - runson:
               display: macos
-              name: macos-14
+              name: macos-15
     runs-on: ${{ matrix.runson.name }}
     container:
       image: ${{ matrix.image }}
@@ -99,7 +99,7 @@ jobs:
         include:
           - runson:
               display: macos-arm64
-              name: macos-14
+              name: macos-15
             java-version: 11
             java-distribution: corretto
             # Not using container for mac-os as we have images only for linux

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -88,7 +88,7 @@ jobs:
           name: test-coverage-${{ matrix.runson.display }}
           path: build/test/coverage/
           if-no-files-found: error
-  test:
+  integration-tests:
     needs: build-and-upload-binaries
     strategy:
       matrix:
@@ -176,7 +176,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     name: publish (nightly)
     runs-on: ubuntu-latest
-    needs: [build-jars, test]
+    needs: [build-jars, integration-tests]
     steps:
       - name: Download async-profiler binaries and jars
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -119,7 +119,7 @@ jobs:
     container:
       image: ${{ matrix.image }}
       options: --privileged
-    name: "Integration test (${{ matrix.runson.display }}, ${{ matrix.java-distribution || env.java_default_distribution }} ${{ matrix.java-version || env.java_default_version }})"
+    name: "Integration test (${{ matrix.runson.display }}, ${{ matrix.java-distribution }} ${{ matrix.java-version }})"
     steps:
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -174,7 +174,7 @@ jobs:
         # Always upload, especially after test failure
         if: always()
         with:
-          name: integration-test-logs-${{ matrix.runson.display }}-${{ matrix.java-version || env.java_default_version }}-${{ steps.set_variables.outputs.short_sha }}
+          name: integration-test-logs-${{ matrix.runson.display }}-${{ matrix.java-version }}-${{ steps.set_variables.outputs.short_sha }}
           path: |
             build/test/logs/
             hs_err*.log

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -94,11 +94,14 @@ jobs:
             # Using "latest" here as the build and test will any ways run inside a container which we control
             name: ubuntu-latest
         java-version: [11, 17, 21, 24]
+        java-distribution: [corretto]
         image: ["public.ecr.aws/async-profiler/asprof-builder-x86:latest"]
         include:
           - runson:
               display: macos-arm64
               name: macos-15
+            java-version: 11
+            java-distribution: corretto
             # Not using container for mac-os as we have images only for linux
             image: ""
             # ARM MacOS should take fat binaries built on ARM
@@ -106,6 +109,8 @@ jobs:
           - runson:
               display: macos-x64
               name: macos-13
+            java-version: 11
+            java-distribution: corretto
             architecture: x64
             image: ""
             # x64 MacOS should take fat binaries built on ARM
@@ -114,6 +119,8 @@ jobs:
               display: linux-arm64
               # There is no "latest" tag available (yet) as ARM runners are still in public preview
               name: ubuntu-24.04-arm
+            java-version: 11
+            java-distribution: corretto
             image: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"
     runs-on: ${{ matrix.runson.name }}
     container:
@@ -124,8 +131,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          distribution: ${{ matrix.java-distribution || env.java_default_distribution }}
-          java-version: ${{ matrix.java-version || env.java_default_version }}
+          distribution: ${{ matrix.java-distribution }}
+          java-version: ${{ matrix.java-version }}
           architecture: ${{ matrix.architecture }}
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -29,11 +29,11 @@ jobs:
         include:
           - runson:
               display: linux-arm64
-              name: ubuntu-24.04-arm # There is no "latest" tag available (yet) as ARM runners are still in public preview
+              name: ubuntu-24.04-arm
             container: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"
           - runson:
               display: linux-x64
-              name: ubuntu-latest # Using "latest" here as the build and test will any ways run inside a container which we control
+              name: ubuntu-latest
             container: public.ecr.aws/async-profiler/asprof-builder-x86:latest
           - runson:
               display: macos-arm64

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -1,4 +1,4 @@
-name: Test and Publish Nightly Builds
+name: CI
 
 on:  # We are very liberal in terms of triggering builds. This should be revisited if we start seeing a lot of queueing
   - push

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -129,16 +129,18 @@ jobs:
           architecture: ${{ matrix.architecture }}
       - name: Checkout sources
         uses: actions/checkout@v4
-      - name: Set artifact name
-        id: set_artifact_name
-        run: echo "artifact_name=async-profiler-${{ matrix.asprof-binaries-job || matrix.runson.display }}-${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
+      - name: Set variables
+        id: set_variables
+        run: |
+          echo "short_sha=${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
+          echo "artifact_name=async-profiler-${{ matrix.asprof-binaries-job || matrix.runson.display }}-${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
         shell: bash
         env:
           GITHUB_SHA: ${{ github.sha }}
       - name: Download async-profiler release artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ steps.set_artifact_name.outputs.artifact_name }}
+          name: ${{ steps.set_variables.outputs.artifact_name }}
           path: async_profiler_release
       - name: Download async-profiler JAR artifacts
         uses: actions/download-artifact@v4
@@ -172,7 +174,7 @@ jobs:
         # Always upload, especially after test failure
         if: always()
         with:
-          name: integration-test-logs-${{ matrix.runson.display }}-${{ matrix.java-version }}
+          name: integration-test-logs-${{ matrix.runson.display }}-${{ matrix.java-version }}-${{ steps.set_variables.outputs.short_sha }}
           path: |
             build/test/logs/
             hs_err*.log

--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ test-java: build-test-java
 	echo "Running tests against $(LIB_PROFILER)"
 	$(JAVA) "-Djava.library.path=$(TEST_LIB_DIR)" $(TEST_FLAGS) -ea -cp "build/test.jar:build/jar/*:build/lib/*" one.profiler.test.Runner $(TESTS)
 
-test-java-from-release:
+test-java-from-release: build-test-libs build-test-bins
 	mkdir -p build/jar
 	cp $(JARS_DIRECTORY)/* build/jar
 	$(MAKE) build/$(TEST_JAR)

--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,14 @@ test-java: build-test-java
 	echo "Running tests against $(LIB_PROFILER)"
 	$(JAVA) "-Djava.library.path=$(TEST_LIB_DIR)" $(TEST_FLAGS) -ea -cp "build/test.jar:build/jar/*:build/lib/*" one.profiler.test.Runner $(TESTS)
 
+test-java-from-release:
+	mkdir -p build/jar
+	cp $(JARS_DIRECTORY)/* build/jar
+	$(MAKE) build/$(TEST_JAR)
+	cp -r $(RELEASE_DIRECTORY)/bin build
+	cp -r $(RELEASE_DIRECTORY)/lib build
+	$(JAVA) "-Djava.library.path=$(TEST_LIB_DIR)" $(TEST_FLAGS) -ea -cp "build/test.jar:build/jar/*:build/lib/*" one.profiler.test.Runner $(TESTS)
+
 coverage: override FAT_BINARY=false
 coverage: clean-coverage
 	$(MAKE) test-cpp CXXFLAGS_EXTRA="-fprofile-arcs -ftest-coverage -fPIC -O0 --coverage"

--- a/Makefile
+++ b/Makefile
@@ -232,14 +232,6 @@ test-java: build-test-java
 	echo "Running tests against $(LIB_PROFILER)"
 	$(JAVA) "-Djava.library.path=$(TEST_LIB_DIR)" $(TEST_FLAGS) -ea -cp "build/test.jar:build/jar/*:build/lib/*" one.profiler.test.Runner $(TESTS)
 
-test-java-from-release: build-test-libs build-test-bins
-	mkdir -p build/jar
-	cp $(JARS_DIRECTORY)/* build/jar
-	$(MAKE) build/$(TEST_JAR)
-	cp -r $(RELEASE_DIRECTORY)/bin build
-	cp -r $(RELEASE_DIRECTORY)/lib build
-	$(JAVA) "-Djava.library.path=$(TEST_LIB_DIR)" $(TEST_FLAGS) -ea -cp "build/test.jar:build/jar/*:build/lib/*" one.profiler.test.Runner $(TESTS)
-
 coverage: override FAT_BINARY=false
 coverage: clean-coverage
 	$(MAKE) test-cpp CXXFLAGS_EXTRA="-fprofile-arcs -ftest-coverage -fPIC -O0 --coverage"


### PR DESCRIPTION
### Description
In this PR I split the GHA job `build-binaries-and-test` in two jobs:
- `build-and-upload-binaries`: build release, run unit tests, upload artifacts
- `integration-tests`: run integration tests

<details>

### Old
![image](https://github.com/user-attachments/assets/97cd7665-dd5d-46a7-b232-3ddc7378553b)

### New
![image](https://github.com/user-attachments/assets/5940b1b3-ef45-415f-b948-a43c9a9c2cfb)
</details>

## Artifacts

I changed a bit how we publish publication:
- Removed the confusing `.tar.gz` and `.zip` in the *artifact name* (not *artifact path*, which stays the same), since anyway GHA would create an archive named `{artifact_name}.zip`, thus resulting in a file named `{artifact_name}.zip.zip` or `{artifact_name}.tar.gz.zip`
   - The tree stays the same though
   - *Question*: do we really need to publish a `.tar.gz`/`.zip` here? We could simply upload the artifact as a directory, and GHA will take care of zipping it, this would also simplify the workflow in this PR 
- JAR artifacts are now published as a single `async-profiler-jars` artifact. We can discuss this, it felt more symmetric to me

<details>

### Old
![image](https://github.com/user-attachments/assets/e300558b-985f-4442-af06-f97e9296a7b3)

### New
![image](https://github.com/user-attachments/assets/2cfc6012-9149-486b-b3bd-8db0f686b20e)
</details>

### Related issues
- #1213 will benefit from this
- #1226 and #1246 will need to change a bit
- we may need to adapt the publication workflow, let's see how these changes are received first

### Motivation and context
- We now have two different matrixes for build/upload artifact and integration tests, which means we can remove the hardcoded condition for artifact upload
- We don't need to setup Java two times when eventually we add JDK 8 to the integration test matrix
- Binaries and JARs which are published as artifacts are the same which are used for integration tests

### How has this been tested?
GHA

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
