### PR TITLE
Improve symbol parsing on MacOs & Basic Native memory profiling support

### DIFF
--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -99,7 +99,7 @@ jobs:
             name: ubuntu-latest
         java-version: [11, 17, 21, 24]
         java-distribution: [corretto]
-        image: [public.ecr.aws/async-profiler/asprof-builder-x86:latest]
+        image: ["public.ecr.aws/async-profiler/asprof-builder-x86:latest"]
         include:
           - runson:
               display: macos-arm64

--- a/Makefile
+++ b/Makefile
@@ -210,13 +210,12 @@ build-test: build-test-cpp build-test-java
 
 build-test-libs:
 	@mkdir -p $(TEST_LIB_DIR)
-
-ifeq ($(OS_TAG),linux)
 	$(CC) -shared -fPIC -o $(TEST_LIB_DIR)/libreladyn.$(SOEXT) test/native/libs/reladyn.c
 	$(CC) -shared -fPIC -o $(TEST_LIB_DIR)/libcallsmalloc.$(SOEXT) test/native/libs/callsmalloc.c
 	$(CC) -shared -fPIC $(INCLUDES) -Isrc -o $(TEST_LIB_DIR)/libjnimalloc.$(SOEXT) test/native/libs/jnimalloc.c
 	$(CC) -shared -fPIC -o $(TEST_LIB_DIR)/libmalloc.$(SOEXT) test/native/libs/malloc.c
 
+ifeq ($(OS_TAG),linux)
 	$(CC) -c -shared -fPIC -o $(TEST_LIB_DIR)/vaddrdif.o test/native/libs/vaddrdif.c
 	$(LD) -N -shared -o $(TEST_LIB_DIR)/libvaddrdif.$(SOEXT) $(TEST_LIB_DIR)/vaddrdif.o -T test/native/libs/vaddrdif.ld
 

--- a/src/codeCache.cpp
+++ b/src/codeCache.cpp
@@ -275,7 +275,7 @@ void CodeCache::makeImportsPatchable() {
         uintptr_t patch_start = (uintptr_t)min_import & ~OS::page_mask;
         uintptr_t patch_end = (uintptr_t)max_import & ~OS::page_mask;
 #ifdef __APPLE__
-        vm_protect (mach_task_self (), patch_start, patch_start - patch_end + OS::page_size, 0, VM_PROT_READ | VM_PROT_WRITE | VM_PROT_COPY);
+        vm_protect (mach_task_self (), patch_start, patch_end - patch_start + OS::page_size, 0, VM_PROT_READ | VM_PROT_WRITE | VM_PROT_COPY);
 #else
         mprotect((void*)patch_start, patch_end - patch_start + OS::page_size, PROT_READ | PROT_WRITE);
 #endif

--- a/src/codeCache.cpp
+++ b/src/codeCache.cpp
@@ -11,6 +11,12 @@
 #include "dwarf.h"
 #include "os.h"
 
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#include <mach/mach_init.h>
+#include <mach/vm_map.h>
+#endif
+
 
 char* NativeFunc::create(const char* name, short lib_index) {
     NativeFunc* f = (NativeFunc*)malloc(sizeof(NativeFunc) + 1 + strlen(name));
@@ -268,7 +274,11 @@ void CodeCache::makeImportsPatchable() {
     if (max_import != NULL) {
         uintptr_t patch_start = (uintptr_t)min_import & ~OS::page_mask;
         uintptr_t patch_end = (uintptr_t)max_import & ~OS::page_mask;
+#ifdef __APPLE__
+        vm_protect (mach_task_self (), patch_start, patch_start - patch_end + OS::page_size, 0, VM_PROT_READ | VM_PROT_WRITE | VM_PROT_COPY);
+#else
         mprotect((void*)patch_start, patch_end - patch_start + OS::page_size, PROT_READ | PROT_WRITE);
+#endif
     }
 }
 

--- a/src/symbols_macos.cpp
+++ b/src/symbols_macos.cpp
@@ -62,7 +62,7 @@ class MachOParser {
         uint32_t *indirect_symbol_indices = indirect_symtab + section->reserved1;
         void **indirect_symbol_bindings = (void **)((uintptr_t)slide + section->addr);
 
-        for (uint i = 0; i < section->size / sizeof(void *); i++) {
+        for (uint64_t i = 0; i < section->size / sizeof(void *); i++) {
             uint32_t symtab_index = indirect_symbol_indices[i];
             if (symtab_index == INDIRECT_SYMBOL_ABS || symtab_index == INDIRECT_SYMBOL_LOCAL || symtab_index == (INDIRECT_SYMBOL_LOCAL | INDIRECT_SYMBOL_ABS)){
                 continue;

--- a/test/one/profiler/test/TestProcess.java
+++ b/test/one/profiler/test/TestProcess.java
@@ -33,8 +33,6 @@ public class TestProcess implements Closeable {
     public static final String LIBPROF = "%lib";
     public static final String TESTBIN = "%testbin";
     public static final String TESTLIB = "%testlib";
-    public static final String LDPRELOAD = "%ldpreload";
-    public static final String EXTENSION = "%ext";
 
     private static final String JAVA_HOME = System.getProperty("java.home");
 
@@ -88,7 +86,7 @@ public class TestProcess implements Closeable {
         for (String env : test.env()) {
             String[] keyValue = env.split("=", 2);
             if (keyValue.length == 2) {
-                pb.environment().put(substituteKeys(keyValue[0]), substituteFiles(keyValue[1]));
+                pb.environment().put(keyValue[0], substituteFiles(keyValue[1]));
             }
         }
         pb.environment().put("TEST_JAVA_HOME", JAVA_HOME);
@@ -123,13 +121,6 @@ public class TestProcess implements Closeable {
 
     public String testLibPath() {
         return "build/test/lib";
-    }
-
-    public String ldPreload() {
-        if (this.currentOs() == Os.MACOS) {
-            return "DYLD_INSERT_LIBRARIES";
-        }
-        return "LD_PRELOAD";
     }
 
     private List<String> buildCommandLine(Test test) {
@@ -187,13 +178,6 @@ public class TestProcess implements Closeable {
         }
     }
 
-    private String substituteKeys(String s) {
-        if (s.equals(LDPRELOAD)) {
-            return ldPreload();
-        }
-        return s;
-    }
-
     private String substituteFiles(String s) {
         Matcher m = filePattern.matcher(s);
         if (!m.find()) {
@@ -219,17 +203,7 @@ public class TestProcess implements Closeable {
         if (fileId.equals(TESTLIB)) {
             return testLibPath();
         }
-        if (fileId.equals(LDPRELOAD)) {
-            return ldPreload();
-        }
-        if (fileId.equals(EXTENSION)) {
-            return this.currentOs() == Os.MACOS ? "dylib" : "so";
-        }
         return createTempFile(fileId, ext).getPath();
-    }
-
-    private static void extracted() {
-        return;
     }
 
     private File createTempFile(String fileId) {

--- a/test/one/profiler/test/TestProcess.java
+++ b/test/one/profiler/test/TestProcess.java
@@ -33,6 +33,8 @@ public class TestProcess implements Closeable {
     public static final String LIBPROF = "%lib";
     public static final String TESTBIN = "%testbin";
     public static final String TESTLIB = "%testlib";
+    public static final String LDPRELOAD = "%ldpreload";
+    public static final String EXTENSION = "%ext";
 
     private static final String JAVA_HOME = System.getProperty("java.home");
 
@@ -86,7 +88,7 @@ public class TestProcess implements Closeable {
         for (String env : test.env()) {
             String[] keyValue = env.split("=", 2);
             if (keyValue.length == 2) {
-                pb.environment().put(keyValue[0], substituteFiles(keyValue[1]));
+                pb.environment().put(substituteKeys(keyValue[0]), substituteFiles(keyValue[1]));
             }
         }
         pb.environment().put("TEST_JAVA_HOME", JAVA_HOME);
@@ -121,6 +123,13 @@ public class TestProcess implements Closeable {
 
     public String testLibPath() {
         return "build/test/lib";
+    }
+
+    public String ldPreload() {
+        if (this.currentOs() == Os.MACOS) {
+            return "DYLD_INSERT_LIBRARIES";
+        }
+        return "LD_PRELOAD";
     }
 
     private List<String> buildCommandLine(Test test) {
@@ -178,6 +187,13 @@ public class TestProcess implements Closeable {
         }
     }
 
+    private String substituteKeys(String s) {
+        if (s.equals(LDPRELOAD)) {
+            return ldPreload();
+        }
+        return s;
+    }
+
     private String substituteFiles(String s) {
         Matcher m = filePattern.matcher(s);
         if (!m.find()) {
@@ -203,7 +219,17 @@ public class TestProcess implements Closeable {
         if (fileId.equals(TESTLIB)) {
             return testLibPath();
         }
+        if (fileId.equals(LDPRELOAD)) {
+            return ldPreload();
+        }
+        if (fileId.equals(EXTENSION)) {
+            return this.currentOs() == Os.MACOS ? "dylib" : "so";
+        }
         return createTempFile(fileId, ext).getPath();
+    }
+
+    private static void extracted() {
+        return;
     }
 
     private File createTempFile(String fileId) {

--- a/test/test/cpu/CpuTests.java
+++ b/test/test/cpu/CpuTests.java
@@ -12,7 +12,6 @@ import one.profiler.test.Os;
 import one.profiler.test.Output;
 import one.profiler.test.Test;
 import one.profiler.test.TestProcess;
-import one.profiler.test.Jvm;
 
 public class CpuTests {
 

--- a/test/test/nativemem/CallsAllNoLeak.java
+++ b/test/test/nativemem/CallsAllNoLeak.java
@@ -13,7 +13,7 @@ public class CallsAllNoLeak {
     private static final int CALLOC_SIZE = 2000147;
     private static final int REALLOC_SIZE = 30000170;
     private static final int POSIX_MEMALIGN_SIZE = 30000193;
-    private static final int ALIGNED_ALLOC_SIZE = 30002009;
+    private static final int ALIGNED_ALLOC_SIZE = 1024*1024;
 
     private static void doMallocRealloc() {
         long ptr = Native.malloc(MALLOC_SIZE);

--- a/test/test/nativemem/CallsAllNoLeak.java
+++ b/test/test/nativemem/CallsAllNoLeak.java
@@ -13,7 +13,7 @@ public class CallsAllNoLeak {
     private static final int CALLOC_SIZE = 2000147;
     private static final int REALLOC_SIZE = 30000170;
     private static final int POSIX_MEMALIGN_SIZE = 30000193;
-    private static final int ALIGNED_ALLOC_SIZE = 1024*1024;
+    private static final int ALIGNED_ALLOC_SIZE = 2*1024*1024;
 
     private static void doMallocRealloc() {
         long ptr = Native.malloc(MALLOC_SIZE);

--- a/test/test/nativemem/NativememTests.java
+++ b/test/test/nativemem/NativememTests.java
@@ -26,9 +26,9 @@ public class NativememTests {
     private static final int CALLOC_SIZE = 2000147;
     private static final int REALLOC_SIZE = 30000170;
     private static final int POSIX_MEMALIGN_SIZE = 30000193;
-    private static final int ALIGNED_ALLOC_SIZE = 30002009;
+    private static final int ALIGNED_ALLOC_SIZE = 1024*1024;
 
-    @Test(mainClass = CallsMallocCalloc.class, os = Os.LINUX, agentArgs = "start,nativemem,total,collapsed,file=%f", args = "once")
+    @Test(mainClass = CallsMallocCalloc.class, agentArgs = "start,nativemem,total,collapsed,file=%f", args = "once")
     public void canAgentTraceMallocCalloc(TestProcess p) throws Exception {
         Output out = p.waitForExit("%f");
 
@@ -36,14 +36,14 @@ public class NativememTests {
         Assert.isEqual(out.samples("Java_test_nativemem_Native_calloc"), CALLOC_SIZE);
     }
 
-    @Test(mainClass = CallsMallocCalloc.class, os = Os.LINUX, agentArgs = "start,nativemem=10000000,total,collapsed,file=%f", args = "once")
+    @Test(mainClass = CallsMallocCalloc.class, agentArgs = "start,nativemem=10000000,total,collapsed,file=%f", args = "once")
     public void canAgentFilterMallocCalloc(TestProcess p) throws Exception {
         Output out = p.waitForExit("%f");
         Assert.isEqual(out.samples("Java_test_nativemem_Native_malloc"), 0);
         Assert.isEqual(out.samples("Java_test_nativemem_Native_calloc"), 0);
     }
 
-    @Test(mainClass = CallsMallocCalloc.class, os = Os.LINUX)
+    @Test(mainClass = CallsMallocCalloc.class)
     public void canAsprofTraceMallocCalloc(TestProcess p) throws Exception {
         Output out = p.profile("-e nativemem --total -o collapsed -d 2");
         long samplesMalloc = out.samples("Java_test_nativemem_Native_malloc");
@@ -55,7 +55,7 @@ public class NativememTests {
         Assert.isEqual(samplesCalloc % CALLOC_SIZE, 0);
     }
 
-    @Test(mainClass = CallsRealloc.class, agentArgs = "start,nativemem,total,collapsed,file=%f", args = "once", os = Os.LINUX)
+    @Test(mainClass = CallsRealloc.class, agentArgs = "start,nativemem,total,collapsed,file=%f", args = "once")
     public void canAgentTraceRealloc(TestProcess p) throws Exception {
         Output out = p.waitForExit("%f");
 
@@ -63,7 +63,7 @@ public class NativememTests {
         Assert.isEqual(out.samples("Java_test_nativemem_Native_realloc"), REALLOC_SIZE);
     }
 
-    @Test(mainClass = CallsRealloc.class, os = Os.LINUX)
+    @Test(mainClass = CallsRealloc.class)
     public void canAsprofTraceRealloc(TestProcess p) throws Exception {
         Output out = p.profile("-e nativemem --total -o collapsed -d 2");
         long samplesMalloc = out.samples("Java_test_nativemem_Native_malloc");
@@ -75,7 +75,7 @@ public class NativememTests {
         Assert.isEqual(samplesRealloc % REALLOC_SIZE, 0);
     }
 
-    @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX)
+    @Test(mainClass = CallsAllNoLeak.class)
     public void canAsprofTraceAllNoLeak(TestProcess p) throws Exception {
         Output out = p.profile("-e nativemem --total -o collapsed -d 2");
 
@@ -146,17 +146,17 @@ public class NativememTests {
         return sizeCounts;
     }
 
-    @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX, args = "once", agentArgs = "start,nativemem,file=%f.jfr")
-    @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX, args = "once", agentArgs = "start,nativemem,total,file=%f.jfr")
-    @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX, args = "once", agentArgs = "start,nativemem=1,total,file=%f.jfr")
-    @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX, args = "once", agentArgs = "start,nativemem=10M,total,file=%f.jfr")
-    @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX, args = "once", agentArgs = "start,cpu,alloc,nativemem,total,file=%f.jfr")
+    @Test(mainClass = CallsAllNoLeak.class, args = "once", agentArgs = "start,nativemem,file=%f.jfr")
+    @Test(mainClass = CallsAllNoLeak.class, args = "once", agentArgs = "start,nativemem,total,file=%f.jfr")
+    @Test(mainClass = CallsAllNoLeak.class, args = "once", agentArgs = "start,nativemem=1,total,file=%f.jfr")
+    @Test(mainClass = CallsAllNoLeak.class, args = "once", agentArgs = "start,nativemem=10M,total,file=%f.jfr")
+    @Test(mainClass = CallsAllNoLeak.class, args = "once", agentArgs = "start,cpu,alloc,nativemem,total,file=%f.jfr")
     public void jfrNoLeaks(TestProcess p) throws Exception {
         assertNoLeaks(p);
     }
 
-    @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX, args = "once", inputs = "nofree", agentArgs = "start,nativemem,nofree,file=%f.jfr")
-    @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX, args = "once", inputs = "nofree", agentArgs = "start,cpu,alloc,nativemem,nofree,total,file=%f.jfr")
+    @Test(mainClass = CallsAllNoLeak.class, args = "once", inputs = "nofree", agentArgs = "start,nativemem,nofree,file=%f.jfr")
+    @Test(mainClass = CallsAllNoLeak.class, args = "once", inputs = "nofree", agentArgs = "start,cpu,alloc,nativemem,nofree,total,file=%f.jfr")
     public void jfrNoFree(TestProcess p) throws Exception {
         assertNoLeaks(p);
     }
@@ -179,10 +179,10 @@ public class NativememTests {
         Assert.isEqual(sizeCounts.getOrDefault((long) MALLOC_DYN_SIZE, 0L), 1);
     }
 
-    @Test(os = Os.LINUX, sh = "%testbin/profile_with_dlopen dlopen_first %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "dlopen_first")
-    @Test(os = Os.LINUX, sh = "%testbin/profile_with_dlopen profile_first %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "profile_first")
-    @Test(os = Os.LINUX, sh = "LD_PRELOAD=%lib %testbin/profile_with_dlopen dlopen_first %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "dlopen_first+LD_PRELOAD")
-    @Test(os = Os.LINUX, sh = "LD_PRELOAD=%lib %testbin/profile_with_dlopen profile_first %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "profile_first+LD_PRELOAD")
+    @Test(sh = "%testbin/profile_with_dlopen dlopen_first %f.jfr", nameSuffix = "dlopen_first")
+    @Test(sh = "%testbin/profile_with_dlopen profile_first %f.jfr", nameSuffix = "profile_first")
+    @Test(os = Os.LINUX, sh = "LD_PRELOAD=%lib %testbin/profile_with_dlopen dlopen_first %f.jfr", nameSuffix = "dlopen_first+LD_PRELOAD")
+    @Test(os = Os.LINUX, sh = "LD_PRELOAD=%lib %testbin/profile_with_dlopen profile_first %f.jfr", nameSuffix = "profile_first+LD_PRELOAD")
     public void dlopenCustomLib(TestProcess p) throws Exception {
         Map<Long, Long> sizeCounts = assertNoLeaks(p);
 

--- a/test/test/nativemem/NativememTests.java
+++ b/test/test/nativemem/NativememTests.java
@@ -26,7 +26,7 @@ public class NativememTests {
     private static final int CALLOC_SIZE = 2000147;
     private static final int REALLOC_SIZE = 30000170;
     private static final int POSIX_MEMALIGN_SIZE = 30000193;
-    private static final int ALIGNED_ALLOC_SIZE = 1024*1024;
+    private static final int ALIGNED_ALLOC_SIZE = 2*1024*1024;
 
     @Test(mainClass = CallsMallocCalloc.class, agentArgs = "start,nativemem,total,collapsed,file=%f", args = "once")
     public void canAgentTraceMallocCalloc(TestProcess p) throws Exception {

--- a/test/test/nativemem/profile_with_dlopen.c
+++ b/test/test/nativemem/profile_with_dlopen.c
@@ -9,6 +9,14 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef __APPLE__
+const char profiler_lib[] = "build/lib/libasyncProfiler.dylib";
+const char call_malloc_lib[] = "build/test/lib/libcallsmalloc.dylib";
+#else
+const char profiler_lib[] = "build/lib/libasyncProfiler.so";
+const char call_malloc_lib[] = "build/test/lib/libcallsmalloc.so";
+#endif
+
 #define ASSERT_NO_DLERROR(sym)            \
     if (sym == NULL) {                    \
         err = dlerror();                  \
@@ -43,7 +51,7 @@ int main(int argc, char** argv) {
     int dlopen_first = strcmp(argv[1], "dlopen_first") == 0 ? 1 : 0;
     const char* filename = argv[2];
 
-    void* libprof = dlopen("libasyncProfiler.so", RTLD_NOW);
+    void* libprof = dlopen(profiler_lib, RTLD_NOW);
     ASSERT_NO_DLERROR(libprof);
 
     asprof_init_t asprof_init = ((asprof_init_t)dlsym(libprof, "asprof_init"));
@@ -58,7 +66,7 @@ int main(int argc, char** argv) {
 
     // Load libcallsmalloc.so before or after starting the profiler, based on args.
     if (dlopen_first) {
-        lib = dlopen("libcallsmalloc.so", RTLD_NOW);
+        lib = dlopen(call_malloc_lib, RTLD_NOW);
         ASSERT_NO_DLERROR(lib);
     }
 
@@ -70,7 +78,7 @@ int main(int argc, char** argv) {
     ASSERT_NO_ASPROF_ERR(asprof_err);
 
     if (!dlopen_first) {
-        lib = dlopen("libcallsmalloc.so", RTLD_NOW);
+        lib = dlopen(call_malloc_lib, RTLD_NOW);
         ASSERT_NO_DLERROR(lib);
     }
 


### PR DESCRIPTION
### Description
Improving Macos symbol parsing to better detect dynamic symbols & patch them more effectively 
As well as basic native memory profiling support on MacOs


### Related issues
#1193

### Motivation and context
MacOs Symbol parsing was missing many symbols which was causing problems when trying to make improvements on Linux side.

By making the Symbol parsing to be more inline with Linux it makes it easier to make improvements that effect both platforms 

### How has this been tested?
Nativemem tests have been enabled on MacOs
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
