### PR TITLE
Cleanup malloc tracer

### DIFF
--- a/src/mallocTracer.cpp
+++ b/src/mallocTracer.cpp
@@ -14,12 +14,6 @@
 #include <dlfcn.h>
 #include <string.h>
 
-#ifdef __clang__
-#  define NO_OPTIMIZE __attribute__((optnone))
-#else
-#  define NO_OPTIMIZE __attribute__((optimize("O1")))
-#endif
-
 extern "C" void* malloc_hook(size_t size) {
     void* ret = malloc(size);
     if (MallocTracer::running() && ret && size) {


### PR DESCRIPTION
### Description
Removing redundant methods `calloc_hook_dummy` & `posix_memalign_hook_dummy` 

In MUSL:
* calloc calls malloc internally
* posixMemalign calls aligned_alloc_hook internally

It seems these methods were only needed to keep the Integration tests under `test/test/nativemem/NativememTests.java` as passing for MUSL.

=> While unwinding the stack it's highly possible that distance between stack frames goes further than what async-profiler considers safe to continue the unwinding process.

Methods were removed to get rid of unneeded overhead & Integration tests were updated to account for possible missing stack frames in the unwinding process

### Related issues
NA

### Motivation and context
Remove unneeded overhead on MUSL & remove redundant methods

### How has this been tested?
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
