### PR TITLE
Support "--all" profiling mode

### DIFF
--- a/docs/ProfilingModes.md
+++ b/docs/ProfilingModes.md
@@ -221,6 +221,34 @@ The same, when starting profiler as an agent:
 -agentpath:/path/to/libasyncProfiler.so=start,event=cpu,alloc=2m,lock=10ms,file=profile.jfr
 ```
 
+### All possible modes
+
+Instead of passing each execution event type in the startup command, it is possible to pass a single parameter called `--all` which profiles `cpu`,`wall`, `alloc`, `live`, `lock` and `nativemem` simultaneously.
+
+Sample command:
+
+```
+asprof --all -f profile.jfr
+```
+
+or combine it with `--alloc`/`--wall`/`--lock`/`--nativemem` flags to override individual settings. For example:
+
+```
+asprof --all --alloc 2m --lock 10ms -f profile.jfr
+```
+
+The same, when starting profiler as an agent:
+
+```
+-agentpath:/path/to/libasyncProfiler.so=start,all,alloc=2m,lock=10ms,file=profile.jfr
+```
+
+Instead of `cpu`, it is possible to override the `--all` parameter with any other event type of your choice. For instance, the following command will profile perf-event `cycles` along with ` wall`, `alloc`, `live`, `lock` and `nativemem`:
+
+```
+asprof --all -e cycles -f profile.jfr
+```
+
 ## Continuous profiling
 
 Continuous profiling is a means by which an application can be profiled

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include "arguments.h"
+#include "os.h"
 
 
 // Arguments of the last start/resume command; reused for shutdown and restart
@@ -223,7 +224,7 @@ Error Arguments::parse(const char* args) {
                     if (_nativemem < 0) _nativemem = 0;
                 } else if (strcmp(value, EVENT_LOCK) == 0) {
                     if (_lock < 0) _lock = DEFAULT_LOCK_INTERVAL;
-                } else if (_event != NULL) {
+                } else if (_event != NULL && !_all) {
                     msg = "Duplicate event argument";
                 } else {
                     _event = value;
@@ -250,7 +251,7 @@ Error Arguments::parse(const char* args) {
                 _nofree = true;
 
             CASE("lock")
-                _lock = value == NULL ? 0 : parseUnits(value, NANOS);
+                _lock = value == NULL ? DEFAULT_LOCK_INTERVAL : parseUnits(value, NANOS);
 
             CASE("wall")
                 _wall = value == NULL ? 0 : parseUnits(value, NANOS);
@@ -259,6 +260,25 @@ Error Arguments::parse(const char* args) {
                 if (_event != NULL) {
                     msg = "Duplicate event argument";
                 } else {
+                    _event = EVENT_CPU;
+                }
+
+            CASE("all")
+                _all = true;
+                _live = true;
+                if (_wall < 0) {
+                    _wall = 0;
+                }
+                if (_alloc < 0) {
+                    _alloc = 0;
+                }
+                if (_lock < 0) {
+                    _lock = DEFAULT_LOCK_INTERVAL;
+                }
+                if (_nativemem < 0) {
+                    _nativemem = 0;
+                }
+                if (_event == NULL && OS::isLinux()) {
                     _event = EVENT_CPU;
                 }
 

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -208,6 +208,7 @@ class Arguments {
     double _minwidth;
     bool _reverse;
     bool _inverted;
+    bool _all;
 
     Arguments() :
         _buf(NULL),
@@ -262,7 +263,8 @@ class Arguments {
         _title(NULL),
         _minwidth(0),
         _reverse(false),
-        _inverted(false) {
+        _inverted(false),
+        _all(false) {
     }
 
     ~Arguments();

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -91,6 +91,9 @@ static const char USAGE_STRING[] =
     "  --fdtransfer      use fdtransfer to serve perf requests\n"
     "  --target-cpu cpu  sample threads on a specific CPU (perf_events only, default: -1)\n"
     "                    from the non-privileged target\n"
+    "  --all             shorthand for enabling cpu, wall, alloc (includes live objects), nativemem and lock profiling simultaneously.\n"
+    "                    This can be combined with --alloc 2m --lock 10ms etc. to also pass custom interval/threshold.\n"
+    "                    It is also possible to combine it with -e flag to change the type of event being collected. Default is cpu.\n"
     "\n"
     "<pid> is a numeric process ID of the target JVM\n"
     "      or 'jps' keyword to find running JVM automatically\n"
@@ -99,7 +102,8 @@ static const char USAGE_STRING[] =
     "Example: " APP_BINARY " -d 30 -f profile.html 3456\n"
     "         " APP_BINARY " start -i 1ms jps\n"
     "         " APP_BINARY " stop -o flat jps\n"
-    "         " APP_BINARY " -d 5 -e alloc MyAppName\n";
+    "         " APP_BINARY " -d 5 -e alloc MyAppName\n"
+    "         " APP_BINARY " --all -f profile.jfr\n";
 
 
 extern "C" int jattach(int pid, int argc, const char** argv, int print_output);
@@ -544,6 +548,8 @@ int main(int argc, const char** argv) {
             // The last argument is the application name as it would appear in the jps tool
             pid = jps("jps -J-XX:+PerfDisableSharedMem", arg.str());
 
+        } else if (arg == "--all") {
+            params << ",all";
         } else {
             fprintf(stderr, "Unrecognized option: %s\n", arg.str());
             return 1;

--- a/test/native/argumentsTest.cpp
+++ b/test/native/argumentsTest.cpp
@@ -1,0 +1,60 @@
+#include "testRunner.hpp"
+#include "arguments.h"
+#include <stdio.h>
+
+TEST_CASE(Parse_all_mode_no_override) {
+    Arguments args;
+    char argument[] = "start,all,file=%f.jfr";
+    Error error = args.parse(argument);
+    ASSERT_EQ(args._all, true);
+    #ifdef __linux__
+    ASSERT_EQ(args._event, EVENT_CPU);
+    #endif
+    #ifdef __APPLE__
+    ASSERT_EQ(args._event, NULL);
+    #endif
+    ASSERT_EQ(args._wall, 0);
+    ASSERT_EQ(args._alloc, 0);
+    ASSERT_EQ(args._nativemem, 0);
+    ASSERT_EQ(args._lock, DEFAULT_LOCK_INTERVAL);
+    ASSERT_EQ(args._live, true);
+}
+
+TEST_CASE(Parse_all_mode_event_override) {
+    Arguments args;
+    char argument[] = "start,all,event=cycles,file=%f.jfr";
+    Error error = args.parse(argument);
+    ASSERT_EQ(args._all, true);
+    ASSERT_EQ(args._event, "cycles");
+    ASSERT_EQ(args._wall, 0);
+    ASSERT_EQ(args._alloc, 0);
+    ASSERT_EQ(args._nativemem, 0);
+    ASSERT_EQ(args._lock, DEFAULT_LOCK_INTERVAL);
+    ASSERT_EQ(args._live, true);
+}
+
+TEST_CASE(Parse_all_mode_event_and_threshold_override) {
+    Arguments args;
+    char argument[] = "start,all,event=cycles,nativemem=10,lock=100,alloc=1000,wall=10000,file=%f.jfr";
+    Error error = args.parse(argument);
+    ASSERT_EQ(args._all, true);
+    ASSERT_EQ(args._event, "cycles");
+    ASSERT_EQ(args._wall, 10000);
+    ASSERT_EQ(args._alloc, 1000);
+    ASSERT_EQ(args._nativemem, 10);
+    ASSERT_EQ(args._lock, 100);
+    ASSERT_EQ(args._live, true);
+}
+
+TEST_CASE(Parse_override_before_all_mode) {
+    Arguments args;
+    char argument[] = "start,event=cycles,nativemem=10,lock=100,alloc=1000,all,file=%f.jfr";
+    Error error = args.parse(argument);
+    ASSERT_EQ(args._all, true);
+    ASSERT_EQ(args._event, "cycles");
+    ASSERT_EQ(args._wall, 0);
+    ASSERT_EQ(args._alloc, 1000);
+    ASSERT_EQ(args._nativemem, 10);
+    ASSERT_EQ(args._lock, 100);
+    ASSERT_EQ(args._live, true);
+}

--- a/test/native/argumentsTest.cpp
+++ b/test/native/argumentsTest.cpp
@@ -1,23 +1,22 @@
 #include "testRunner.hpp"
 #include "arguments.h"
-#include <stdio.h>
 
 TEST_CASE(Parse_all_mode_no_override) {
     Arguments args;
     char argument[] = "start,all,file=%f.jfr";
     Error error = args.parse(argument);
     ASSERT_EQ(args._all, true);
+    ASSERT_EQ(args._wall, 0);
+    ASSERT_EQ(args._alloc, 0);
+    ASSERT_EQ(args._nativemem, 0);
+    ASSERT_EQ(args._lock, DEFAULT_LOCK_INTERVAL);
+    ASSERT_EQ(args._live, true);
     #ifdef __linux__
     ASSERT_EQ(args._event, EVENT_CPU);
     #endif
     #ifdef __APPLE__
     ASSERT_EQ(args._event, NULL);
     #endif
-    ASSERT_EQ(args._wall, 0);
-    ASSERT_EQ(args._alloc, 0);
-    ASSERT_EQ(args._nativemem, 0);
-    ASSERT_EQ(args._lock, DEFAULT_LOCK_INTERVAL);
-    ASSERT_EQ(args._live, true);
 }
 
 TEST_CASE(Parse_all_mode_event_override) {

--- a/test/native/argumentsTest.cpp
+++ b/test/native/argumentsTest.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "testRunner.hpp"
 #include "arguments.h"
 

--- a/test/native/demangleTest.cpp
+++ b/test/native/demangleTest.cpp
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "arch.h"
 #include "testRunner.hpp"
 #include "demangle.h"
 #include <stdio.h>

--- a/test/native/testRunner.hpp
+++ b/test/native/testRunner.hpp
@@ -12,6 +12,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include "arch.h"
 
 struct TestCase;
 

--- a/test/test/jfr/JfrTests.java
+++ b/test/test/jfr/JfrTests.java
@@ -86,8 +86,8 @@ public class JfrTests {
      * @param p The test process to profile with.
      * @throws Exception Any exception thrown during profiling JFR output parsing.
      */
-    @Test(mainClass = JfrMutliModeProfiling.class, agentArgs = "start,all,file=%f.jfr", os = Os.LINUX)
-    @Test(mainClass = JfrMutliModeProfiling.class, agentArgs = "start,all,alloc=2m,file=%f.jfr", os = Os.LINUX)
+    @Test(mainClass = JfrMutliModeProfiling.class, agentArgs = "start,all,file=%f.jfr")
+    @Test(mainClass = JfrMutliModeProfiling.class, agentArgs = "start,all,alloc=2m,file=%f.jfr")
     public void allModeRecordingLinuxWithoutEventOverride(TestProcess p) throws Exception {
         p.waitForExit();
         Set<String> events = new HashSet<>();
@@ -108,13 +108,13 @@ public class JfrTests {
         assert events.contains("profiler.Free"); // nativemem profiling
     }
 
-     /**
+    /**
      * Test to validate profiling output with "--all" flag for Linux with event override
      *
      * @param p The test process to profile with.
      * @throws Exception Any exception thrown during profiling JFR output parsing.
      */
-    @Test(mainClass = JfrMutliModeProfiling.class, agentArgs = "start,all,event=cache-misses,alloc=2m,file=%f.jfr", os = Os.LINUX, output = true)
+    @Test(mainClass = JfrMutliModeProfiling.class, agentArgs = "start,all,event=java.util.Properties.getProperty,alloc=2m,file=%f.jfr")
     public void allModeRecordingLinuxWithEventOverride(TestProcess p) throws Exception {
         try {
             p.waitForExit();
@@ -124,10 +124,12 @@ public class JfrTests {
                     RecordedEvent event = recordingFile.readEvent();
                     String eventName = event.getEventType().getName();
                     events.add(eventName);
+                    if (eventName.equals("jdk.ExecutionSample")) {
+                        // This means that only instrumented method was profiled and overall CPU profiling was skipped
+                        assert event.getStackTrace().toString().contains("java.util.Properties.getProperty");
+                    }
                 }
             }
-
-            assert !events.contains("jdk.ExecutionSample"); // no cpu profiling
             assert events.contains("jdk.JavaMonitorEnter"); // lock profiling
             assert events.contains("jdk.ObjectAllocationInNewTLAB"); // alloc profiling
             assert events.contains("profiler.WallClockSample"); // wall clock profiling
@@ -139,34 +141,6 @@ public class JfrTests {
                 throw e;
             }
         }
-    }
-
-    /**
-     * Test to validate profiling output with "--all" flag for MacOS arm64
-     * Note: This can be enabled for x64 macOS after: https://github.com/async-profiler/async-profiler/issues/1193
-     *
-     * @param p The test process to profile with.
-     * @throws Exception Any exception thrown during profiling JFR output parsing.
-     */
-    @Test(mainClass = JfrMutliModeProfiling.class, agentArgs = "start,all,file=%f.jfr", os = Os.MACOS, arch = Arch.ARM64)
-    @Test(mainClass = JfrMutliModeProfiling.class, agentArgs = "start,all,lock=10ms,file=%f.jfr", os = Os.MACOS, arch = Arch.ARM64)
-    public void allModeRecordingMacOs(TestProcess p) throws Exception {
-        p.waitForExit();
-        Set<String> events = new HashSet<>();
-        try (RecordingFile recordingFile = new RecordingFile(p.getFile("%f").toPath())) {
-            while (recordingFile.hasMoreEvents()) {
-                RecordedEvent event = recordingFile.readEvent();
-                String eventName = event.getEventType().getName();
-                events.add(eventName);
-            }
-        }
-
-        assert events.contains("jdk.JavaMonitorEnter"); // lock profiling
-        assert events.contains("jdk.ObjectAllocationInNewTLAB"); // alloc profiling
-        assert events.contains("profiler.WallClockSample"); // wall clock profiling
-        assert events.contains("profiler.LiveObject"); // profiling of live objects
-        assert events.contains("profiler.Malloc"); // nativemem profiling
-        assert events.contains("profiler.Free"); // nativemem profiling
     }
 
     /**


### PR DESCRIPTION
### Description
This PR adds capability to simultaneously profile `cpu`, `lock`, `nativemem`, `alloc` (including `live` objects) and `wall`  by providing a shortcut parameter called `--all` for JFR Output mode
The readme contains a detailed information on how to use it and supported overrides.

### Related issues
#1259

### How has this been tested?

#### Unit testing
There are unit tests which test the parsing of the arguments.
#### Integration testing
There is a new integration test added which asserts that the output of the profile generated using `--all` mode contains JFR Events corresponding to all the expected event types.

#### Manual testing
The following scenarios were tested (attached its `jfr summary` output):

1. `./build/bin/asprof -d 60 --all -f profile.jfr JfrMutliModeProfiling`
```
jfr summary profile.jfr
 Version: 2.0
 Chunks: 1
 Start: 2025-05-01 16:19:07 (UTC)
 Duration: 2 s

 Event Type                          Count  Size (bytes)
=========================================================
 profiler.Malloc                     73368       1612539
 profiler.Free                       66417       1261923
 jdk.JavaMonitorEnter                24922        583502
 jdk.ObjectAllocationInNewTLAB       11224        235293
 profiler.WallClockSample              647         10117
 jdk.ExecutionSample                   290          4277
 profiler.LiveObject                    98          2450
 jdk.ActiveSetting                      27           844
 jdk.NativeLibrary                      19          1321
 jdk.InitialSystemProperty              16           894
 jdk.Metadata                            1          7913
 jdk.CheckPoint                          1        654967
 jdk.CPULoad                             1            21
 jdk.ActiveRecording                     1            75
 jdk.OSInformation                       1           102
 jdk.CPUInformation                      1           365
 jdk.JVMInformation                      1           132
 jdk.GCHeapSummary                       1            41
 jdk.ObjectAllocationOutsideTLAB         0             0
 jdk.ThreadPark                          0             0
 profiler.Log                            0             0
 profiler.Window                         0             0
 profiler.UserEvent                      0             0
---
```
2. `./build/bin/asprof -d 60 --all --lock 10ms -f profile.jfr JfrMutliModeProfiling`
```
jfr summary profile.jfr

 Version: 2.0
 Chunks: 1
 Start: 2025-05-01 16:20:45 (UTC)
 Duration: 1 s

 Event Type                          Count  Size (bytes)
=========================================================
 profiler.Malloc                     46574       1068249
 profiler.Free                       40699        813980
 jdk.ObjectAllocationInNewTLAB       11167        245293
 profiler.WallClockSample              627         10098
 jdk.ExecutionSample                   293          4616
 profiler.LiveObject                    31           802
 jdk.ActiveSetting                      27           847
 jdk.JavaMonitorEnter                   22           540
 jdk.NativeLibrary                      19          1321
 jdk.InitialSystemProperty              16           894
 jdk.Metadata                            1          7913
 jdk.CheckPoint                          1        566746
 jdk.ActiveRecording                     1            75
 jdk.OSInformation                       1           102
 jdk.CPUInformation                      1           365
 jdk.JVMInformation                      1           133
 jdk.ObjectAllocationOutsideTLAB         0             0
 jdk.ThreadPark                          0             0
 jdk.CPULoad                             0             0
 jdk.GCHeapSummary                       0             0
 profiler.Log                            0             0
 profiler.Window                         0             0
 profiler.UserEvent                      0             0
```

3. `./build/bin/asprof -d 60 --all --lock 10ms -e cache-misses -f profile.jfr JfrMutliModeProfiling`
```
jfr summary profile.jfr

 Version: 2.0
 Chunks: 1
 Start: 2025-05-01 16:21:24 (UTC)
 Duration: 1 s

 Event Type                          Count  Size (bytes)
=========================================================
 profiler.Malloc                     48240       1095089
 profiler.Free                       41216        824320
 jdk.ObjectAllocationInNewTLAB       11002        241589
 profiler.LiveObject                  1024         26568
 profiler.WallClockSample              635         10760
 jdk.ActiveSetting                      27           856
 jdk.JavaMonitorEnter                   25           585
 jdk.NativeLibrary                      19          1321
 jdk.InitialSystemProperty              16           894
 jdk.Metadata                            1          7913
 jdk.CheckPoint                          1        667185
 jdk.CPULoad                             1            21
 jdk.ActiveRecording                     1            75
 jdk.OSInformation                       1           102
 jdk.CPUInformation                      1           365
 jdk.JVMInformation                      1           133
 jdk.GCHeapSummary                       1            41
 jdk.ExecutionSample                     0             0
 jdk.ObjectAllocationOutsideTLAB         0             0
 jdk.ThreadPark                          0             0
 profiler.Log                            0             0
 profiler.Window                         0             0
 profiler.UserEvent                      0             0
```

4. `./build/bin/asprof -d 60 -e cache-misses --all -f profile.jfr JfrMutliModeProfiling`
```
jfr summary profile.jfr

 Version: 2.0
 Chunks: 1
 Start: 2025-05-01 16:22:10 (UTC)
 Duration: 2 s

 Event Type                          Count  Size (bytes)
=========================================================
 profiler.Malloc                     67913       1554116
 profiler.Free                       60853       1217060
 jdk.JavaMonitorEnter                20142        492437
 jdk.ObjectAllocationInNewTLAB       10695        224424
 profiler.LiveObject                   972         24280
 profiler.WallClockSample              618         10467
 jdk.ActiveSetting                      27           853
 jdk.NativeLibrary                      19          1321
 jdk.InitialSystemProperty              16           894
 jdk.Metadata                            1          7913
 jdk.CheckPoint                          1        653386
 jdk.CPULoad                             1            21
 jdk.ActiveRecording                     1            75
 jdk.OSInformation                       1           102
 jdk.CPUInformation                      1           365
 jdk.JVMInformation                      1           133
 jdk.GCHeapSummary                       1            42
 jdk.ExecutionSample                     0             0
 jdk.ObjectAllocationOutsideTLAB         0             0
 jdk.ThreadPark                          0             0
 profiler.Log                            0             0
 profiler.Window                         0             0
 profiler.UserEvent                      0             0
```
5. `./build/bin/asprof -d 60 --all -f profile.out JfrMutliModeProfiling`
```
[ERROR] Only JFR output supports multiple events
```

NOTE: Same tests were run in agent mode as well, works as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0