### PR TITLE
#1319: Accessing osThreadId of a terminating thread may fail

### DIFF
--- a/src/safeAccess.h
+++ b/src/safeAccess.h
@@ -52,11 +52,14 @@ class SafeAccess {
     }
 
     static uintptr_t skipLoadArg(uintptr_t pc) {
-#if defined(__aarch64__)
         if ((pc - (uintptr_t)load32) < 16 || (pc - (uintptr_t)loadPtr) < 16) {
-            return 4;
-        }
+#if defined(__x86_64__) || defined(__i386__)
+            if (*(u8*)pc == 0x8b) return 2;      // mov eax, [reg]
+            if (*(u16*)pc == 0x8b48) return 3;   // mov rax, [reg]
+#else
+            return sizeof(instruction_t);
 #endif
+        }
         return 0;
     }
 };

--- a/src/vmStructs.cpp
+++ b/src/vmStructs.cpp
@@ -638,7 +638,7 @@ int VMThread::nativeThreadId(JNIEnv* jni, jthread thread) {
 int VMThread::osThreadId() {
     const char* osthread = *(const char**) at(_thread_osthread_offset);
     if (osthread != NULL) {
-        // Java thread may be in the middle of termination, and its osthread structutre just released
+        // Java thread may be in the middle of termination, and its osthread structure just released
         return SafeAccess::load32((u32*)(osthread + _osthread_id_offset), (u32)-1);
     }
     return -1;

--- a/src/vmStructs.cpp
+++ b/src/vmStructs.cpp
@@ -635,6 +635,15 @@ int VMThread::nativeThreadId(JNIEnv* jni, jthread thread) {
     return VM::isOpenJ9() ? J9Ext::GetOSThreadID(thread) : -1;
 }
 
+int VMThread::osThreadId() {
+    const char* osthread = *(const char**) at(_thread_osthread_offset);
+    if (osthread != NULL) {
+        // Java thread may be in the middle of termination, and its osthread structutre just released
+        return SafeAccess::load32((u32*)(osthread + _osthread_id_offset), (u32)-1);
+    }
+    return -1;
+}
+
 jmethodID VMMethod::id() {
     // We may find a bogus NMethod during stack walking, it does not always point to a valid VMMethod
     const char* const_method = (const char*) SafeAccess::load((void**) at(_method_constmethod_offset));

--- a/src/vmStructs.h
+++ b/src/vmStructs.h
@@ -347,10 +347,7 @@ class VMThread : VMStructs {
 
     static int nativeThreadId(JNIEnv* jni, jthread thread);
 
-    int osThreadId() {
-        const char* osthread = *(const char**) at(_thread_osthread_offset);
-        return osthread != NULL ? *(int*)(osthread + _osthread_id_offset) : -1;
-    }
+    int osThreadId();
 
     int state() {
         return _thread_state_offset >= 0 ? *(int*) at(_thread_state_offset) : 0;


### PR DESCRIPTION
### Description

The problem happens when a sample lands in HotSpot's `Thread::~Thread()` in a short window between

```
  if (osthread() != nullptr) os::free_thread(osthread());
```
and
```
  if (this == Thread::current_or_null()) {
    Thread::clear_thread_current();
  }
```
and freed `osthread` memory is concurrently reused by some other thread.


### Related issues

#1319

### How has this been tested?

Fix confirmed by the original bug reporter.
New stress test is underway.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
