### PR TITLE
Protect from looping on interrupted `clone()` syscall

### DIFF
--- a/src/codeCache.cpp
+++ b/src/codeCache.cpp
@@ -197,6 +197,9 @@ void CodeCache::addImport(void** entry, const char* name) {
             if (strcmp(name, "calloc") == 0) {
                 saveImport(im_calloc, entry);
             }
+            if (strcmp(name, "clone") == 0) {
+                saveImport(im_clone, entry);
+            }
             break;
         case 'd':
             if (strcmp(name, "dlopen") == 0) {

--- a/src/codeCache.h
+++ b/src/codeCache.h
@@ -18,6 +18,7 @@ const int MAX_NATIVE_LIBS = 2048;
 
 enum ImportId {
     im_dlopen,
+    im_clone,
     im_pthread_create,
     im_pthread_exit,
     im_pthread_setspecific,

--- a/src/cpuEngine.cpp
+++ b/src/cpuEngine.cpp
@@ -41,15 +41,19 @@ static int pthread_setspecific_hook(pthread_key_t key, const void* value) {
     }
 }
 
+CpuEngine* CpuEngine::getCurrent() {
+    return __atomic_load_n(&_current, __ATOMIC_ACQUIRE);
+}
+
 void CpuEngine::onThreadStart() {
-    CpuEngine* current = __atomic_load_n(&_current, __ATOMIC_ACQUIRE);
+    CpuEngine* current = getCurrent();
     if (current != NULL) {
         current->createForThread(OS::threadId());
     }
 }
 
 void CpuEngine::onThreadEnd() {
-    CpuEngine* current = __atomic_load_n(&_current, __ATOMIC_ACQUIRE);
+    CpuEngine* current = getCurrent();
     if (current != NULL) {
         current->destroyForThread(OS::threadId());
     }

--- a/src/cpuEngine.h
+++ b/src/cpuEngine.h
@@ -9,9 +9,13 @@
 #include <signal.h>
 #include "engine.h"
 
+class CpuEnginePause;
 
 // Base class for CPU sampling engines: PerfEvents, CTimer, ITimer
 class CpuEngine : public Engine {
+  private:
+    static CpuEngine* getCurrent();
+
   protected:
     static void** _pthread_entry;
     static CpuEngine* _current;
@@ -36,6 +40,9 @@ class CpuEngine : public Engine {
     virtual int createForThread(int tid) { return -1; }
     virtual void destroyForThread(int tid) {}
 
+    virtual void pause() {}
+    virtual void resume() {}
+
   public:
     const char* title() {
         return "CPU profile";
@@ -47,6 +54,21 @@ class CpuEngine : public Engine {
 
     static void onThreadStart();
     static void onThreadEnd();
+
+    friend CpuEnginePause;
+};
+
+class CpuEnginePause {
+  private:
+    CpuEngine* _current;
+
+  public:
+    CpuEnginePause() : _current(CpuEngine::getCurrent()) {
+      if (_current != NULL) _current->pause();
+    }
+    ~CpuEnginePause() {
+      if (_current != NULL) _current->resume();
+    }
 };
 
 #endif // _CPUENGINE_H

--- a/src/ctimer.h
+++ b/src/ctimer.h
@@ -18,6 +18,9 @@ class CTimer : public CpuEngine {
     int createForThread(int tid);
     void destroyForThread(int tid);
 
+    void pause() { destroyForThread(OS::threadId()); }
+    void resume() { createForThread(OS::threadId()); }
+
   public:
     const char* type() {
         return "ctimer";

--- a/src/itimer.h
+++ b/src/itimer.h
@@ -18,6 +18,8 @@ class ITimer : public CpuEngine {
     Error check(Arguments& args);
     Error start(Arguments& args);
     void stop();
+
+    // TODO: pause resume
 };
 
 #endif // _ITIMER_H

--- a/src/perfEvents.h
+++ b/src/perfEvents.h
@@ -32,6 +32,9 @@ class PerfEvents : public CpuEngine {
     int createForThread(int tid);
     void destroyForThread(int tid);
 
+    void pause() { destroyForThread(OS::threadId()); }
+    void resume() { createForThread(OS::threadId()); }
+
   public:
     Error check(Arguments& args);
     Error start(Arguments& args);


### PR DESCRIPTION
### Description
In this PR I introduce protection against infinite looping following an interrupted `clone` system call. The idea is to hook `clone`, check whether it was interrupted, and disable the `CpuEngine` for the thread while we retry.

### Related issues
Fixes #1114 

### Motivation and context
Async-Profiler should not try to interrupt `clone` again.

### How has this been tested?
I could not reproduce the problem locally yet.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
