### PR TITLE
Mention JVM flags in "Getting Started"

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -23,6 +23,7 @@ For example, to list all Java process IDs with their full command lines, run
 async-profiler works in the context of the target Java application,
 i.e. it runs as an agent in the process being profiled.
 `asprof` is a tool to attach and control the agent.
+It is highly recommended to start the JVM with the `-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints` flags to improve accuracy, see [Known Limitations](Troubleshooting.md#known-limitations).
 
 A typical workflow would be to launch your Java application, attach
 the agent and start profiling, exercise your performance scenario, and


### PR DESCRIPTION
### Description

Mention the `+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints` in the "Getting Started" section of the documentation.

### Motivation and context

These are important options to improve accuracy (and reduce safepoint bias), but they are currently hidden in
the Troubleshooting section of the documentation, where people are unlikely to look.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
