### PR TITLE
Enable unit tests related to parsing for MacOs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ build-test-bins:
 
 test-cpp: build-test-cpp
 	echo "Running cpp tests..."
-	LD_LIBRARY_PATH="$(TEST_LIB_DIR)" build/test/cpptests
+	LD_LIBRARY_PATH="$(TEST_LIB_DIR)" DYLD_LIBRARY_PATH="$(TEST_LIB_DIR)" build/test/cpptests
 
 test-java: build-test-java
 	echo "Running tests against $(LIB_PROFILER)"

--- a/test/native/libs/reladyn.c
+++ b/test/native/libs/reladyn.c
@@ -31,7 +31,7 @@ int reladyn() {
     indirect_pthread_setspecific = pthread_setspecific;
     indirect_pthread_setspecific(key, "Thread-specific value");
 
-    // static pointer don't get reported in lazy nor none lazy symbol sections when discovering the symbols for MacOs
+    // static pointer doesn't get reported in the lazy or the non-lazy sections when discovering the symbols for MacOs
 #ifdef __APPLE__
     static_pthread_exit = pthread_exit;
 #endif

--- a/test/native/libs/reladyn.c
+++ b/test/native/libs/reladyn.c
@@ -31,6 +31,10 @@ int reladyn() {
     indirect_pthread_setspecific = pthread_setspecific;
     indirect_pthread_setspecific(key, "Thread-specific value");
 
+    // static pointer don't get reported in lazy nor none lazy symbol sections when discovering the symbols for MacOs
+#ifdef __APPLE__
+    static_pthread_exit = pthread_exit;
+#endif
     // Use pthread_exit via the static pointer, forces into .rela.dyn as R_X86_64_64.
     static_pthread_exit(NULL);
 

--- a/test/native/libs/reladyn.c
+++ b/test/native/libs/reladyn.c
@@ -31,10 +31,6 @@ int reladyn() {
     indirect_pthread_setspecific = pthread_setspecific;
     indirect_pthread_setspecific(key, "Thread-specific value");
 
-    // static pointer doesn't get reported in the lazy or the non-lazy sections when discovering the symbols for MacOs
-#ifdef __APPLE__
-    static_pthread_exit = pthread_exit;
-#endif
     // Use pthread_exit via the static pointer, forces into .rela.dyn as R_X86_64_64.
     static_pthread_exit(NULL);
 

--- a/test/native/symbolsTest.cpp
+++ b/test/native/symbolsTest.cpp
@@ -43,11 +43,11 @@ TEST_CASE(ResolveFromRela_dyn_R_GLOB_DAT) {
     ASSERT_RESOLVE(im_pthread_setspecific);
 }
 
+#ifdef __linux__
+
 TEST_CASE(ResolveFromRela_dyn_R_ABS64) {
     ASSERT_RESOLVE(im_pthread_exit);
 }
-
-#ifdef __linux__
 
 TEST_CASE(VirtAddrDifferentLoadAddr) {
     const void* sym = resolveSymbol("libvaddrdif" EXT, "vaddrdif_square");

--- a/test/native/symbolsTest.cpp
+++ b/test/native/symbolsTest.cpp
@@ -4,6 +4,10 @@
  */
 
 #ifdef __linux__
+#define EXT ".so"
+#else
+#define EXT ".dylib"
+#endif
 
 #include "codeCache.h"
 #include "profiler.h"
@@ -22,7 +26,7 @@ const void* resolveSymbol(const char* lib, const char* name) {
 
 #define ASSERT_RESOLVE(id)                                                             \
     {                                                                                  \
-        void* result = dlopen("libreladyn.so", RTLD_NOW); /* see reladyn.c */          \
+        void* result = dlopen("libreladyn" EXT, RTLD_NOW); /* see reladyn.c */         \
         ASSERT(result);                                                                \
         Profiler::instance()->updateSymbols(false);                                    \
         CodeCache* libreladyn = Profiler::instance()->findLibraryByName("libreladyn"); \
@@ -43,8 +47,10 @@ TEST_CASE(ResolveFromRela_dyn_R_ABS64) {
     ASSERT_RESOLVE(im_pthread_exit);
 }
 
+#ifdef __linux__
+
 TEST_CASE(VirtAddrDifferentLoadAddr) {
-    const void* sym = resolveSymbol("libvaddrdif.so", "vaddrdif_square");
+    const void* sym = resolveSymbol("libvaddrdif" EXT, "vaddrdif_square");
     ASSERT(sym);
 
     int (*square)(int) = (int (*)(int))sym;
@@ -52,7 +58,7 @@ TEST_CASE(VirtAddrDifferentLoadAddr) {
 }
 
 TEST_CASE(MappedTwiceAtZeroOffset) {
-    const void* sym = resolveSymbol("libtwiceatzero.so", "twiceatzero_hello");
+    const void* sym = resolveSymbol("libtwiceatzero" EXT, "twiceatzero_hello");
     // Resolving the symbol without crashing is enough for this test case.
     ASSERT(sym);
 
@@ -61,13 +67,13 @@ TEST_CASE(MappedTwiceAtZeroOffset) {
 }
 
 TEST_CASE(MultipleMatchingSymbols) {
-    const void* sym = resolveSymbol("multiplematching.so", "Class::function");
+    const void* sym = resolveSymbol("multiplematching" EXT, "Class::function");
     ASSERT(sym);
 
-    const void* sym_ok = resolveSymbol("multiplematching.so", "_ZN5Class8functionEv");
+    const void* sym_ok = resolveSymbol("multiplematching" EXT, "_ZN5Class8functionEv");
     ASSERT_EQ(sym, sym_ok);
 
-    const void* sym_cold = resolveSymbol("multiplematching.so", "_ZN5Class8functionEv.cold");
+    const void* sym_cold = resolveSymbol("multiplematching" EXT, "_ZN5Class8functionEv.cold");
     ASSERT_NE(sym, sym_cold);
 }
 


### PR DESCRIPTION
### Description
As mentioned in description, Enabling more tests to run on Mac that were previously disabled

### Related issues
N/A

### Motivation and context
Enable as much of the available tests to run on all platforms

### How has this been tested?
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
