### PR TITLE
Fix `comptask` test flakyness on JDK8

### DIFF
--- a/test/test/comptask/ComptaskTests.java
+++ b/test/test/comptask/ComptaskTests.java
@@ -17,6 +17,6 @@ public class ComptaskTests {
     public void testCompTask(TestProcess p) throws Exception {
         Output out = p.waitForExit("%f");
         assert p.exitCode() == 0;
-        assert out.contains("C2Compiler::compile_method;java/lang/Thread.<init>");
+        assert out.contains("C2Compiler::compile_method;java/lang/Thread.<?init>?");
     }
 }


### PR DESCRIPTION
### Description
I noticed some sporadic failures of the new `comptask` test (#1293) on JDK8.

The reason for this failure is that sometimes `C2Compiler::compile_method;java/lang/Thread.<init>` is not found in the stacktrace. I had a look at the code, and noticed that `Thread.<init>` was relatively simple in JDK8, while some complexity was delegated to [`Thread.init`](https://github.com/openjdk/jdk8/blob/master/jdk/src/share/classes/java/lang/Thread.java#L363). Indeed, I get this from `-XX:+PrintCompilation`:
```
    278  106    b  3       java.lang.Thread::<init> (49 bytes)
    278  107    b  4       java.lang.Thread::<init> (49 bytes)
    279  106       3       java.lang.Thread::<init> (49 bytes)   made not entrant
    279  108    b  3       java.lang.Thread::init (214 bytes)
    280  109    b  4       java.lang.Thread::init (214 bytes)
    283  108       3       java.lang.Thread::init (214 bytes)   made not entrant
```

Example failure [here](https://github.com/fandreuz/async-profiler/actions/runs/15158228787/job/42618128202#step:10:93).

### Related issues
#1293 

### Motivation and context
The test should not be flaky.

### How has this been tested?
GHA

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
