### PR TITLE
[GHA] Disable matrix fail-fast

### DIFF
--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -29,7 +29,6 @@ jobs:
           if-no-files-found: error
   build-and-upload-binaries:
     strategy:
-      fail-fast: false
       matrix:
         include:
           - runson:

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -29,6 +29,7 @@ jobs:
           if-no-files-found: error
   build-and-upload-binaries:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - runson:
@@ -104,6 +105,7 @@ jobs:
   integration-tests:
     needs: build-and-upload-binaries
     strategy:
+      fail-fast: false
       matrix:
         runson:
           - display: linux-x64


### PR DESCRIPTION
### Description
In this PR I disable `fail-fast` error handling strategy in GHA matrix runs. This means all matrix entries will run until completion of integration tests, instead of being cancelled as soon as one fails.

Docs [here](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#handling-failures).

### Related issues
n/a

### Motivation and context
I felt some frustration about GHA cancelling all tests as soon as one of the matrix entries fails. Sometimes I just want to see all errors.

### How has this been tested?
https://github.com/fandreuz/async-profiler/actions/runs/15065133649/job/42348221865

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
