### PR TITLE
Make sure siginfo is passed to custom SEGV handler

### DIFF
--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -265,6 +265,7 @@ SigAction OS::replaceCrashHandler(SigAction action) {
     sigaction(SIGSEGV, NULL, &sa);
     SigAction old_action = sa.sa_sigaction;
     sa.sa_sigaction = action;
+    sa.sa_flags |= SA_SIGINFO | SA_RESTART;
     sigaction(SIGSEGV, &sa, NULL);
     return old_action;
 }

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -910,7 +910,7 @@ void Profiler::setupSignalHandlers() {
         orig_trapHandler = prev_handler;
     }
 
-    if (VM::hotspot_version() > 0 || !VM::loaded()) {
+    if (!VM::isOpenJ9() && !VM::isZing()) {
         // HotSpot tolerates interposed SIGSEGV/SIGBUS handler; other JVMs probably not
         orig_segvHandler = OS::replaceCrashHandler(segvHandler);
     }


### PR DESCRIPTION
### Description

If `OS::replaceCrashHandler()` is called before JVM start, it may setup signal handler without `SA_SIGINFO` flag, causing `segvHandler` to work incorrectly.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
