### PR TITLE
Poc unify hooks

### DIFF
--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -107,7 +107,7 @@ jobs:
             name: ubuntu-latest
         java-version: [11, 17, 21, 24]
         java-distribution: [corretto]
-        image: [public.ecr.aws/async-profiler/asprof-builder-x86:latest]
+        image: ["public.ecr.aws/async-profiler/asprof-builder-x86:latest"]
         include:
           - runson:
               display: macos-arm64

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -209,8 +209,20 @@ jobs:
           esac
           echo "jars_directory=jar_artifacts" >> $GITHUB_OUTPUT
           echo "release_directory=$(basename $(find . -type d -iname "async-profiler-*" ))" >> $GITHUB_OUTPUT
+      - name: Setup core dump collection
+        run: |
+          case "${{ matrix.runson.name }}" in
+            macos*)
+              sudo sysctl -w kern.corefile=core.%P
+              sudo sysctl kern.coredump=1
+            ;;
+            *)
+              echo "$GITHUB_WORKSPACE/core" | sudo tee /proc/sys/kernel/core_pattern
+            ;;
+          esac
       - name: Run integration tests
         run: |
+          ulimit -c unlimited
           mkdir -p build/jar
           cp ${{ steps.extract_artifact.outputs.jars_directory }}/* build/jar
           make build/test.jar
@@ -226,6 +238,16 @@ jobs:
           path: |
             build/test/logs/
             hs_err*.log
+      - name: Upload integration test core dump
+        uses: actions/upload-artifact@v4
+        # Always upload, especially after test failure
+        if: always()
+        with:
+          name: integration-test-core-dump-${{ matrix.runson.display }}-${{ matrix.java-version }}-${{ steps.set_variables.outputs.short_sha }}
+          retention-days: 1
+          if-no-files-found: ignore
+          path: |
+            core*
   publish-only-on-push:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     name: publish (nightly)

--- a/Makefile
+++ b/Makefile
@@ -226,13 +226,12 @@ build-test: build-test-cpp build-test-java
 
 build-test-libs:
 	@mkdir -p $(TEST_LIB_DIR)
-
-ifeq ($(OS_TAG),linux)
 	$(CC) -shared -fPIC -o $(TEST_LIB_DIR)/libreladyn.$(SOEXT) test/native/libs/reladyn.c
 	$(CC) -shared -fPIC -o $(TEST_LIB_DIR)/libcallsmalloc.$(SOEXT) test/native/libs/callsmalloc.c
 	$(CC) -shared -fPIC $(INCLUDES) -Isrc -o $(TEST_LIB_DIR)/libjnimalloc.$(SOEXT) test/native/libs/jnimalloc.c
 	$(CC) -shared -fPIC -o $(TEST_LIB_DIR)/libmalloc.$(SOEXT) test/native/libs/malloc.c
 
+ifeq ($(OS_TAG),linux)
 	$(CC) -c -shared -fPIC -o $(TEST_LIB_DIR)/vaddrdif.o test/native/libs/vaddrdif.c
 	$(LD) -N -shared -o $(TEST_LIB_DIR)/libvaddrdif.$(SOEXT) $(TEST_LIB_DIR)/vaddrdif.o -T test/native/libs/vaddrdif.ld
 

--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,7 @@ build-test-bins:
 	$(CC) -o $(TEST_BIN_DIR)/native_api -Isrc test/test/c/native_api.c -ldl
 	$(CC) -o $(TEST_BIN_DIR)/profile_with_dlopen -Isrc test/test/nativemem/profile_with_dlopen.c -ldl
 	$(CC) -o $(TEST_BIN_DIR)/preload_malloc -Isrc test/test/nativemem/preload_malloc.c -ldl
+	$(CC) -o $(TEST_BIN_DIR)/nativemem_known_lib_crash -Isrc test/test/nativemem/nativemem_known_lib_crash.c -ldl
 	$(CXX) -o $(TEST_BIN_DIR)/non_java_app $(INCLUDES) $(CPP_TEST_INCLUDES) test/test/nonjava/non_java_app.cpp $(LIBS)
 
 test-cpp: build-test-cpp

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -1,3 +1,3 @@
 FROM public.ecr.aws/docker/library/amazoncorretto:11-alpine-jdk
 
-RUN apk add --no-cache make gcc g++ linux-headers musl-dev util-linux patchelf gcovr bash tar
+RUN apk add --no-cache make gcc g++ linux-headers musl-dev util-linux patchelf gcovr bash tar sudo

--- a/docker/amazonlinux2.Dockerfile
+++ b/docker/amazonlinux2.Dockerfile
@@ -23,7 +23,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2
 COPY --from=0 /usr/local/bin/node /usr/local/bin/node
 RUN amazon-linux-extras enable python3.8 && \
     yum update -y && \
-    yum install -y gcc-c++ binutils make java-11-amazon-corretto patchelf tar python38 && \
+    yum install -y gcc-c++ libstdc++-static binutils make java-11-amazon-corretto patchelf tar sudo python38 && \
     yum clean all && \
     rm -rf /var/cache/yum && \
     python -m ensurepip && \
@@ -35,3 +35,4 @@ RUN cat <<EOF > /root/setup.sh
 mkdir -p "$NODE_JS_LOCATION/bin"
 ln --force --symbolic "/usr/local/bin/node" "$NODE_JS_LOCATION/bin/node"
 EOF
+RUN chmod +x /root/setup.sh

--- a/docker/amazonlinux2023.Dockerfile
+++ b/docker/amazonlinux2023.Dockerfile
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
 RUN yum update -y && \
-    yum install -y binutils findutils make tar gcc-c++ util-linux && \
+    yum install -y binutils findutils make tar gcc-c++ libstdc++-static util-linux sudo && \
     yum clean all && \
     rm -rf /var/cache/yum && \
     python3 -m ensurepip && \

--- a/src/asprof.cpp
+++ b/src/asprof.cpp
@@ -16,7 +16,7 @@ static asprof_error_t asprof_error(const char* msg) {
 
 
 DLLEXPORT void asprof_init() {
-    Hooks::init(true);
+    Hooks::init();
 }
 
 DLLEXPORT const char* asprof_error_str(asprof_error_t err) {

--- a/src/codeCache.cpp
+++ b/src/codeCache.cpp
@@ -268,7 +268,8 @@ void CodeCache::makeImportsPatchable() {
     if (max_import != NULL) {
         uintptr_t patch_start = (uintptr_t)min_import & ~OS::page_mask;
         uintptr_t patch_end = (uintptr_t)max_import & ~OS::page_mask;
-        mprotect((void*)patch_start, patch_end - patch_start + OS::page_size, PROT_READ | PROT_WRITE);
+        uintptr_t patch_size = patch_end - patch_start + OS::page_size;
+        OS::protect(patch_start, patch_size, PROT_READ | PROT_WRITE);
     }
 }
 

--- a/src/codeCache.cpp
+++ b/src/codeCache.cpp
@@ -29,12 +29,15 @@ size_t NativeFunc::usedMemory(const char* name) {
 
 
 CodeCache::CodeCache(const char* name, short lib_index, bool imports_patchable,
-                     const void* min_address, const void* max_address) {
+                     const void* min_address, const void* max_address,
+                     const char* image_base) {
     _name = NativeFunc::create(name, -1);
+
     _lib_index = lib_index;
     _min_address = min_address;
     _max_address = max_address;
     _text_base = NULL;
+    _image_base = image_base;
 
     _plt_offset = 0;
     _plt_size = 0;
@@ -234,7 +237,6 @@ void CodeCache::addImport(void** entry, const char* name) {
 void** CodeCache::findImport(ImportId id) {
     if (!_imports_patchable) {
         makeImportsPatchable();
-        _imports_patchable = true;
     }
     return _imports[id][PRIMARY];
 }
@@ -271,6 +273,8 @@ void CodeCache::makeImportsPatchable() {
         uintptr_t patch_size = patch_end - patch_start + OS::page_size;
         OS::protect(patch_start, patch_size, PROT_READ | PROT_WRITE);
     }
+
+    _imports_patchable = true;
 }
 
 void CodeCache::setDwarfTable(FrameDesc* table, int length) {

--- a/src/codeCache.h
+++ b/src/codeCache.h
@@ -100,13 +100,18 @@ class CodeBlob {
 
 class FrameDesc;
 
+class UnloadProtection;
+
 class CodeCache {
+  friend UnloadProtection;
+
   private:
     char* _name;
     short _lib_index;
     const void* _min_address;
     const void* _max_address;
     const char* _text_base;
+    const char* _image_base;
 
     unsigned int _plt_offset;
     unsigned int _plt_size;
@@ -131,7 +136,8 @@ class CodeCache {
               short lib_index = -1,
               bool imports_patchable = false,
               const void* min_address = NO_MIN_ADDRESS,
-              const void* max_address = NO_MAX_ADDRESS);
+              const void* max_address = NO_MAX_ADDRESS,
+              const char* image_base = NULL);
 
     ~CodeCache();
 
@@ -145,6 +151,10 @@ class CodeCache {
 
     const void* maxAddress() const {
         return _max_address;
+    }
+
+    const char* imageBase() const {
+        return _image_base;
     }
 
     bool contains(const void* address) const {

--- a/src/codeCache.h
+++ b/src/codeCache.h
@@ -107,6 +107,7 @@ class CodeCache {
 
   private:
     char* _name;
+    const char* _short_name;
     short _lib_index;
     const void* _min_address;
     const void* _max_address;
@@ -117,6 +118,7 @@ class CodeCache {
     unsigned int _plt_size;
 
     void** _imports[NUM_IMPORTS][NUM_IMPORT_TYPES];
+    void* _orig_import_references[NUM_IMPORTS][NUM_IMPORT_TYPES];
     bool _imports_patchable;
     bool _debug_symbols;
 
@@ -143,6 +145,10 @@ class CodeCache {
 
     const char* name() const {
         return _name;
+    }
+
+    const char* shortName() const {
+        return _short_name;
     }
 
     const void* minAddress() const {
@@ -200,6 +206,7 @@ class CodeCache {
     void addImport(void** entry, const char* name);
     void** findImport(ImportId id);
     void patchImport(ImportId, void* hook_func);
+    void unpatchImport(ImportId id);
 
     CodeBlob* findBlob(const char* name);
     CodeBlob* findBlobByAddress(const void* address);

--- a/src/cpuEngine.h
+++ b/src/cpuEngine.h
@@ -24,10 +24,10 @@ class CpuEngine : public Engine {
     static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext);
     static void signalHandlerJ9(int signo, siginfo_t* siginfo, void* ucontext);
 
-    static bool setupThreadHook();
+    static bool validateThreadHook();
 
-    void enableThreadHook();
-    void disableThreadHook();
+    void enableEngine();
+    void disableEngine();
 
     bool isResourceLimit(int err);
 

--- a/src/ctimer_linux.cpp
+++ b/src/ctimer_linux.cpp
@@ -74,7 +74,7 @@ void CTimer::destroyForThread(int tid) {
 }
 
 Error CTimer::check(Arguments& args) {
-    if (!setupThreadHook()) {
+    if (!validateThreadHook()) {
         return Error("Could not set pthread hook");
     }
 
@@ -88,7 +88,7 @@ Error CTimer::check(Arguments& args) {
 }
 
 Error CTimer::start(Arguments& args) {
-    if (!setupThreadHook()) {
+    if (!validateThreadHook()) {
         return Error("Could not set pthread hook");
     }
 
@@ -117,13 +117,12 @@ Error CTimer::start(Arguments& args) {
         OS::installSignalHandler(_signal, signalHandler);
     }
 
-    // Enable pthread hook before traversing currently running threads
-    enableThreadHook();
+    enableEngine();
 
     // Create timers for all existing threads
     int err = createForAllThreads();
     if (err) {
-        disableThreadHook();
+        disableEngine();
         J9StackTraces::stop();
         return Error("Failed to create CPU timer");
     }
@@ -131,7 +130,7 @@ Error CTimer::start(Arguments& args) {
 }
 
 void CTimer::stop() {
-    disableThreadHook();
+    disableEngine();
     for (int i = 0; i < _max_timers; i++) {
         destroyForThread(i);
     }

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -13,6 +13,7 @@
 #include "cpuEngine.h"
 #include "mallocTracer.h"
 #include "profiler.h"
+#include "symbols.h"
 
 
 #define ADDRESS_OF(sym) ({ \
@@ -182,6 +183,11 @@ void Hooks::patchLibraries() {
 
     while (_patched_libs < native_lib_count) {
         CodeCache* cc = (*native_libs)[_patched_libs++];
+        UnloadProtection handle(cc);
+        if (!handle.isValid()) {
+            continue;
+        }
+
         if (!cc->contains((const void*)Hooks::init)) {
             // Let libasyncProfiler always use original dlopen
             cc->patchImport(im_dlopen, (void*)dlopen_hook);

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -7,14 +7,13 @@
 #include <pthread.h>
 #include <signal.h>
 #include <stdlib.h>
-#include <string.h>
 #include "hooks.h"
 #include "asprof.h"
 #include "cpuEngine.h"
 #include "mallocTracer.h"
 #include "profiler.h"
 #include "symbols.h"
-
+#include "vmStructs.h"
 
 #define ADDRESS_OF(sym) ({ \
     void* addr = dlsym(RTLD_NEXT, #sym); \
@@ -88,83 +87,52 @@ static void pthread_exit_hook(void* retval) {
 }
 
 
-typedef void* (*dlopen_t)(const char*, int);
-static dlopen_t _orig_dlopen = NULL;
-
-static void* dlopen_hook_impl(const char* filename, int flags, bool patch) {
+static void* dlopen_hook_impl(const char* filename, int flags) {
     Log::debug("dlopen: %s", filename);
-    void* result = _orig_dlopen(filename, flags);
+    void* result = dlopen(filename, flags);
     if (result != NULL && filename != NULL) {
         Profiler::instance()->updateSymbols(false);
-        if (patch) {
-            Hooks::patchLibraries();
-        }
-        MallocTracer::installHooks();
+        Profiler::installHooks();
     }
     return result;
 }
 
-static void* dlopen_hook(const char* filename, int flags) {
-    return dlopen_hook_impl(filename, flags, true);
-}
-
-
-// LD_PRELOAD hooks
-
-extern "C" WEAK DLLEXPORT
-int pthread_create(pthread_t* thread, const pthread_attr_t* attr, ThreadFunc start_routine, void* arg) {
-    if (_orig_pthread_create == NULL) {
-        _orig_pthread_create = ADDRESS_OF(pthread_create);
+// Intercept thread creation/termination by patching libjvm's GOT entry for pthread_setspecific().
+// HotSpot puts VMThread into TLS on thread start, and resets on thread end.
+static int pthread_setspecific_hook(pthread_key_t key, const void* value) {
+    if (key != VMThread::key()) {
+        return pthread_setspecific(key, value);
     }
-    if (Hooks::initialized()) {
-        return pthread_create_hook(thread, attr, start_routine, arg);
-    }
-    return _orig_pthread_create(thread, attr, start_routine, arg);
-}
 
-extern "C" WEAK DLLEXPORT
-void pthread_exit(void* retval) {
-    if (_orig_pthread_exit == NULL) {
-        _orig_pthread_exit = ADDRESS_OF(pthread_exit);
+    if (pthread_getspecific(key) == value) {
+        return 0;
     }
-    if (Hooks::initialized()) {
-        pthread_exit_hook(retval);
+
+    if (value != NULL) {
+        int result = pthread_setspecific(key, value);
+        CpuEngine::onThreadStart();
+        return result;
     } else {
-        _orig_pthread_exit(retval);
+        CpuEngine::onThreadEnd();
+        return pthread_setspecific(key, value);
     }
-    abort();  // to suppress gcc warning
 }
-
-extern "C" WEAK DLLEXPORT
-void* dlopen(const char* filename, int flags) {
-    if (_orig_dlopen == NULL) {
-        _orig_dlopen = ADDRESS_OF(dlopen);
-    }
-    if (Hooks::initialized()) {
-        return dlopen_hook_impl(filename, flags, false);
-    }
-    return _orig_dlopen(filename, flags);
-}
-
 
 Mutex Hooks::_patch_lock;
 int Hooks::_patched_libs = 0;
 bool Hooks::_initialized = false;
 
-bool Hooks::init(bool attach) {
+bool Hooks::init() {
     if (!__sync_bool_compare_and_swap(&_initialized, false, true)) {
         return false;
     }
 
     Profiler::setupSignalHandlers();
 
-    if (attach) {
-        Profiler::instance()->updateSymbols(false);
-        _orig_pthread_create = ADDRESS_OF(pthread_create);
-        _orig_pthread_exit = ADDRESS_OF(pthread_exit);
-        _orig_dlopen = ADDRESS_OF(dlopen);
-        patchLibraries();
-    }
+    Profiler::instance()->updateSymbols(false);
+    _orig_pthread_create = ADDRESS_OF(pthread_create);
+    _orig_pthread_exit = ADDRESS_OF(pthread_exit);
+    patchLibraries();
 
     atexit(shutdown);
 
@@ -190,9 +158,27 @@ void Hooks::patchLibraries() {
 
         if (!cc->contains((const void*)Hooks::init)) {
             // Let libasyncProfiler always use original dlopen
-            cc->patchImport(im_dlopen, (void*)dlopen_hook);
+            cc->patchImport(im_dlopen, (void*)dlopen_hook_impl);
+            cc->patchImport(im_pthread_setspecific, (void*)pthread_setspecific_hook);
         }
         cc->patchImport(im_pthread_create, (void*)pthread_create_hook);
         cc->patchImport(im_pthread_exit, (void*)pthread_exit_hook);
+    }
+}
+
+void Hooks::unpatchLibraries() {
+    MutexLocker ml(_patch_lock);
+
+    CodeCacheArray* native_libs = Profiler::instance()->nativeLibs();
+    while (_patched_libs > 0) {
+        CodeCache* cc = (*native_libs)[--_patched_libs];
+        UnloadProtection handle(cc);
+        if (!handle.isValid()) {
+            continue;
+        }
+        cc->unpatchImport(im_dlopen);
+        cc->unpatchImport(im_pthread_setspecific);
+        cc->unpatchImport(im_pthread_create);
+        cc->unpatchImport(im_pthread_exit);
     }
 }

--- a/src/hooks.h
+++ b/src/hooks.h
@@ -16,9 +16,10 @@ class Hooks {
     static bool _initialized;
 
   public:
-    static bool init(bool attach);
+    static bool init();
     static void shutdown();
     static void patchLibraries();
+    static void unpatchLibraries();
 
     static bool initialized() {
         return _initialized;

--- a/src/mallocTracer.cpp
+++ b/src/mallocTracer.cpp
@@ -10,6 +10,7 @@
 #include "os.h"
 #include "profiler.h"
 #include "tsc.h"
+#include "symbols.h"
 #include <dlfcn.h>
 #include <string.h>
 
@@ -123,6 +124,11 @@ void MallocTracer::patchLibraries() {
 
         if (cc->contains((const void*)MallocTracer::initialize)) {
             // Let libasyncProfiler always use original allocation methods
+            continue;
+        }
+
+        UnloadProtection handle(cc);
+        if (!handle.isValid()) {
             continue;
         }
 

--- a/src/mallocTracer.h
+++ b/src/mallocTracer.h
@@ -57,6 +57,7 @@ class MallocTracer : public Engine {
         return _nofree;
     }
 
+    static void unpatchLibraries();
     static void recordMalloc(void* address, size_t size);
     static void recordFree(void* address);
 };

--- a/src/os.h
+++ b/src/os.h
@@ -103,6 +103,7 @@ class OS {
     static int createMemoryFile(const char* name);
     static void copyFile(int src_fd, int dst_fd, off_t offset, size_t size);
     static void freePageCache(int fd, off_t start_offset);
+    static int protect(uintptr_t start_address, uintptr_t size, int access);
 };
 
 #endif // _OS_H

--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -383,4 +383,8 @@ void OS::freePageCache(int fd, off_t start_offset) {
     posix_fadvise(fd, start_offset & ~page_mask, 0, POSIX_FADV_DONTNEED);
 }
 
+int OS::protect(uintptr_t start_address, uintptr_t size, int access) {
+    return mprotect((void*)start_address, size, access);
+}
+
 #endif // __linux__

--- a/src/os_macos.cpp
+++ b/src/os_macos.cpp
@@ -11,6 +11,7 @@
 #include <mach/mach_host.h>
 #include <mach/mach_time.h>
 #include <mach/processor_info.h>
+#include <mach/vm_map.h>
 #include <pthread.h>
 #include <sys/mman.h>
 #include <sys/sysctl.h>
@@ -359,6 +360,12 @@ void OS::copyFile(int src_fd, int dst_fd, off_t offset, size_t size) {
 
 void OS::freePageCache(int fd, off_t start_offset) {
     // Not supported on macOS
+}
+
+int OS::protect(uintptr_t start_address, uintptr_t size, int access) {
+    // If write permission append VM_PROT_COPY to access request
+    access = access | (access & PROT_WRITE ? VM_PROT_COPY : VM_PROT_NONE);
+    return vm_protect(mach_task_self(), start_address, size, 0, access);
 }
 
 #endif // __APPLE__

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -748,7 +748,7 @@ Error PerfEvents::check(Arguments& args) {
         return Error("Only arguments 1-4 can be counted");
     }
 
-    if (!setupThreadHook()) {
+    if (!validateThreadHook()) {
         return Error("Could not set pthread hook");
     }
 
@@ -801,7 +801,7 @@ Error PerfEvents::start(Arguments& args) {
         return Error("Only arguments 1-4 can be counted");
     }
 
-    if (!setupThreadHook()) {
+    if (!validateThreadHook()) {
         return Error("Could not set pthread hook");
     }
 
@@ -846,8 +846,7 @@ Error PerfEvents::start(Arguments& args) {
         OS::installSignalHandler(_signal, signalHandler);
     }
 
-    // Enable pthread hook before traversing currently running threads
-    enableThreadHook();
+    enableEngine();
 
     // Create perf_events for all existing threads
     int err = createForAllThreads();
@@ -865,7 +864,7 @@ Error PerfEvents::start(Arguments& args) {
 }
 
 void PerfEvents::stop() {
-    disableThreadHook();
+    disableEngine();
     for (int i = 0; i < _max_events; i++) {
         destroyForThread(i);
     }

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -97,11 +97,6 @@ class Profiler {
     const void* _call_stub_begin;
     const void* _call_stub_end;
 
-    // dlopen() hook support
-    void** _dlopen_entry;
-    static void* dlopen_hook(const char* filename, int flags);
-    void switchLibraryTrap(bool enable);
-
     Error installTraps(const char* begin, const char* end, bool nostop);
     void uninstallTraps();
 
@@ -152,6 +147,7 @@ class Profiler {
     void dumpCollapsed(Writer& out, Arguments& args);
     void dumpFlameGraph(Writer& out, Arguments& args, bool tree);
     void dumpText(Writer& out, Arguments& args);
+    static void uninstallHooks();
 
     static Profiler* const _instance;
 
@@ -173,8 +169,7 @@ class Profiler {
         _runtime_stubs("[stubs]"),
         _native_libs(),
         _call_stub_begin(NULL),
-        _call_stub_end(NULL),
-        _dlopen_entry(NULL) {
+        _call_stub_end(NULL) {
 
         for (int i = 0; i < CONCURRENCY_LEVEL; i++) {
             _calltrace_buffer[i] = NULL;
@@ -227,6 +222,7 @@ class Profiler {
     static void segvHandler(int signo, siginfo_t* siginfo, void* ucontext);
     static void wakeupHandler(int signo);
     static void setupSignalHandlers();
+    static void installHooks();
 
     // CompiledMethodLoad is also needed to enable DebugNonSafepoints info by default
     static void JNICALL CompiledMethodLoad(jvmtiEnv* jvmti, jmethodID method,

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -25,4 +25,18 @@ class Symbols {
     }
 };
 
+class UnloadProtection {
+  private:
+    void* _lib_handle;
+    bool _valid;
+
+  public:
+    UnloadProtection(const CodeCache *cc);
+    ~UnloadProtection();
+
+    UnloadProtection& operator=(const UnloadProtection& other) = delete;
+
+    bool isValid() const { return _valid; }
+};
+
 #endif // _SYMBOLS_H

--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -861,6 +861,9 @@ UnloadProtection::UnloadProtection(const CodeCache *cc) {
         return;
     }
 
+    if (cc->name() == NULL) {
+        return;
+    }
     const char* stripped_name;
     size_t name_len = strlen(cc->name());
     if (hasDeletedSuffix(cc->name(), name_len)) {

--- a/src/symbols_macos.cpp
+++ b/src/symbols_macos.cpp
@@ -178,7 +178,7 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
             break;
         }
 
-        CodeCache* cc = new CodeCache(path, count, true);
+        CodeCache* cc = new CodeCache(path, count);
         UnloadProtection handle(cc);
         if (handle.isValid()) {
             MachOParser parser(cc, image_base);

--- a/src/symbols_macos.cpp
+++ b/src/symbols_macos.cpp
@@ -13,7 +13,7 @@
 #include <mach-o/nlist.h>
 #include "symbols.h"
 #include "log.h"
-
+#include <vector>
 
 class MachOParser {
   private:
@@ -24,15 +24,15 @@ class MachOParser {
         return (const char*)base + offset;
     }
 
-    const section_64* findSymbolPtrSection(const segment_command_64* sc) {
+    void findSymbolPtrSection(const segment_command_64* sc, std::vector<const section_64*>& symbol_sections) {
         const section_64* section = (const section_64*)add(sc, sizeof(segment_command_64));
         for (uint32_t i = 0; i < sc->nsects; i++) {
-            if (strcmp(section->sectname, "__la_symbol_ptr") == 0) {
-                return section;
+            uint32_t section_type = section->flags & SECTION_TYPE;
+            if (section_type == S_LAZY_SYMBOL_POINTERS || section_type == S_NON_LAZY_SYMBOL_POINTERS) {
+                symbol_sections.push_back(section);
             }
             section++;
         }
-        return NULL;
     }
 
     void loadSymbols(const symtab_command* symtab, const char* text_base, const char* link_base) {
@@ -54,19 +54,22 @@ class MachOParser {
         _cc->setDebugSymbols(debug_symbols);
     }
 
-    void loadImports(const symtab_command* symtab, const dysymtab_command* dysymtab,
-                     const section_64* la_symbol_ptr, const char* link_base) {
-        const nlist_64* sym = (const nlist_64*)add(link_base, symtab->symoff);
-        const char* str_table = add(link_base, symtab->stroff);
+    void loadImports(const section_64* symbol_section, const char* text_base, const nlist_64* symbols, 
+                     const char* string_table, const uint32_t* dynamic_symbols) {
+        const uint32_t* dynamic_symbol_indices = dynamic_symbols + symbol_section->reserved1;
+        void** dynamic_symbol_references = (void**)((uintptr_t)text_base + symbol_section->addr);
 
-        const uint32_t* isym = (const uint32_t*)add(link_base, dysymtab->indirectsymoff) + la_symbol_ptr->reserved1;
-        uint32_t isym_count = la_symbol_ptr->size / sizeof(void*);
-        void** slot = (void**)add(_image_base, la_symbol_ptr->addr);
-
-        for (uint32_t i = 0; i < isym_count; i++) {
-            const char* name = str_table + sym[isym[i]].n_un.n_strx;
-            if (name[0] == '_') name++;
-            _cc->addImport(&slot[i], name);
+        for (uint64_t i = 0; i < symbol_section->size / sizeof(void*); i++) {
+            const uint32_t dynamic_symbol_index = dynamic_symbol_indices[i];
+            if (dynamic_symbol_index == INDIRECT_SYMBOL_ABS || dynamic_symbol_index == INDIRECT_SYMBOL_LOCAL 
+                    || dynamic_symbol_index == (INDIRECT_SYMBOL_LOCAL | INDIRECT_SYMBOL_ABS)) {
+                continue;
+            }
+            const char* symbol_name = string_table + symbols[dynamic_symbol_index].n_un.n_strx;
+            if (symbol_name[0] == '_' && symbol_name[1] != '\0') {
+                // first character in symbol name is always '_' so it's skipped
+                _cc->addImport(&dynamic_symbol_references[i], symbol_name + 1);
+            }
         }
     }
 
@@ -85,40 +88,49 @@ class MachOParser {
         const char* UNDEFINED = (const char*)-1;
         const char* text_base = UNDEFINED;
         const char* link_base = UNDEFINED;
-        const section_64* la_symbol_ptr = NULL;
-        const symtab_command* symtab = NULL;
+        const symtab_command* symbol_table = NULL;
+        const dysymtab_command* dynamic_symbol_table = NULL;
+        std::vector<const section_64*> symbol_sections;
 
         for (uint32_t i = 0; i < header->ncmds; i++) {
             if (lc->cmd == LC_SEGMENT_64) {
                 const segment_command_64* sc = (const segment_command_64*)lc;
-                if ((sc->initprot & 4) != 0) {
-                    if (text_base == UNDEFINED || strcmp(sc->segname, "__TEXT") == 0) {
-                        text_base = (const char*)_image_base - sc->vmaddr;
-                        _cc->setTextBase(text_base);
-                        _cc->updateBounds(_image_base, add(_image_base, sc->vmsize));
-                    }
-                } else if ((sc->initprot & 7) == 1) {
-                    if (link_base == UNDEFINED || strcmp(sc->segname, "__LINKEDIT") == 0) {
-                        link_base = text_base + sc->vmaddr - sc->fileoff;
-                    }
-                } else if ((sc->initprot & 2) != 0) {
-                    if (strcmp(sc->segname, "__DATA") == 0) {
-                        la_symbol_ptr = findSymbolPtrSection(sc);
-                    }
+                if (strcmp(sc->segname, SEG_TEXT) == 0) {
+                    text_base = (const char*)_image_base - sc->vmaddr;
+                    _cc->setTextBase(text_base);
+                    _cc->updateBounds(_image_base, add(_image_base, sc->vmsize));
+                } else if (strcmp(sc->segname, SEG_LINKEDIT) == 0) {
+                    link_base = text_base + sc->vmaddr - sc->fileoff;
+                } else if (strcmp(sc->segname, "__DATA_CONST") == 0 || strcmp(sc->segname, SEG_DATA) == 0) {
+                    findSymbolPtrSection(sc, symbol_sections);
                 }
             } else if (lc->cmd == LC_SYMTAB) {
-                symtab = (const symtab_command*)lc;
-                if (text_base != UNDEFINED && link_base != UNDEFINED) {
-                    loadSymbols(symtab, text_base, link_base);
-                }
+                symbol_table = (const symtab_command*)lc;
             } else if (lc->cmd == LC_DYSYMTAB) {
-                if (la_symbol_ptr != NULL && symtab != NULL && link_base != UNDEFINED) {
-                    loadImports(symtab, (const dysymtab_command*)lc, la_symbol_ptr, link_base);
-                }
+                dynamic_symbol_table = (const dysymtab_command*)lc;
             }
             lc = (const load_command*)add(lc, lc->cmdsize);
         }
 
+        // can't parse symbol table
+        if (text_base == UNDEFINED || link_base == UNDEFINED || symbol_table == NULL) {
+            return true;
+        }
+        loadSymbols(symbol_table, text_base, link_base);
+
+        // can't parse dynamic symbols table
+        if (dynamic_symbol_table == NULL || dynamic_symbol_table->nindirectsyms == 0 || symbol_sections.empty()) {
+            return true;
+        }
+
+        nlist_64* symbols = (nlist_64*)(link_base + symbol_table->symoff);
+        uint32_t* dynamic_symbols = (uint32_t*)(link_base + dynamic_symbol_table->indirectsymoff);
+        char* string_table = (char*)(link_base + symbol_table->stroff);
+
+        // Load imports for library
+        for (auto symbol_section : symbol_sections) {
+            loadImports(symbol_section, text_base, symbols, string_table, dynamic_symbols);
+        }
         return true;
     }
 };
@@ -138,6 +150,8 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
 
     for (uint32_t i = 0; i < images; i++) {
         const mach_header* image_base = _dyld_get_image_header(i);
+        const char* path = _dyld_get_image_name(i);
+
         if (image_base == NULL || !_parsed_libraries.insert(image_base).second) {
             continue;  // the library was already parsed
         }
@@ -151,15 +165,13 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
             break;
         }
 
-        const char* path = _dyld_get_image_name(i);
-
         // Protect the library from unloading while parsing symbols
         void* handle = dlopen(path, RTLD_LAZY | RTLD_NOLOAD);
         if (handle == NULL) {
             continue;
         }
 
-        CodeCache* cc = new CodeCache(path, count, true);
+        CodeCache* cc = new CodeCache(path, count);
         MachOParser parser(cc, image_base);
         if (!parser.parse()) {
             Log::warn("Could not parse symbols from %s", path);

--- a/src/symbols_macos.cpp
+++ b/src/symbols_macos.cpp
@@ -15,6 +15,19 @@
 #include "log.h"
 #include <vector>
 
+UnloadProtection::UnloadProtection(const CodeCache *cc) {
+    // Protect library from unloading while parsing in-memory ELF program headers.
+    // Also, dlopen() ensures the library is fully loaded.
+    _lib_handle = dlopen(cc->name(), RTLD_LAZY | RTLD_NOLOAD);
+    _valid = _lib_handle != NULL;
+}
+
+UnloadProtection::~UnloadProtection() {
+    if (_lib_handle != NULL) {
+        dlclose(_lib_handle);
+    }
+}
+
 class MachOParser {
   private:
     CodeCache* _cc;
@@ -54,14 +67,14 @@ class MachOParser {
         _cc->setDebugSymbols(debug_symbols);
     }
 
-    void loadImports(const section_64* symbol_section, const char* text_base, const nlist_64* symbols, 
+    void loadImports(const section_64* symbol_section, const char* text_base, const nlist_64* symbols,
                      const char* string_table, const uint32_t* dynamic_symbols) {
         const uint32_t* dynamic_symbol_indices = dynamic_symbols + symbol_section->reserved1;
         void** dynamic_symbol_references = (void**)((uintptr_t)text_base + symbol_section->addr);
 
         for (uint64_t i = 0; i < symbol_section->size / sizeof(void*); i++) {
             const uint32_t dynamic_symbol_index = dynamic_symbol_indices[i];
-            if (dynamic_symbol_index == INDIRECT_SYMBOL_ABS || dynamic_symbol_index == INDIRECT_SYMBOL_LOCAL 
+            if (dynamic_symbol_index == INDIRECT_SYMBOL_ABS || dynamic_symbol_index == INDIRECT_SYMBOL_LOCAL
                     || dynamic_symbol_index == (INDIRECT_SYMBOL_LOCAL | INDIRECT_SYMBOL_ABS)) {
                 continue;
             }
@@ -165,21 +178,16 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
             break;
         }
 
-        // Protect the library from unloading while parsing symbols
-        void* handle = dlopen(path, RTLD_LAZY | RTLD_NOLOAD);
-        if (handle == NULL) {
-            continue;
+        CodeCache* cc = new CodeCache(path, count, true);
+        UnloadProtection handle(cc);
+        if (handle.isValid()) {
+            MachOParser parser(cc, image_base);
+            if (!parser.parse()) {
+                Log::warn("Could not parse symbols from %s", path);
+            }
+            cc->sort();
+            array->add(cc);
         }
-
-        CodeCache* cc = new CodeCache(path, count);
-        MachOParser parser(cc, image_base);
-        if (!parser.parse()) {
-            Log::warn("Could not parse symbols from %s", path);
-        }
-        dlclose(handle);
-
-        cc->sort();
-        array->add(cc);
     }
 }
 

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -48,8 +48,8 @@ void Trap::pair(Trap& second) {
 // Patch instruction at the entry point
 bool Trap::patch(instruction_t insn) {
     if (_unprotect) {
-        int prot = WX_MEMORY ? (PROT_READ | PROT_WRITE) : (PROT_READ | PROT_WRITE | PROT_EXEC);
-        if (mprotect((void*)(_entry & -OS::page_size), OS::page_size, prot) != 0) {
+        int prot = PROT_READ | PROT_WRITE | (WX_MEMORY ? 0 : PROT_EXEC);
+        if (OS::protect((_entry & -OS::page_size), OS::page_size, prot) != 0) {
             return false;
         }
     }
@@ -58,7 +58,7 @@ bool Trap::patch(instruction_t insn) {
     flushCache(_entry);
 
     if (_protect) {
-        mprotect((void*)(_entry & -OS::page_size), OS::page_size, PROT_READ | PROT_EXEC);
+        OS::protect((_entry & -OS::page_size), OS::page_size, PROT_READ | PROT_EXEC);
     }
     return true;
 }

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -354,10 +354,10 @@ void VM::applyPatch(char* func, const char* patch, const char* end_patch) {
     uintptr_t start_page = (uintptr_t)func & ~OS::page_mask;
     uintptr_t end_page = ((uintptr_t)func + size + OS::page_mask) & ~OS::page_mask;
 
-    if (mprotect((void*)start_page, end_page - start_page, PROT_READ | PROT_WRITE | PROT_EXEC) == 0) {
+    if (OS::protect(start_page, end_page - start_page, PROT_READ | PROT_WRITE | PROT_EXEC) == 0) {
         memcpy(func, patch, size);
         __builtin___clear_cache(func, func + size);
-        mprotect((void*)start_page, end_page - start_page, PROT_READ | PROT_EXEC);
+        OS::protect(start_page, end_page - start_page, PROT_READ | PROT_WRITE);
     }
 }
 

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -10,6 +10,7 @@
 #include "vmEntry.h"
 #include "arguments.h"
 #include "asprof.h"
+#include "hooks.h"
 #include "j9Ext.h"
 #include "j9ObjectSampler.h"
 #include "javaApi.h"
@@ -296,6 +297,9 @@ bool VM::init(JavaVM* vm, bool attach) {
     } else {
         _jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL);
     }
+
+    // Initialize hook installation
+    Hooks::init();
 
     return true;
 }

--- a/src/zInit.cpp
+++ b/src/zInit.cpp
@@ -25,7 +25,7 @@ class LateInitializer {
 
         if (!checkJvmLoaded()) {
             const char* command = getenv("ASPROF_COMMAND");
-            if (command != NULL && Hooks::init(false)) {
+            if (command != NULL && Hooks::init()) {
                 startProfiler(command);
             }
         }

--- a/test/test/cpu/CpuTests.java
+++ b/test/test/cpu/CpuTests.java
@@ -14,7 +14,6 @@ import one.profiler.test.Os;
 import one.profiler.test.Output;
 import one.profiler.test.Test;
 import one.profiler.test.TestProcess;
-import one.profiler.test.Jvm;
 
 public class CpuTests {
 

--- a/test/test/jfr/JfrTests.java
+++ b/test/test/jfr/JfrTests.java
@@ -83,16 +83,12 @@ public class JfrTests {
 
     /**
      * Test to validate profiling output with "--all" flag without event override.
-     * We can't run this test in macOS x64 due to: https://github.com/async-profiler/async-profiler/issues/1193.
-     * Once it is fixed, we can remove the `os` and `arch` arguments.
      *
      * @param p The test process to profile with.
      * @throws Exception Any exception thrown during profiling JFR output parsing.
      */
-    @Test(mainClass = JfrMutliModeProfiling.class, agentArgs = "start,all,file=%f.jfr", os = Os.LINUX)
-    @Test(mainClass = JfrMutliModeProfiling.class, agentArgs = "start,all,alloc=100,file=%f.jfr", os = Os.LINUX)
-    @Test(mainClass = JfrMutliModeProfiling.class, agentArgs = "start,all,file=%f.jfr", os = Os.MACOS, arch = Arch.ARM64)
-    @Test(mainClass = JfrMutliModeProfiling.class, agentArgs = "start,all,lock=10ms,file=%f.jfr", os = Os.MACOS, arch = Arch.ARM64)
+    @Test(mainClass = JfrMutliModeProfiling.class, agentArgs = "start,all,file=%f.jfr")
+    @Test(mainClass = JfrMutliModeProfiling.class, agentArgs = "start,all,alloc=100,file=%f.jfr")
     public void allModeNoEventOverride(TestProcess p) throws Exception {
         p.waitForExit();
         assert p.exitCode() == 0;
@@ -117,14 +113,11 @@ public class JfrTests {
 
     /**
      * Test to validate profiling output with "--all" flag with event override
-     * We can't run this test in macOS x64 due to: https://github.com/async-profiler/async-profiler/issues/1193.
-     * Once it is fixed, we can remove the `os` and `arch` arguments.
      *
      * @param p The test process to profile with.
      * @throws Exception Any exception thrown during profiling JFR output parsing.
      */
-    @Test(mainClass = JfrMutliModeProfiling.class, agentArgs = "start,all,event=java.util.Properties.getProperty,alloc=100,file=%f.jfr", os = Os.LINUX)
-    @Test(mainClass = JfrMutliModeProfiling.class, agentArgs = "start,all,event=java.util.Properties.getProperty,alloc=100,file=%f.jfr", os = Os.MACOS, arch = Arch.ARM64)
+    @Test(mainClass = JfrMutliModeProfiling.class, agentArgs = "start,all,event=java.util.Properties.getProperty,alloc=100,file=%f.jfr")
     public void allModeEventOverride(TestProcess p) throws Exception {
         p.waitForExit();
         assert p.exitCode() == 0;

--- a/test/test/nativemem/CallsAllNoLeak.java
+++ b/test/test/nativemem/CallsAllNoLeak.java
@@ -13,7 +13,7 @@ public class CallsAllNoLeak {
     private static final int CALLOC_SIZE = 2000147;
     private static final int REALLOC_SIZE = 30000170;
     private static final int POSIX_MEMALIGN_SIZE = 30000193;
-    private static final int ALIGNED_ALLOC_SIZE = 30002009;
+    private static final int ALIGNED_ALLOC_SIZE = 2*1024*1024;
 
     private static void doMallocRealloc() {
         long ptr = Native.malloc(MALLOC_SIZE);

--- a/test/test/nativemem/NativememTests.java
+++ b/test/test/nativemem/NativememTests.java
@@ -199,4 +199,10 @@ public class NativememTests {
 
         Assert.isEqual(sizeCounts.getOrDefault((long) MALLOC_SIZE, 0L), 1);
     }
+
+    @Test(os = Os.LINUX, sh = "%testbin/nativemem_known_lib_crash %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "dlopen_first")
+    public void nativememKnownLibCrash(TestProcess p) throws Exception {
+        p.waitForExit();
+        Assert.isEqual(p.exitCode(), 0);
+    }
 }

--- a/test/test/nativemem/NativememTests.java
+++ b/test/test/nativemem/NativememTests.java
@@ -26,9 +26,9 @@ public class NativememTests {
     private static final int CALLOC_SIZE = 2000147;
     private static final int REALLOC_SIZE = 30000170;
     private static final int POSIX_MEMALIGN_SIZE = 30000193;
-    private static final int ALIGNED_ALLOC_SIZE = 30002009;
+    private static final int ALIGNED_ALLOC_SIZE = 2*1024*1024;
 
-    @Test(mainClass = CallsMallocCalloc.class, os = Os.LINUX, agentArgs = "start,nativemem,total,collapsed,file=%f", args = "once")
+    @Test(mainClass = CallsMallocCalloc.class, agentArgs = "start,nativemem,total,collapsed,file=%f", args = "once")
     public void canAgentTraceMallocCalloc(TestProcess p) throws Exception {
         Output out = p.waitForExit("%f");
 
@@ -36,14 +36,14 @@ public class NativememTests {
         Assert.isEqual(out.samples("Java_test_nativemem_Native_calloc"), CALLOC_SIZE);
     }
 
-    @Test(mainClass = CallsMallocCalloc.class, os = Os.LINUX, agentArgs = "start,nativemem=10000000,total,collapsed,file=%f", args = "once")
+    @Test(mainClass = CallsMallocCalloc.class, agentArgs = "start,nativemem=10000000,total,collapsed,file=%f", args = "once")
     public void canAgentFilterMallocCalloc(TestProcess p) throws Exception {
         Output out = p.waitForExit("%f");
         Assert.isEqual(out.samples("Java_test_nativemem_Native_malloc"), 0);
         Assert.isEqual(out.samples("Java_test_nativemem_Native_calloc"), 0);
     }
 
-    @Test(mainClass = CallsMallocCalloc.class, os = Os.LINUX)
+    @Test(mainClass = CallsMallocCalloc.class)
     public void canAsprofTraceMallocCalloc(TestProcess p) throws Exception {
         Output out = p.profile("-e nativemem --total -o collapsed -d 2");
         long samplesMalloc = out.samples("Java_test_nativemem_Native_malloc");
@@ -55,7 +55,7 @@ public class NativememTests {
         Assert.isEqual(samplesCalloc % CALLOC_SIZE, 0);
     }
 
-    @Test(mainClass = CallsRealloc.class, agentArgs = "start,nativemem,total,collapsed,file=%f", args = "once", os = Os.LINUX)
+    @Test(mainClass = CallsRealloc.class, agentArgs = "start,nativemem,total,collapsed,file=%f", args = "once")
     public void canAgentTraceRealloc(TestProcess p) throws Exception {
         Output out = p.waitForExit("%f");
 
@@ -63,7 +63,7 @@ public class NativememTests {
         Assert.isEqual(out.samples("Java_test_nativemem_Native_realloc"), REALLOC_SIZE);
     }
 
-    @Test(mainClass = CallsRealloc.class, os = Os.LINUX)
+    @Test(mainClass = CallsRealloc.class)
     public void canAsprofTraceRealloc(TestProcess p) throws Exception {
         Output out = p.profile("-e nativemem --total -o collapsed -d 2");
         long samplesMalloc = out.samples("Java_test_nativemem_Native_malloc");
@@ -75,7 +75,7 @@ public class NativememTests {
         Assert.isEqual(samplesRealloc % REALLOC_SIZE, 0);
     }
 
-    @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX)
+    @Test(mainClass = CallsAllNoLeak.class)
     public void canAsprofTraceAllNoLeak(TestProcess p) throws Exception {
         Output out = p.profile("-e nativemem --total -o collapsed -d 2");
 
@@ -146,17 +146,17 @@ public class NativememTests {
         return sizeCounts;
     }
 
-    @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX, args = "once", agentArgs = "start,nativemem,file=%f.jfr")
-    @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX, args = "once", agentArgs = "start,nativemem,total,file=%f.jfr")
-    @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX, args = "once", agentArgs = "start,nativemem=1,total,file=%f.jfr")
-    @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX, args = "once", agentArgs = "start,nativemem=10M,total,file=%f.jfr")
-    @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX, args = "once", agentArgs = "start,cpu,alloc,nativemem,total,file=%f.jfr")
+    @Test(mainClass = CallsAllNoLeak.class, args = "once", agentArgs = "start,nativemem,file=%f.jfr")
+    @Test(mainClass = CallsAllNoLeak.class, args = "once", agentArgs = "start,nativemem,total,file=%f.jfr")
+    @Test(mainClass = CallsAllNoLeak.class, args = "once", agentArgs = "start,nativemem=1,total,file=%f.jfr")
+    @Test(mainClass = CallsAllNoLeak.class, args = "once", agentArgs = "start,nativemem=10M,total,file=%f.jfr")
+    @Test(mainClass = CallsAllNoLeak.class, args = "once", agentArgs = "start,cpu,alloc,nativemem,total,file=%f.jfr")
     public void jfrNoLeaks(TestProcess p) throws Exception {
         assertNoLeaks(p);
     }
 
-    @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX, args = "once", inputs = "nofree", agentArgs = "start,nativemem,nofree,file=%f.jfr")
-    @Test(mainClass = CallsAllNoLeak.class, os = Os.LINUX, args = "once", inputs = "nofree", agentArgs = "start,cpu,alloc,nativemem,nofree,total,file=%f.jfr")
+    @Test(mainClass = CallsAllNoLeak.class, args = "once", inputs = "nofree", agentArgs = "start,nativemem,nofree,file=%f.jfr")
+    @Test(mainClass = CallsAllNoLeak.class, args = "once", inputs = "nofree", agentArgs = "start,cpu,alloc,nativemem,nofree,total,file=%f.jfr")
     public void jfrNoFree(TestProcess p) throws Exception {
         assertNoLeaks(p);
     }
@@ -179,10 +179,10 @@ public class NativememTests {
         Assert.isEqual(sizeCounts.getOrDefault((long) MALLOC_DYN_SIZE, 0L), 1);
     }
 
-    @Test(os = Os.LINUX, sh = "%testbin/profile_with_dlopen dlopen_first %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "dlopen_first")
-    @Test(os = Os.LINUX, sh = "%testbin/profile_with_dlopen profile_first %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "profile_first")
-    @Test(os = Os.LINUX, sh = "LD_PRELOAD=%lib %testbin/profile_with_dlopen dlopen_first %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "dlopen_first+LD_PRELOAD")
-    @Test(os = Os.LINUX, sh = "LD_PRELOAD=%lib %testbin/profile_with_dlopen profile_first %f.jfr", output = true, env = {"LD_LIBRARY_PATH=build/test/lib:build/lib"}, nameSuffix = "profile_first+LD_PRELOAD")
+    @Test(sh = "%testbin/profile_with_dlopen dlopen_first %f.jfr", nameSuffix = "dlopen_first")
+    @Test(sh = "%testbin/profile_with_dlopen profile_first %f.jfr", nameSuffix = "profile_first")
+    @Test(os = Os.LINUX, sh = "LD_PRELOAD=%lib %testbin/profile_with_dlopen dlopen_first %f.jfr", nameSuffix = "dlopen_first+LD_PRELOAD")
+    @Test(os = Os.LINUX, sh = "LD_PRELOAD=%lib %testbin/profile_with_dlopen profile_first %f.jfr", nameSuffix = "profile_first+LD_PRELOAD")
     public void dlopenCustomLib(TestProcess p) throws Exception {
         Map<Long, Long> sizeCounts = assertNoLeaks(p);
 

--- a/test/test/nativemem/nativemem_known_lib_crash.c
+++ b/test/test/nativemem/nativemem_known_lib_crash.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "asprof.h"
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define ASSERT_NO_DLERROR(sym)            \
+    if (sym == NULL) {                    \
+        err = dlerror();                  \
+        if (err != NULL) {                \
+            fprintf(stderr, "%s\n", err); \
+            exit(1);                      \
+        }                                 \
+    }                                     \
+
+#define ASSERT_NO_ASPROF_ERR(err)                       \
+    if (err != NULL) {                                  \
+        fprintf(stderr, "%s\n", asprof_error_str(err)); \
+        exit(1);                                        \
+    }
+
+void outputCallback(const char* buffer, size_t size) {
+    fwrite(buffer, sizeof(char), size, stdout);
+}
+
+/*
+Idea of the test (the behavior applies as of 0c72a8d):
+- We load libcallsmalloc.so
+- We start AP without nativemem mode
+    => 'malloc' is not hooked
+- We stop AP
+- We dlclose libcallsmalloc.so
+    => Memory region(s) for libcallsmalloc.so are now unmapped.
+- We restart AP in nativemem mode 
+    => we try to hook 'malloc'
+- AP remembers the previous instance libcallsmalloc.so
+    => AP tries to patch an inaccessible memory location
+    => SEGFAULT
+*/
+int main() {
+    char *err;
+
+    void* libprof = dlopen("libasyncProfiler.so", RTLD_NOW);
+    ASSERT_NO_DLERROR(libprof);
+
+    asprof_init_t asprof_init = (asprof_init_t)dlsym(libprof, "asprof_init");
+    ASSERT_NO_DLERROR(asprof_init);
+    asprof_init();
+
+    asprof_execute_t asprof_execute = (asprof_execute_t)dlsym(libprof, "asprof_execute");
+    ASSERT_NO_DLERROR(asprof_execute);
+
+    asprof_error_str_t asprof_error_str = (asprof_error_str_t)dlsym(libprof, "asprof_error_str");
+    ASSERT_NO_DLERROR(asprof_error_str);
+
+    void* lib = dlopen("libcallsmalloc.so", RTLD_NOW | RTLD_GLOBAL);
+    ASSERT_NO_DLERROR(lib);
+
+    asprof_error_t asprof_err = asprof_execute("start,cstack=dwarf,collapsed", outputCallback);
+    ASSERT_NO_ASPROF_ERR(asprof_err);
+
+    asprof_err = asprof_execute("stop", NULL);
+    ASSERT_NO_ASPROF_ERR(asprof_err);
+
+    dlclose(lib);
+
+    asprof_err = asprof_execute("start,nativemem,cstack=dwarf,collapsed", outputCallback);
+    ASSERT_NO_ASPROF_ERR(asprof_err);
+
+    asprof_err = asprof_execute("stop", NULL);
+    ASSERT_NO_ASPROF_ERR(asprof_err);
+}

--- a/test/test/nativemem/profile_with_dlopen.c
+++ b/test/test/nativemem/profile_with_dlopen.c
@@ -9,6 +9,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef __APPLE__
+#define LIB_EXT ".dylib"
+#else
+#define LIB_EXT ".so"
+#endif
+
 #define ASSERT_NO_DLERROR(sym)            \
     if (sym == NULL) {                    \
         err = dlerror();                  \
@@ -43,7 +49,7 @@ int main(int argc, char** argv) {
     int dlopen_first = strcmp(argv[1], "dlopen_first") == 0 ? 1 : 0;
     const char* filename = argv[2];
 
-    void* libprof = dlopen("libasyncProfiler.so", RTLD_NOW);
+    void* libprof = dlopen("build/lib/libasyncProfiler" LIB_EXT, RTLD_NOW);
     ASSERT_NO_DLERROR(libprof);
 
     asprof_init_t asprof_init = ((asprof_init_t)dlsym(libprof, "asprof_init"));
@@ -58,7 +64,7 @@ int main(int argc, char** argv) {
 
     // Load libcallsmalloc.so before or after starting the profiler, based on args.
     if (dlopen_first) {
-        lib = dlopen("libcallsmalloc.so", RTLD_NOW);
+        lib = dlopen("build/test/lib/libcallsmalloc" LIB_EXT, RTLD_NOW);
         ASSERT_NO_DLERROR(lib);
     }
 
@@ -70,7 +76,7 @@ int main(int argc, char** argv) {
     ASSERT_NO_ASPROF_ERR(asprof_err);
 
     if (!dlopen_first) {
-        lib = dlopen("libcallsmalloc.so", RTLD_NOW);
+        lib = dlopen("build/test/lib/libcallsmalloc" LIB_EXT, RTLD_NOW);
         ASSERT_NO_DLERROR(lib);
     }
 


### PR DESCRIPTION
### Description
Currently in Async profiler there are multiple locations were hooks are being installed 
This creates complexity in tracking what's installed & could create different behaviors depending on how async profiler is started 

This depends on the following PRs  
#1264 
#1279 

This will fix the following:
Partially fix #1245 if profiler is restarted (patches will be applied again)
Fix #1280 as patching is unified to use the same to all
Fix #1273 as preload hooks are removed

### Related issues
#1245 #1280 #1273

### Motivation and context
Simplify hook installation into a centralized method that is used by all

### How has this been tested?
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
