### PR TITLE
Redirect only stderr from `taskset` in integration tests

### DIFF
--- a/test/test/cpu/CpuTests.java
+++ b/test/test/cpu/CpuTests.java
@@ -6,6 +6,7 @@
 package test.cpu;
 
 import java.io.IOException;
+import java.lang.ProcessBuilder.Redirect;
 
 import one.profiler.test.Assert;
 import one.profiler.test.Os;
@@ -23,7 +24,7 @@ public class CpuTests {
 
     private static void pinCpu(TestProcess p, int cpu) throws Exception {
         String[] tasksetCmd = {"taskset", "-acp", String.valueOf(cpu), String.valueOf(p.pid())};
-        ProcessBuilder cpuPinPb = new ProcessBuilder(tasksetCmd).inheritIO();
+        ProcessBuilder cpuPinPb = new ProcessBuilder(tasksetCmd).redirectError(Redirect.INHERIT);
         if (cpuPinPb.start().waitFor() != 0) {
             throw new RuntimeException("Could not set CPU list for the test process");
         }

--- a/test/test/cpu/CpuTests.java
+++ b/test/test/cpu/CpuTests.java
@@ -5,6 +5,7 @@
 
 package test.cpu;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.ProcessBuilder.Redirect;
 
@@ -26,7 +27,7 @@ public class CpuTests {
         String[] tasksetCmd = {"taskset", "-acp", String.valueOf(cpu), String.valueOf(p.pid())};
         ProcessBuilder cpuPinPb = new ProcessBuilder(tasksetCmd)
             .redirectError(Redirect.INHERIT)
-            .redirectOutput(Redirect.DISCARD);
+            .redirectOutput(new File("/dev/null"));
         if (cpuPinPb.start().waitFor() != 0) {
             throw new RuntimeException("Could not set CPU list for the test process");
         }

--- a/test/test/cpu/CpuTests.java
+++ b/test/test/cpu/CpuTests.java
@@ -24,7 +24,9 @@ public class CpuTests {
 
     private static void pinCpu(TestProcess p, int cpu) throws Exception {
         String[] tasksetCmd = {"taskset", "-acp", String.valueOf(cpu), String.valueOf(p.pid())};
-        ProcessBuilder cpuPinPb = new ProcessBuilder(tasksetCmd).redirectError(Redirect.INHERIT);
+        ProcessBuilder cpuPinPb = new ProcessBuilder(tasksetCmd)
+            .redirectError(Redirect.INHERIT)
+            .redirectOutput(Redirect.DISCARD);
         if (cpuPinPb.start().waitFor() != 0) {
             throw new RuntimeException("Could not set CPU list for the test process");
         }


### PR DESCRIPTION
### Description
The stdout pollutes test logs in GHA.

### Related issues
n/a

### Motivation and context
Before:
<details>
<code>
INFO: Running CpuTests.itimerTotal...
INFO: Running CpuTests.perfEventsTargetCpuEventsCount...
PASS [20/75] CpuTests.itimerTotal took 2.797 s
pid 758's current affinity list: 0-3
pid 758's new affinity list: 0
pid 759's current affinity list: 0-3
pid 759's new affinity list: 0
pid 760's current affinity list: 0-3
pid 760's new affinity list: 0
pid 761's current affinity list: 0-3
pid 761's new affinity list: 0
pid 762's current affinity list: 0-3
pid 762's new affinity list: 0
pid 763's current affinity list: 0-3
pid 763's new affinity list: 0
pid 764's current affinity list: 0-3
pid 764's new affinity list: 0
pid 765's current affinity list: 0-3
pid 765's new affinity list: 0
pid 766's current affinity list: 0-3
pid 766's new affinity list: 0
pid 767's current affinity list: 0-3
pid 767's new affinity list: 0
pid 768's current affinity list: 0-3
pid 768's new affinity list: 0
pid 769's current affinity list: 0-3
pid 769's new affinity list: 0
pid 770's current affinity list: 0-3
pid 770's new affinity list: 0
pid 771's current affinity list: 0-3
pid 771's new affinity list: 0
pid 772's current affinity list: 0-3
pid 772's new affinity list: 0
pid 773's current affinity list: 0-3
pid 773's new affinity list: 0
pid 774's current affinity list: 0-3
pid 774's new affinity list: 0
pid 775's current affinity list: 0-3
pid 775's new affinity list: 0
pid 776's current affinity list: 0-3
pid 776's new affinity list: 0
pid 777's current affinity list: 0-3
pid 777's new affinity list: 0
pid 778's current affinity list: 0-3
pid 778's new affinity list: 0
pid 779's current affinity list: 0-3
pid 779's new affinity list: 0
PASS [21/75] CpuTests.perfEventsTargetCpuEventsCount took 5.171 s
INFO: Running CpuTests.perfEventsTargetCpuWithFdtransferEventsCount...
pid 789's current affinity list: 0-3
pid 789's new affinity list: 0
pid 790's current affinity list: 0-3
pid 790's new affinity list: 0
pid 791's current affinity list: 0-3
pid 791's new affinity list: 0
pid 792's current affinity list: 0-3
pid 792's new affinity list: 0
pid 793's current affinity list: 0-3
pid 793's new affinity list: 0
pid 794's current affinity list: 0-3
pid 794's new affinity list: 0
pid 795's current affinity list: 0-3
pid 795's new affinity list: 0
pid 796's current affinity list: 0-3
pid 796's new affinity list: 0
pid 797's current affinity list: 0-3
pid 797's new affinity list: 0
pid 798's current affinity list: 0-3
pid 798's new affinity list: 0
pid 799's current affinity list: 0-3
pid 799's new affinity list: 0
pid 800's current affinity list: 0-3
pid 800's new affinity list: 0
pid 801's current affinity list: 0-3
pid 801's new affinity list: 0
pid 802's current affinity list: 0-3
pid 802's new affinity list: 0
pid 803's current affinity list: 0-3
pid 803's new affinity list: 0
pid 804's current affinity list: 0-3
pid 804's new affinity list: 0
pid 805's current affinity list: 0-3
pid 805's new affinity list: 0
pid 806's current affinity list: 0-3
pid 806's new affinity list: 0
pid 807's current affinity list: 0-3
pid 807's new affinity list: 0
pid 808's current affinity list: 0-3
pid 808's new affinity list: 0
pid 809's current affinity list: 0-3
pid 809's new affinity list: 0
pid 810's current affinity list: 0-3
pid 810's new affinity list: 0
PASS [22/75] CpuTests.perfEventsTargetCpuWithFdtransferEventsCount took 5.090 s
</code>
</details>

After:
```
INFO: Running CpuTests.ctimerTotal...
PASS [18/74] CpuTests.ctimerTotal took 4.807 s
INFO: Running CpuTests.itimerDoesNotSupportTargetCpu...
PASS [19/74] CpuTests.itimerDoesNotSupportTargetCpu took 0.794 s
INFO: Running CpuTests.itimerTotal...
PASS [20/74] CpuTests.itimerTotal took 2.796 s
INFO: Running CpuTests.perfEventsTargetCpuEventsCount...
PASS [21/74] CpuTests.perfEventsTargetCpuEventsCount took 5.166 s
INFO: Running CpuTests.perfEventsTargetCpuWithFdtransferEventsCount...
PASS [22/74] CpuTests.perfEventsTargetCpuWithFdtransferEventsCount took 5.096 s
```

### How has this been tested?
GHA

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
