### PR TITLE
Prevent parsing more libs than the MAX_NATIVE_LIBS limit

### DIFF
--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -675,7 +675,7 @@ Mutex Symbols::_parse_lock;
 bool Symbols::_have_kernel_symbols = false;
 bool Symbols::_libs_limit_reported = false;
 static std::unordered_set<u64> _parsed_inodes;
-static bool in_parse_libraries = false;
+static bool _in_parse_libraries = false;
 
 void Symbols::parseKernelSymbols(CodeCache* cc) {
     int fd;
@@ -779,10 +779,10 @@ static void collectSharedLibraries(std::unordered_map<u64, SharedLibrary>& libs,
 void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
     MutexLocker ml(_parse_lock);
 
-    if (in_parse_libraries || array->count() >= MAX_NATIVE_LIBS) {
+    if (_in_parse_libraries || array->count() >= MAX_NATIVE_LIBS) {
         return;
     }
-    in_parse_libraries = true;
+    _in_parse_libraries = true;
 
     if (kernel_symbols && !haveKernelSymbols()) {
         CodeCache* cc = new CodeCache("[kernel]");
@@ -831,12 +831,12 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
         array->add(cc);
     }
 
-    in_parse_libraries = false;
-
     if (array->count() >= MAX_NATIVE_LIBS && !_libs_limit_reported) {
         Log::warn("Number of parsed libraries reached the limit of %d", MAX_NATIVE_LIBS);
         _libs_limit_reported = true;
     }
+
+    _in_parse_libraries = false;
 }
 
 // Check that the base address of the shared object has not changed

--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -827,6 +827,11 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
         cc->sort();
         applyPatch(cc);
         array->add(cc);
+
+        // Don't continue parsing libs as limit was reached
+        if (array->count() >= MAX_NATIVE_LIBS) {
+            break;
+        }
     }
 
     if (array->count() >= MAX_NATIVE_LIBS && !_libs_limit_reported) {

--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -675,6 +675,7 @@ Mutex Symbols::_parse_lock;
 bool Symbols::_have_kernel_symbols = false;
 bool Symbols::_libs_limit_reported = false;
 static std::unordered_set<u64> _parsed_inodes;
+static bool in_parse_libraries = false;
 
 void Symbols::parseKernelSymbols(CodeCache* cc) {
     int fd;
@@ -757,15 +758,13 @@ static void collectSharedLibraries(std::unordered_map<u64, SharedLibrary>& libs,
         }
 
         if (map.isExecutable()) {
-            if (libs.find(inode) == libs.end()) {
-                max_count--;
-            }
             SharedLibrary& lib = libs[inode];
             if (lib.file == nullptr) {
                 lib.file = strdup(map.file());
                 lib.map_start = map_start;
                 lib.map_end = map_end;
                 lib.image_base = inode == last_inode ? image_base : NULL;
+                max_count--;
             } else {
                 // The same library may have multiple executable segments mapped
                 lib.map_end = map_end;
@@ -780,9 +779,10 @@ static void collectSharedLibraries(std::unordered_map<u64, SharedLibrary>& libs,
 void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
     MutexLocker ml(_parse_lock);
 
-    if (array->count() >= MAX_NATIVE_LIBS) {
+    if (in_parse_libraries || array->count() >= MAX_NATIVE_LIBS) {
         return;
     }
+    in_parse_libraries = true;
 
     if (kernel_symbols && !haveKernelSymbols()) {
         CodeCache* cc = new CodeCache("[kernel]");
@@ -815,15 +815,10 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
             // Be careful: executable file is not always ELF, e.g. classes.jsa
             ElfParser::parseFile(cc, lib.map_start, lib.file, true);
         } else {
-            UnloadProtection handle(cc);
-            // Due to async-profiler issue #1273, it's possible for a recursive dlopen to happen at UnloadProtection
-            // This check is needed to prevent parsing the lib & adding it when limit was reached by the internal dlopen call
-            if (array->count() >= MAX_NATIVE_LIBS) {
-                break;
-            }
             // Parse debug symbols first
             ElfParser::parseFile(cc, lib.image_base, lib.file, true);
 
+            UnloadProtection handle(cc);
             if (handle.isValid()) {
                 ElfParser::parseProgramHeaders(cc, lib.image_base, lib.map_end, OS::isMusl());
             }
@@ -835,6 +830,8 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
         applyPatch(cc);
         array->add(cc);
     }
+
+    in_parse_libraries = false;
 
     if (array->count() >= MAX_NATIVE_LIBS && !_libs_limit_reported) {
         Log::warn("Number of parsed libraries reached the limit of %d", MAX_NATIVE_LIBS);


### PR DESCRIPTION
### Description
It's possible for the profiler to try to parse more libs than it's specified limit which may result in an out of bounds exceptions 

This was discovered while writing dlopen heavy applications that load thousands of shared objects

### Related issues
N/A

### Motivation and context
Prevent the profiler from crashing & exceeding it's limits 

### How has this been tested?
the dlopen heavy application is no longer crashing 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
