### PR TITLE
Fix nightly publication

### DIFF
--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -194,7 +194,7 @@ jobs:
       - name: Download async-profiler binaries and jars
         uses: actions/download-artifact@v4
         with:
-          pattern: '*.*' # download everything except test logs
+          pattern: 'async-profiler-*'
           merge-multiple: 'true'
       - name: Delete previous release and publish new release
         uses: actions/github-script@v7


### PR DESCRIPTION
### Description
Artifacts are [not properly discovered](https://github.com/async-profiler/async-profiler/actions/runs/14667937072/job/41167591394) due to a change in the naming pattern.

### Related issues
#1253 broke it

### Motivation and context
We should fix nightly publication

### How has this been tested?
https://github.com/fandreuz/async-profiler/actions/runs/14668389291/job/41168859417

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
