### PR TITLE
Fix `NativememTests#dlopenCustomLib` on Alpine

### DIFF
--- a/test/test/nativemem/profile_with_dlopen.c
+++ b/test/test/nativemem/profile_with_dlopen.c
@@ -44,8 +44,10 @@ int main(int argc, char** argv) {
     void* libprof = dlopen("libasyncProfiler.so", RTLD_NOW);
     ASSERT_NO_DLERROR();
 
-    ((asprof_init_t)dlsym(libprof, "asprof_init"))();
+    asprof_init_t init_func = (asprof_init_t) dlsym(libprof, "asprof_init");
     ASSERT_NO_DLERROR();
+    init_func();
+    dlerror();
 
     asprof_execute_t asprof_execute = (asprof_execute_t)dlsym(libprof, "asprof_execute");
     ASSERT_NO_DLERROR();
@@ -69,6 +71,8 @@ int main(int argc, char** argv) {
     if (!dlopen_first) {
         lib = dlopen("libcallsmalloc.so", RTLD_NOW);
         ASSERT_NO_DLERROR();
+    } else {
+        dlerror();
     }
 
     call_malloc_t call_malloc = (call_malloc_t)dlsym(lib, "call_malloc");


### PR DESCRIPTION
### Description
This PR fixes `NativememTests#dlopenCustomLib` on Alpine.

`Hooks::init` includes the following three lines:
```cpp
_orig_pthread_create = ADDRESS_OF(pthread_create);
_orig_pthread_exit = ADDRESS_OF(pthread_exit);
_orig_dlopen = ADDRESS_OF(dlopen);
```

`ADDRESS_OF` is defined as follows:
```cpp
#define ADDRESS_OF(sym) ({ \
    void* addr = dlsym(RTLD_NEXT, #sym); \
    addr != NULL ? (sym##_t)addr : sym;  \
})
```
and ignores `dlerror`, which could then leak in subsequent parts of the code, even though `sym` is eventually patched using the original symbol rather than the one resolved by `dlsym`. This is why the `ASSERT_NO_DLERROR` at L48 fails with the following error:
```
Symbol not found: dlopen
```

A similar problem happens a bit below, in the `ASSERT_NO_DLERROR` after `(call_malloc_t)dlsym(lib, "call_malloc")`:
```
Library libjvm.so is not already loaded
```
This is coming from `Profiler::start -> VM::tryAttach`, which does not find any `libjvm.so` (as expected) and does not reset the `dlerror`.

### Related issues
#1226 

### Motivation and context
Tests introduced in #1243 do not work properly on Alpine, presumably because `dlerror` is not used in the same way in glibc and musl.

### How has this been tested?
```bash
docker run \
   -it --privileged --rm \
   -v $(pwd):/async-profiler amazoncorretto:11-alpine-jdk 
   sh -c 'apk add --no-cache musl-dev util-linux make gcc g++ linux-headers && \
      cd /async-profiler && \
      rm -rf build && \
      make -j test-java TESTS=jfr'
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
