### PR TITLE
Allow profiling kprobes/uprobes with --fdtransfer

### DIFF
--- a/src/fdtransfer.h
+++ b/src/fdtransfer.h
@@ -17,6 +17,8 @@
 
 #define RESTARTABLE(call)  ({ ssize_t ret; while ((ret = call) < 0 && errno == EINTR); ret; })
 
+#define MAX_PROBE_LEN  256
+
 
 // base header for all requests
 enum request_type {
@@ -34,6 +36,7 @@ struct perf_fd_request {
     int tid;
     int target_cpu;
     struct perf_event_attr attr;
+    char probe_name[MAX_PROBE_LEN];
 };
 
 struct fd_response {

--- a/src/fdtransferClient.h
+++ b/src/fdtransferClient.h
@@ -26,7 +26,7 @@ class FdTransferClient {
         }
     }
 
-    static int requestPerfFd(int *tid, int target_cpu, struct perf_event_attr *attr);
+    static int requestPerfFd(int* tid, int target_cpu, struct perf_event_attr* attr, const char* probe_name);
     static int requestKallsymsFd();
 };
 

--- a/src/main/fdtransferServer_linux.cpp
+++ b/src/main/fdtransferServer_linux.cpp
@@ -5,6 +5,7 @@
 
 #ifdef __linux__
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -114,6 +115,11 @@ bool FdTransferServer::serveRequests(int peer_pid) {
             struct perf_fd_request *request = (struct perf_fd_request*)req;
             int perf_fd = -1;
             int error;
+
+            if (request->probe_name[0]) {
+                // kprobe/uprobe name must be in the address space of the current process
+                request->attr.config1 = (__u64)(uintptr_t)request->probe_name;
+            }
 
             // In pid == 0 mode, allow all perf_event_open requests.
             // Otherwise, verify the thread belongs to PID.

--- a/test/test/kernel/KernelTests.java
+++ b/test/test/kernel/KernelTests.java
@@ -35,6 +35,13 @@ public class KernelTests {
         assert out.contains("sys_getdents");
     }
 
+    @Test(mainClass = ListFiles.class, os = Os.LINUX)
+    public void kprobe(TestProcess p) throws Exception {
+        p.profile("-e kprobe:fd_install -d 2 -o collapsed -f %f --fdtransfer", true);
+        Output out = p.readFile("%f");
+        assert out.contains("java/io/File.list;.+;fd_install_\\[k]");
+    }
+
     @Test(mainClass = ListFiles.class, os = {Os.MACOS, Os.WINDOWS})
     public void notLinux(TestProcess p) throws Exception {
         try {


### PR DESCRIPTION
### Description

Extend fdtransfer protocol to pass probe name in perf_event requests.

### Motivation and context

Async-profiler can profile kprobes and uprobes, e.g. `asprof -e kprobe:fd_install`. However, this does not work with `--fdtransfer` option. The reason is, `perf_event_attr` structure contains a pointer to kprobe/uprobe name, but when `perf_event_attr` is passed to another process (fdtransfer server), this pointer becomes invalid, since the address belongs to a different process.

The proposed solution extends `perf_fd_request` structure with a new field that contains a name of kprobe/uprobe. For events other than kprobe/uprobe, this field contains an empty string. When fdtransfer server receives non-empty probe name, it adjusts pointer in `perf_event_attr`.

### How has this been tested?

Added `KernelTests.kprobe` test, which failed before the fix, but passes now.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
