### PR TITLE
Skip last 10% allocations for leak detection

### DIFF
--- a/docs/ConverterUsage.md
+++ b/docs/ConverterUsage.md
@@ -49,6 +49,7 @@ JFR options:
     --live             Build allocation profile from live objects only during conversion
     --nativemem        Generate native memory allocation profile
     --leak             Only include memory leaks in nativemem
+    --tail RATIO       Ignore tail allocations for leak profiling (10% by default)
     --lock             Generate only Lock contention profile during conversion
  -t --threads          Split stack traces by threads
  -s --state LIST       Filter thread states: runnable, sleeping, default. State name is case insensitive

--- a/docs/ProfilingModes.md
+++ b/docs/ProfilingModes.md
@@ -117,9 +117,17 @@ jfrconv --total --nativemem --leak app.jfr app-leak.html
 jfrconv --total --nativemem app.jfr app-malloc.html
 ```
 
-When `--leak` option is used, the generated flame graph will show allocations without matching `free` calls. If `-nofree` is specified, every allocation will be reported as a leak:
+When `--leak` option is used, the generated flame graph will show allocations without matching `free` calls.
 
 ![nativemem flamegraph](../.assets/images/nativemem_flamegraph.png)
+
+To avoid bias towards youngest allocations not freed by the end of the profiling session,
+leak profiler ignores tail allocations made in the last 10% of the profiling period.
+Tail length can be altered with `--tail` option that accepts `ratio` or `percent%` as an argument.
+For example, to ignore allocations in the last 2 minutes of a 10 minutes profile, use
+```
+jfrconf --nativemem --leak --tail 20% app.jfr app-leak.html
+```
 
 The overhead of `nativemem` profiling depends on the number of native allocations,
 but is usually small enough even for production use. If required, the overhead can be reduced
@@ -180,9 +188,9 @@ of all compiled methods. The subsequent instrumentation flushes only the _depend
 
 The massive CodeCache flush doesn't occur if attaching async-profiler as an agent.
 
-### Java native method profiling
+## Native function profiling
 
-Here are some useful native methods to profile:
+Here are some useful native functions to profile:
 
 - `G1CollectedHeap::humongous_obj_allocate` - trace _humongous allocations_ of the G1 GC,
 - `JVM_StartThread` - trace creation of new Java threads,

--- a/docs/ProfilingModes.md
+++ b/docs/ProfilingModes.md
@@ -125,6 +125,7 @@ To avoid bias towards youngest allocations not freed by the end of the profiling
 leak profiler ignores tail allocations made in the last 10% of the profiling period.
 Tail length can be altered with `--tail` option that accepts `ratio` or `percent%` as an argument.
 For example, to ignore allocations in the last 2 minutes of a 10 minutes profile, use
+
 ```
 jfrconf --nativemem --leak --tail 20% app.jfr app-leak.html
 ```

--- a/src/converter/Main.java
+++ b/src/converter/Main.java
@@ -102,6 +102,7 @@ public class Main {
                 "     --live             Live object profile\n" +
                 "     --nativemem        malloc profile\n" +
                 "     --leak             Only include memory leaks in nativemem\n" +
+                "     --tail RATIO       Ignore tail allocations for leak profiling (10% by default)\n" +
                 "     --lock             Lock contention profile\n" +
                 "  -t --threads          Split stack traces by threads\n" +
                 "  -s --state LIST       Filter thread states: runnable, sleeping\n" +

--- a/src/converter/one/convert/Arguments.java
+++ b/src/converter/one/convert/Arguments.java
@@ -19,6 +19,7 @@ public class Arguments {
     public Pattern exclude;
     public double minwidth;
     public double grain;
+    public double tail = 0.1;
     public int skip;
     public boolean help;
     public boolean reverse;
@@ -69,7 +70,7 @@ public class Arguments {
                 } else if (type == int.class) {
                     f.setInt(this, Integer.parseInt(args[++i]));
                 } else if (type == double.class) {
-                    f.setDouble(this, Double.parseDouble(args[++i]));
+                    f.setDouble(this, parseRatio(args[++i]));
                 } else if (type == long.class) {
                     f.setLong(this, parseTimestamp(args[++i]));
                 } else if (type == Pattern.class) {
@@ -102,6 +103,14 @@ public class Arguments {
             default:
                 return String.valueOf(c);
         }
+    }
+
+    // Absolute floating point value or percentage followed by %
+    private static double parseRatio(String value) {
+        if (value.endsWith("%")) {
+            return Double.parseDouble(value.substring(0, value.length() - 1)) / 100;
+        }
+        return Double.parseDouble(value);
     }
 
     // Milliseconds or HH:mm:ss.S or yyyy-MM-dd'T'HH:mm:ss.S

--- a/src/converter/one/convert/JfrConverter.java
+++ b/src/converter/one/convert/JfrConverter.java
@@ -29,7 +29,7 @@ public abstract class JfrConverter extends Classifier {
         this.args = args;
 
         EventCollector collector = createCollector(args);
-        this.collector = args.nativemem && args.leak ? new MallocLeakAggregator(collector) : collector;
+        this.collector = args.nativemem && args.leak ? new MallocLeakAggregator(collector, args.tail) : collector;
     }
 
     public void convert() throws IOException {

--- a/src/converter/one/jfr/event/MallocLeakAggregator.java
+++ b/src/converter/one/jfr/event/MallocLeakAggregator.java
@@ -62,7 +62,7 @@ public class MallocLeakAggregator implements EventCollector {
 
         wrapped.beforeChunk();
         for (Event e : addresses.values()) {
-            if (e.time < timeCutoff) {
+            if (e.time <= timeCutoff) {
                 wrapped.collect(e);
             }
         }


### PR DESCRIPTION
### Description

For native leak profiling, ignore allocations made in the last 10% of the profiling session.

### Motivation and context

#1064 introduced the feature to create a flamegraph of native memory allocations. With `--leak` option, only those allocations are displayed that do not have matching `free` calls - such allocations are considered memory leaks. However, this algorithm is biased towards allocations made closer to the end of the profiling session, because such allocations are more likely to be freed only after the session has ended.

To avoid such a bias, it is proposed to simply ignore younger allocations. For example, if a profiling session runs for 10 minutes, allocations made during the last minute won't be included in the leak flamegraph.

### How has this been tested?

Created an artificial memory leak by not closing `DirectoryStream` and ran
```
jfrconv --nativemem --leak --total --lines leak.jfr
```

**Before the change:**
![leak-old](https://github.com/user-attachments/assets/ce56ee2b-6114-45a5-80f0-2db6fc93cc97)

**After the change:**
![leak-new](https://github.com/user-attachments/assets/997dc636-9a02-4fc6-b5df-fbe02292533f)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
