### PR TITLE
Move out `Buffer` from `flightRecorder.cpp`

### DIFF
--- a/src/buffer.h
+++ b/src/buffer.h
@@ -16,9 +16,12 @@ constexpr int MAX_STRING_LENGTH = 8191;
 class Buffer {
   private:
     std::size_t _offset;
-    char* _data;
+    char _data[0];
 
   protected:
+    Buffer() : _offset(0) {
+    }
+
     void set(char v, std::size_t idx) {
         _data[idx] = v;
     }
@@ -28,9 +31,6 @@ class Buffer {
     }
 
   public:
-    Buffer(char* data) : _offset(0), _data(data) {
-    }
-
     const char* data() const {
         return _data;
     }

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -11,7 +11,10 @@
 #include <cstring>
 #include <cstdint>
 
-constexpr int MAX_STRING_LENGTH = 8191;
+const std::size_t MAX_STRING_LENGTH = 8191;
+// https://github.com/openjdk/jmc/blob/master/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/SeekableInputStream.java
+const char STRING_ENCODING_UTF8_BYTE_ARRAY = 3;
+const char STRING_ENCODING_LATIN1_BYTE_ARRAY = 5;
 
 class Buffer {
   private:
@@ -47,11 +50,6 @@ class Buffer {
 
     void reset() {
         _offset = 0;
-    }
-
-    void put(const char* v, std::size_t len) {
-        std::memcpy(_data + _offset, v, len);
-        _offset += (int)len;
     }
 
     void put8(char v) {
@@ -131,6 +129,11 @@ class Buffer {
         _data[_offset++] = (char)v;
     }
 
+    void put(const char* v, std::size_t len) {
+        std::memcpy(_data + _offset, v, len);
+        _offset += len;
+    }
+
     void putUtf8(const char* v) {
         if (v == NULL) {
             put8(0);
@@ -141,13 +144,13 @@ class Buffer {
     }
 
     void putUtf8(const char* v, std::size_t len) {
-        put8(3);
+        put8(STRING_ENCODING_UTF8_BYTE_ARRAY);
         putVar32(len);
         put(v, len);
     }
 
     void putByteString(const char* v, std::size_t len) {
-        put8(5); // STRING_ENCODING_LATIN1_BYTE_ARRAY
+        put8(STRING_ENCODING_LATIN1_BYTE_ARRAY);
         putVar32(len);
         put(v, len);
     }

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -87,37 +87,36 @@ class Buffer {
     }
 
     void putVar32(u32 v) {
-        while (v > 0x7f) {
-            _data[_offset++] = (char)v | 0x80;
-            v >>= 7;
-        }
-        _data[_offset++] = (char)v;
+        _offset = putVar32(_offset, v);
     }
 
-    void putVar32(std::size_t offset, u32 v) {
-        _data[offset] = v | 0x80;
-        _data[offset + 1] = (v >> 7) | 0x80;
-        _data[offset + 2] = (v >> 14) | 0x80;
-        _data[offset + 3] = (v >> 21) | 0x80;
-        _data[offset + 4] = (v >> 28);
+    std::size_t putVar32(std::size_t offset, u32 v) {
+        while (v > 0x7f) {
+            _data[offset++] = (char)v | 0x80;
+            v >>= 7;
+        }
+        _data[offset++] = (char)v;
+        return offset;
     }
 
     void putVar64(u64 v) {
+        _offset = putVar64(_offset, v);
+    }
+
+    std::size_t putVar64(std::size_t offset, u64 v) {
         int iter = 0;
         while (v > 0x1fffff) {
-            _data[_offset++] = (char)v | 0x80;
+            _data[offset++] = (char)v | 0x80;
             v >>= 7;
-            _data[_offset++] = (char)v | 0x80;
-            v >>= 7;
-            _data[_offset++] = (char)v | 0x80;
-            v >>= 7;
-            if (++iter == 3) return;
         }
         while (v > 0x7f) {
-            _data[_offset++] = (char)v | 0x80;
+            _data[offset++] = (char)v | 0x80;
             v >>= 7;
         }
-        _data[_offset++] = (char)v;
+        if (v > 0) {
+            _data[offset++] = (char)v;
+        }
+        return offset;
     }
 
     void put(const char* v, std::size_t len) {

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -11,11 +11,6 @@
 #include <cstring>
 #include <cstdint>
 
-const std::size_t MAX_STRING_LENGTH = 8191;
-// https://github.com/openjdk/jmc/blob/master/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/SeekableInputStream.java
-const char STRING_ENCODING_UTF8_BYTE_ARRAY = 3;
-const char STRING_ENCODING_LATIN1_BYTE_ARRAY = 5;
-
 class Buffer {
   private:
     std::size_t _offset;
@@ -132,27 +127,6 @@ class Buffer {
     void put(const char* v, std::size_t len) {
         std::memcpy(_data + _offset, v, len);
         _offset += len;
-    }
-
-    void putUtf8(const char* v) {
-        if (v == NULL) {
-            put8(0);
-        } else {
-            std::size_t len = strlen(v);
-            putUtf8(v, len < MAX_STRING_LENGTH ? len : MAX_STRING_LENGTH);
-        }
-    }
-
-    void putUtf8(const char* v, std::size_t len) {
-        put8(STRING_ENCODING_UTF8_BYTE_ARRAY);
-        putVar32(len);
-        put(v, len);
-    }
-
-    void putByteString(const char* v, std::size_t len) {
-        put8(STRING_ENCODING_LATIN1_BYTE_ARRAY);
-        putVar32(len);
-        put(v, len);
     }
 };
 

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -91,8 +91,8 @@ class Buffer {
     }
 
     std::size_t putVar32(std::size_t offset, u32 v) {
-        while (v > 0x7f) {
-            _data[offset++] = (char)v | 0x80;
+        while (v > 0b01111111) {
+            _data[offset++] = (char)v | 0b10000000;
             v >>= 7;
         }
         _data[offset++] = (char)v;
@@ -105,12 +105,12 @@ class Buffer {
 
     std::size_t putVar64(std::size_t offset, u64 v) {
         int iter = 0;
-        while (v > 0x1fffff) {
-            _data[offset++] = (char)v | 0x80;
+        while (v > 0b111111111111111111111) {
+            _data[offset++] = (char)v | 0b10000000;
             v >>= 7;
         }
-        while (v > 0x7f) {
-            _data[offset++] = (char)v | 0x80;
+        while (v > 0b01111111) {
+            _data[offset++] = (char)v | 0b10000000;
             v >>= 7;
         }
         if (v > 0) {

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -46,8 +46,8 @@ class Buffer {
         _data[offset] = v;
     }
 
-    virtual void put16(short v) = 0;
-    virtual void put32(int v) = 0;
+    virtual void put16(u16 v) = 0;
+    virtual void put32(u32 v) = 0;
     virtual void put64(u64 v) = 0;
 
     void putFloat(float v) {
@@ -78,12 +78,12 @@ class Buffer {
 
 class BigEndianBuffer : public Buffer {
   public:
-    void put16(short v) override {
+    void put16(u16 v) override {
         *(short*)(_data + _offset) = htons(v);
         _offset += 2;
     }
 
-    void put32(int v) override {
+    void put32(u32 v) override {
         *(int*)(_data + _offset) = htonl(v);
         _offset += 4;
     }

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -53,7 +53,7 @@ class Buffer {
     void putFloat(float v) {
         union {
             float f;
-            int i;
+            u32 i;
         } u;
 
         u.f = v;
@@ -63,7 +63,7 @@ class Buffer {
     void putDouble(double v) {
         union {
             double d;
-            long l;
+            u64 l;
         } u;
 
         u.d = v;

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -24,10 +24,6 @@ class Buffer {
         _data[idx] = v;
     }
 
-    std::size_t advanceOffset(std::size_t incr) {
-        return _offset += incr;
-    }
-
   public:
     const char* data() const {
         return _data;

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -12,7 +12,7 @@
 
 class Buffer {
   protected:
-    std::size_t _offset;
+    size_t _offset;
     char* _data;
 
     Buffer(char* data) : _offset(0), _data(data) {
@@ -23,12 +23,12 @@ class Buffer {
         return _data;
     }
 
-    std::size_t offset() const {
+    size_t offset() const {
         return _offset;
     }
 
-    int skip(std::size_t delta) {
-        std::size_t offset = _offset;
+    int skip(size_t delta) {
+        size_t offset = _offset;
         _offset = offset + delta;
         return offset;
     }
@@ -41,7 +41,7 @@ class Buffer {
         _data[_offset++] = v;
     }
 
-    void put8(std::size_t offset, char v) {
+    void put8(size_t offset, char v) {
         _data[offset] = v;
     }
 
@@ -69,7 +69,7 @@ class Buffer {
         put64(u.l);
     }
 
-    void put(const char* v, std::size_t len) {
+    void put(const char* v, size_t len) {
         memcpy(_data + _offset, v, len);
         _offset += len;
     }

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -12,16 +12,11 @@
 #include <string.h>
 
 class Buffer {
-  private:
+  protected:
     std::size_t _offset;
     char _data[0];
 
-  protected:
     Buffer() : _offset(0) {
-    }
-
-    void set(char v, std::size_t idx) {
-        _data[idx] = v;
     }
 
   public:
@@ -84,39 +79,6 @@ class Buffer {
 
         u.d = v;
         put64(u.l);
-    }
-
-    void putVar32(u32 v) {
-        _offset = putVar32(_offset, v);
-    }
-
-    std::size_t putVar32(std::size_t offset, u32 v) {
-        while (v > 0b01111111) {
-            _data[offset++] = (char)v | 0b10000000;
-            v >>= 7;
-        }
-        _data[offset++] = (char)v;
-        return offset;
-    }
-
-    void putVar64(u64 v) {
-        _offset = putVar64(_offset, v);
-    }
-
-    std::size_t putVar64(std::size_t offset, u64 v) {
-        int iter = 0;
-        while (v > 0b111111111111111111111) {
-            _data[offset++] = (char)v | 0b10000000;
-            v >>= 7;
-        }
-        while (v > 0b01111111) {
-            _data[offset++] = (char)v | 0b10000000;
-            v >>= 7;
-        }
-        if (v > 0) {
-            _data[offset++] = (char)v;
-        }
-        return offset;
     }
 
     void put(const char* v, std::size_t len) {

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -9,7 +9,7 @@
 #include "os.h"
 #include <arpa/inet.h>
 #include <cstdint>
-#include <cstring>
+#include <string.h>
 
 class Buffer {
   private:
@@ -120,7 +120,7 @@ class Buffer {
     }
 
     void put(const char* v, std::size_t len) {
-        std::memcpy(_data + _offset, v, len);
+        memcpy(_data + _offset, v, len);
         _offset += len;
     }
 };

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -7,7 +7,6 @@
 #define _BUFFER_H
 
 #include "os.h"
-#include <cstdint>
 #include <string.h>
 
 class Buffer {

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -3,17 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef _BUFFER_H
+#define _BUFFER_H
+
+#include <cstring>
 #include <cstdint>
 
 constexpr int MAX_STRING_LENGTH = 8191;
 
 class Buffer {
   private:
-    size_t _offset;
-    char _data[0];
+    std::size_t _offset;
+    char* _data;
 
   protected:
-    Buffer() : _offset(0) {
+    Buffer(char* data) : _offset(0), _data(data) {
     }
 
   public:
@@ -21,12 +25,12 @@ class Buffer {
         return _data;
     }
 
-    int offset() const {
+    std::size_t offset() const {
         return _offset;
     }
 
-    int skip(int delta) {
-        int offset = _offset;
+    int skip(std::size_t delta) {
+        std::size_t offset = _offset;
         _offset = offset + delta;
         return offset;
     }
@@ -36,7 +40,7 @@ class Buffer {
     }
 
     void put(const char* v, u32 len) {
-        memcpy(_data + _offset, v, len);
+        std::memcpy(_data + _offset, v, len);
         _offset += (int)len;
     }
 
@@ -99,7 +103,7 @@ class Buffer {
         if (v == NULL) {
             put8(0);
         } else {
-            size_t len = strlen(v);
+            std::size_t len = strlen(v);
             putUtf8(v, len < MAX_STRING_LENGTH ? len : MAX_STRING_LENGTH);
         }
     }
@@ -116,11 +120,11 @@ class Buffer {
         put(v, len);
     }
 
-    void put8(int offset, char v) {
+    void put8(std::size_t offset, char v) {
         _data[offset] = v;
     }
 
-    void putVar32(int offset, u32 v) {
+    void putVar32(std::size_t offset, u32 v) {
         _data[offset] = v | 0x80;
         _data[offset + 1] = (v >> 7) | 0x80;
         _data[offset + 2] = (v >> 14) | 0x80;
@@ -128,3 +132,5 @@ class Buffer {
         _data[offset + 4] = (v >> 28);
     }
 };
+
+#endif // _BUFFER_H

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -46,20 +46,9 @@ class Buffer {
         _data[offset] = v;
     }
 
-    void put16(short v) {
-        *(short*)(_data + _offset) = htons(v);
-        _offset += 2;
-    }
-
-    void put32(int v) {
-        *(int*)(_data + _offset) = htonl(v);
-        _offset += 4;
-    }
-
-    void put64(u64 v) {
-        *(u64*)(_data + _offset) = OS::hton64(v);
-        _offset += 8;
-    }
+    virtual void put16(short v) = 0;
+    virtual void put32(int v) = 0;
+    virtual void put64(u64 v) = 0;
 
     void putFloat(float v) {
         union {
@@ -84,6 +73,24 @@ class Buffer {
     void put(const char* v, std::size_t len) {
         memcpy(_data + _offset, v, len);
         _offset += len;
+    }
+};
+
+class BigEndianBuffer : public Buffer {
+  public:
+    void put16(short v) override {
+        *(short*)(_data + _offset) = htons(v);
+        _offset += 2;
+    }
+
+    void put32(int v) override {
+        *(int*)(_data + _offset) = htonl(v);
+        _offset += 4;
+    }
+
+    void put64(u64 v) override {
+        *(u64*)(_data + _offset) = OS::hton64(v);
+        _offset += 8;
     }
 };
 

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -18,6 +18,15 @@ class Buffer {
     std::size_t _offset;
     char* _data;
 
+  protected:
+    void set(char v, std::size_t idx) {
+        _data[idx] = v;
+    }
+
+    std::size_t advanceOffset(std::size_t incr) {
+        return _offset += incr;
+    }
+
   public:
     Buffer(char* data) : _offset(0), _data(data) {
     }
@@ -141,14 +150,6 @@ class Buffer {
         put8(5); // STRING_ENCODING_LATIN1_BYTE_ARRAY
         putVar32(len);
         put(v, len);
-    }
-
-    void set(char v, std::size_t idx) {
-        _data[idx] = v;
-    }
-
-    std::size_t advanceOffset(std::size_t incr) {
-        return _offset += incr;
     }
 };
 

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -8,8 +8,8 @@
 
 #include "os.h"
 #include <arpa/inet.h>
-#include <cstring>
 #include <cstdint>
+#include <cstring>
 
 class Buffer {
   private:

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -7,16 +7,15 @@
 #define _BUFFER_H
 
 #include "os.h"
-#include <arpa/inet.h>
 #include <cstdint>
 #include <string.h>
 
 class Buffer {
   protected:
     std::size_t _offset;
-    char _data[0];
+    char* _data;
 
-    Buffer() : _offset(0) {
+    Buffer(char* data) : _offset(0), _data(data) {
     }
 
   public:
@@ -73,24 +72,6 @@ class Buffer {
     void put(const char* v, std::size_t len) {
         memcpy(_data + _offset, v, len);
         _offset += len;
-    }
-};
-
-class BigEndianBuffer : public Buffer {
-  public:
-    void put16(u16 v) override {
-        *(short*)(_data + _offset) = htons(v);
-        _offset += 2;
-    }
-
-    void put32(u32 v) override {
-        *(int*)(_data + _offset) = htonl(v);
-        _offset += 4;
-    }
-
-    void put64(u64 v) override {
-        *(u64*)(_data + _offset) = OS::hton64(v);
-        _offset += 8;
     }
 };
 

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cstdint>
+
+constexpr int MAX_STRING_LENGTH = 8191;
+
+class Buffer {
+  private:
+    size_t _offset;
+    char _data[0];
+
+  protected:
+    Buffer() : _offset(0) {
+    }
+
+  public:
+    const char* data() const {
+        return _data;
+    }
+
+    int offset() const {
+        return _offset;
+    }
+
+    int skip(int delta) {
+        int offset = _offset;
+        _offset = offset + delta;
+        return offset;
+    }
+
+    void reset() {
+        _offset = 0;
+    }
+
+    void put(const char* v, u32 len) {
+        memcpy(_data + _offset, v, len);
+        _offset += (int)len;
+    }
+
+    void put8(char v) {
+        _data[_offset++] = v;
+    }
+
+    void put16(short v) {
+        *(short*)(_data + _offset) = htons(v);
+        _offset += 2;
+    }
+
+    void put32(int v) {
+        *(int*)(_data + _offset) = htonl(v);
+        _offset += 4;
+    }
+
+    void put64(u64 v) {
+        *(u64*)(_data + _offset) = OS::hton64(v);
+        _offset += 8;
+    }
+
+    void putFloat(float v) {
+        union {
+            float f;
+            int i;
+        } u;
+
+        u.f = v;
+        put32(u.i);
+    }
+
+    void putVar32(u32 v) {
+        while (v > 0x7f) {
+            _data[_offset++] = (char)v | 0x80;
+            v >>= 7;
+        }
+        _data[_offset++] = (char)v;
+    }
+
+    void putVar64(u64 v) {
+        int iter = 0;
+        while (v > 0x1fffff) {
+            _data[_offset++] = (char)v | 0x80;
+            v >>= 7;
+            _data[_offset++] = (char)v | 0x80;
+            v >>= 7;
+            _data[_offset++] = (char)v | 0x80;
+            v >>= 7;
+            if (++iter == 3) return;
+        }
+        while (v > 0x7f) {
+            _data[_offset++] = (char)v | 0x80;
+            v >>= 7;
+        }
+        _data[_offset++] = (char)v;
+    }
+
+    void putUtf8(const char* v) {
+        if (v == NULL) {
+            put8(0);
+        } else {
+            size_t len = strlen(v);
+            putUtf8(v, len < MAX_STRING_LENGTH ? len : MAX_STRING_LENGTH);
+        }
+    }
+
+    void putUtf8(const char* v, u32 len) {
+        put8(3);
+        putVar32(len);
+        put(v, len);
+    }
+
+    void putByteString(const char* v, u32 len) {
+        put8(5); // STRING_ENCODING_LATIN1_BYTE_ARRAY
+        putVar32(len);
+        put(v, len);
+    }
+
+    void put8(int offset, char v) {
+        _data[offset] = v;
+    }
+
+    void putVar32(int offset, u32 v) {
+        _data[offset] = v | 0x80;
+        _data[offset + 1] = (v >> 7) | 0x80;
+        _data[offset + 2] = (v >> 14) | 0x80;
+        _data[offset + 3] = (v >> 21) | 0x80;
+        _data[offset + 4] = (v >> 28);
+    }
+};

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -6,6 +6,8 @@
 #ifndef _BUFFER_H
 #define _BUFFER_H
 
+#include "os.h"
+#include <arpa/inet.h>
 #include <cstring>
 #include <cstdint>
 
@@ -16,11 +18,10 @@ class Buffer {
     std::size_t _offset;
     char* _data;
 
-  protected:
+  public:
     Buffer(char* data) : _offset(0), _data(data) {
     }
 
-  public:
     const char* data() const {
         return _data;
     }

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -293,7 +293,7 @@ class Lookup {
     }
 };
 
-class FlightRecorderBuffer : public Buffer {
+class FlightRecorderBuffer : public BigEndianBuffer {
   public:
     void putVar32(u32 v) {
         while (v > 0b01111111) {

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -28,6 +28,7 @@
 #include "tsc.h"
 #include "userEvents.h"
 #include "vmStructs.h"
+#include "buffer.h"
 
 
 INCLUDE_HELPER_CLASS(JFR_SYNC_NAME, JFR_SYNC_CLASS, "one/profiler/JfrSync")
@@ -41,7 +42,6 @@ const int SMALL_BUFFER_SIZE = 1024;
 const int SMALL_BUFFER_LIMIT = SMALL_BUFFER_SIZE - 128;
 const int RECORDING_BUFFER_SIZE = 65536;
 const int RECORDING_BUFFER_LIMIT = RECORDING_BUFFER_SIZE - 4096;
-const int MAX_STRING_LENGTH = 8191;
 const u64 MAX_JLONG = 0x7fffffffffffffffULL;
 const u64 MIN_JLONG = 0x8000000000000000ULL;
 
@@ -291,125 +291,6 @@ class Lookup {
     }
 };
 
-
-class Buffer {
-  private:
-    int _offset;
-    char _data[0];
-
-  protected:
-    Buffer() : _offset(0) {
-    }
-
-  public:
-    const char* data() const {
-        return _data;
-    }
-
-    int offset() const {
-        return _offset;
-    }
-
-    int skip(int delta) {
-        int offset = _offset;
-        _offset = offset + delta;
-        return offset;
-    }
-
-    void reset() {
-        _offset = 0;
-    }
-
-    void put(const char* v, u32 len) {
-        memcpy(_data + _offset, v, len);
-        _offset += (int)len;
-    }
-
-    void put8(char v) {
-        _data[_offset++] = v;
-    }
-
-    void put16(short v) {
-        *(short*)(_data + _offset) = htons(v);
-        _offset += 2;
-    }
-
-    void put32(int v) {
-        *(int*)(_data + _offset) = htonl(v);
-        _offset += 4;
-    }
-
-    void put64(u64 v) {
-        *(u64*)(_data + _offset) = OS::hton64(v);
-        _offset += 8;
-    }
-
-    void putFloat(float v) {
-        union {
-            float f;
-            int i;
-        } u;
-
-        u.f = v;
-        put32(u.i);
-    }
-
-    void putVar32(u32 v) {
-        while (v > 0x7f) {
-            _data[_offset++] = (char)v | 0x80;
-            v >>= 7;
-        }
-        _data[_offset++] = (char)v;
-    }
-
-    void putVar64(u64 v) {
-        int iter = 0;
-        while (v > 0x1fffff) {
-            _data[_offset++] = (char)v | 0x80; v >>= 7;
-            _data[_offset++] = (char)v | 0x80; v >>= 7;
-            _data[_offset++] = (char)v | 0x80; v >>= 7;
-            if (++iter == 3) return;
-        }
-        while (v > 0x7f) {
-            _data[_offset++] = (char)v | 0x80;
-            v >>= 7;
-        }
-        _data[_offset++] = (char)v;
-    }
-
-    void putUtf8(const char* v) {
-        if (v == NULL) {
-            put8(0);
-        } else {
-            size_t len = strlen(v);
-            putUtf8(v, len < MAX_STRING_LENGTH ? len : MAX_STRING_LENGTH);
-        }
-    }
-
-    void putUtf8(const char* v, u32 len) {
-        put8(3);
-        putVar32(len);
-        put(v, len);
-    }
-
-    void putByteString(const char* v, u32 len) {
-        put8(5); // STRING_ENCODING_LATIN1_BYTE_ARRAY
-        putVar32(len);
-        put(v, len);
-    }
-
-    void put8(int offset, char v) {
-        _data[offset] = v;
-    }
-
-    void putVar32(int offset, u32 v) {
-        _data[offset] = v | 0x80;
-        _data[offset + 1] = (v >> 7) | 0x80;
-        _data[offset + 2] = (v >> 14) | 0x80;
-        _data[offset + 3] = (v >> 21) | 0x80;
-        _data[offset + 4] = (v >> 28);
-    }
-};
 
 class SmallBuffer : public Buffer {
   private:

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -296,6 +296,40 @@ class Lookup {
 
 class FlightRecorderBuffer : public Buffer {
   public:
+    void putVar32(u32 v) {
+        while (v > 0b01111111) {
+            _data[_offset++] = (char)v | 0b10000000;
+            v >>= 7;
+        }
+        _data[_offset++] = (char)v;
+    }
+
+    void putVar32(std::size_t offset, u32 v) {
+        _data[offset] = v | 0b10000000;
+        _data[offset + 1] = (v >> 7) | 0b10000000;
+        _data[offset + 2] = (v >> 14) | 0b10000000;
+        _data[offset + 3] = (v >> 21) | 0b10000000;
+        _data[offset + 4] = (v >> 28);
+    }
+
+    void putVar64(u64 v) {
+        int iter = 0;
+        while (v > 0b111111111111111111111) {
+            _data[_offset++] = (char)v | 0b10000000;
+            v >>= 7;
+            _data[_offset++] = (char)v | 0b10000000;
+            v >>= 7;
+            _data[_offset++] = (char)v | 0b10000000;
+            v >>= 7;
+            if (++iter == 3) return;
+        }
+        while (v > 0b01111111) {
+            _data[_offset++] = (char)v | 0b10000000;
+            v >>= 7;
+        }
+        _data[_offset++] = (char)v;
+    }
+
     void putUtf8(const char* v) {
         if (v == NULL) {
             put8(0);

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -322,14 +322,6 @@ class FlightRecorderBuffer : public Buffer {
         _data[_offset++] = (char)v;
     }
 
-    void putVar32(size_t offset, u32 v) {
-        _data[offset] = v | 0b10000000;
-        _data[offset + 1] = (v >> 7) | 0b10000000;
-        _data[offset + 2] = (v >> 14) | 0b10000000;
-        _data[offset + 3] = (v >> 21) | 0b10000000;
-        _data[offset + 4] = (v >> 28);
-    }
-
     void putVar64(u64 v) {
         int iter = 0;
         while (v > 0b111111111111111111111) {
@@ -367,6 +359,14 @@ class FlightRecorderBuffer : public Buffer {
         put8(STRING_ENCODING_LATIN1_BYTE_ARRAY);
         putVar32(len);
         put(v, len);
+    }
+
+    void putVar32(size_t offset, u32 v) {
+        _data[offset] = v | 0b10000000;
+        _data[offset + 1] = (v >> 7) | 0b10000000;
+        _data[offset + 2] = (v >> 14) | 0b10000000;
+        _data[offset + 3] = (v >> 21) | 0b10000000;
+        _data[offset + 4] = (v >> 28);
     }
 };
 

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -325,12 +325,9 @@ class FlightRecorderBuffer : public Buffer {
     void putVar64(u64 v) {
         int iter = 0;
         while (v > 0b111111111111111111111) {
-            _data[_offset++] = (char)v | 0b10000000;
-            v >>= 7;
-            _data[_offset++] = (char)v | 0b10000000;
-            v >>= 7;
-            _data[_offset++] = (char)v | 0b10000000;
-            v >>= 7;
+            _data[_offset++] = (char)v | 0b10000000; v >>= 7;
+            _data[_offset++] = (char)v | 0b10000000; v >>= 7;
+            _data[_offset++] = (char)v | 0b10000000; v >>= 7;
             if (++iter == 3) return;
         }
         while (v > 0b01111111) {

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -297,7 +297,7 @@ class SmallBuffer : public Buffer {
     char _buf[SMALL_BUFFER_SIZE - sizeof(Buffer)];
 
   public:
-    SmallBuffer() : Buffer() {
+    SmallBuffer() : Buffer(_buf) {
     }
 };
 
@@ -306,7 +306,7 @@ class RecordingBuffer : public Buffer {
     char _buf[RECORDING_BUFFER_SIZE - sizeof(Buffer)];
 
   public:
-    RecordingBuffer() : Buffer() {
+    RecordingBuffer() : Buffer(_buf) {
     }
 };
 

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -5,7 +5,6 @@
 
 #include <map>
 #include <string>
-#include <arpa/inet.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdint.h>

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -296,7 +296,7 @@ class SmallBuffer : public Buffer {
     char _buf[SMALL_BUFFER_SIZE - sizeof(Buffer)];
 
   public:
-    SmallBuffer() : Buffer(_buf) {
+    SmallBuffer() : Buffer() {
     }
 };
 
@@ -305,7 +305,7 @@ class RecordingBuffer : public Buffer {
     char _buf[RECORDING_BUFFER_SIZE - sizeof(Buffer)];
 
   public:
-    RecordingBuffer() : Buffer(_buf) {
+    RecordingBuffer() : Buffer() {
     }
 };
 

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -41,7 +41,7 @@ const int SMALL_BUFFER_SIZE = 1024;
 const int SMALL_BUFFER_LIMIT = SMALL_BUFFER_SIZE - 128;
 const int RECORDING_BUFFER_SIZE = 65536;
 const int RECORDING_BUFFER_LIMIT = RECORDING_BUFFER_SIZE - 4096;
-const std::size_t MAX_STRING_LENGTH = 8191;
+const size_t MAX_STRING_LENGTH = 8191;
 const u64 MAX_JLONG = 0x7fffffffffffffffULL;
 const u64 MIN_JLONG = 0x8000000000000000ULL;
 // https://github.com/openjdk/jmc/blob/master/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/SeekableInputStream.java
@@ -322,7 +322,7 @@ class FlightRecorderBuffer : public Buffer {
         _data[_offset++] = (char)v;
     }
 
-    void putVar32(std::size_t offset, u32 v) {
+    void putVar32(size_t offset, u32 v) {
         _data[offset] = v | 0b10000000;
         _data[offset + 1] = (v >> 7) | 0b10000000;
         _data[offset + 2] = (v >> 14) | 0b10000000;
@@ -352,18 +352,18 @@ class FlightRecorderBuffer : public Buffer {
         if (v == NULL) {
             put8(0);
         } else {
-            std::size_t len = strlen(v);
+            size_t len = strlen(v);
             putUtf8(v, len < MAX_STRING_LENGTH ? len : MAX_STRING_LENGTH);
         }
     }
 
-    void putUtf8(const char* v, std::size_t len) {
+    void putUtf8(const char* v, size_t len) {
         put8(STRING_ENCODING_UTF8_BYTE_ARRAY);
         putVar32(len);
         put(v, len);
     }
 
-    void putByteString(const char* v, std::size_t len) {
+    void putByteString(const char* v, size_t len) {
         put8(STRING_ENCODING_LATIN1_BYTE_ARRAY);
         putVar32(len);
         put(v, len);

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -9,7 +9,6 @@
 #include <fcntl.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
 #include <unistd.h>


### PR DESCRIPTION
### Description
In this PR I move `Buffer` out of `flightRecorder.cpp`.

### Related issues
#1188 

### Motivation and context
I plan to use `Buffer` as the base for a Protobuf writer.

### How has this been tested?
GHA

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
