### PR TITLE
Fix memory leaks reported by Infer

### DIFF
--- a/src/jattach/jattach_openj9.c
+++ b/src/jattach/jattach_openj9.c
@@ -125,9 +125,11 @@ static int read_response(int fd, const char* cmd, int print_output) {
         ssize_t bytes = read(fd, buf + off, size - off);
         if (bytes == 0) {
             fprintf(stderr, "Unexpected EOF reading response\n");
+            free(buf);
             return 1;
         } else if (bytes < 0) {
             perror("Error reading response");
+            free(buf);
             return 1;
         }
 
@@ -137,7 +139,13 @@ static int read_response(int fd, const char* cmd, int print_output) {
         }
 
         if (off >= size) {
-            buf = realloc(buf, size *= 2);
+            char* temp_buf = realloc(buf, size *= 2);
+            if (temp_buf == NULL) {
+                free(buf);
+                fprintf(stderr, "Failed to reallocate memory for response\n");
+                return 1;
+            }
+            buf = temp_buf;
         }
     }
 


### PR DESCRIPTION
### Description
This pull request fixes memory leaks in the `read_response()` function (`jattach_openj9.c`) identified via static analysis using Infer.

- Ensures `buf` is freed when `read()` returns `0` or `< 0`
- Adds `NULL` check after `realloc()` to avoid losing the original buffer
- All exit paths now properly release allocated memory

These are minor but important fixes to improve memory safety

### Related issues
#1327

### Motivation and context
Improve memory safety by ensuring all dynamic memory is properly freed in early return paths and in case of allocation failure

This change was guided by results from the Infer static analyzer

### How has this been tested?
Verified using Infer that the memory leak warnings no longer appear after the patch

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
