### PR TITLE
A bug report about VM Structs stack walker on Alpine (#1317)

### DIFF
--- a/src/codeCache.cpp
+++ b/src/codeCache.cpp
@@ -302,6 +302,11 @@ FrameDesc* CodeCache::findFrameDesc(const void* pc) {
     }
 
     if (low > 0) {
+      	if (target_loc < _dwarf_table[low - 1].fde_loc_end) {
+			return &_dwarf_table[low - 1];
+      	} else {
+			return NULL;
+      	}
         return &_dwarf_table[low - 1];
     } else if (target_loc - _plt_offset < _plt_size) {
         return &FrameDesc::empty_frame;

--- a/src/dwarf.h
+++ b/src/dwarf.h
@@ -66,6 +66,7 @@ struct FrameDesc {
     int cfa;
     int fp_off;
     int pc_off;
+    u32 fde_loc_end;
 
     static FrameDesc empty_frame;
     static FrameDesc default_frame;
@@ -147,11 +148,11 @@ class DwarfParser {
     void parse(const char* eh_frame_hdr);
     void parseCie();
     void parseFde();
-    void parseInstructions(u32 loc, const char* end);
+    void parseInstructions(u32 loc, const char* end, u32 fde_loc_end);
     int parseExpression();
 
-    void addRecord(u32 loc, u32 cfa_reg, int cfa_off, int fp_off, int pc_off);
-    FrameDesc* addRecordRaw(u32 loc, int cfa, int fp_off, int pc_off);
+    void addRecord(u32 loc, u32 cfa_reg, int cfa_off, int fp_off, int pc_off, u32 fde_loc_end);
+    FrameDesc* addRecordRaw(u32 loc, int cfa, int fp_off, int pc_off, u32 fde_loc_end);
 
   public:
     DwarfParser(const char* name, const char* image_base, const char* eh_frame_hdr);


### PR DESCRIPTION
### Description
Hi, could I have a review of this patch ?
If `FrameDesc` can not be found for the `pc`, then it means we don't know how to unwind the current native frame.
Instead, we add a `skipped frames` dummy frame to indicate some frames are skipped, and use `Java Frame Anchor` to unwind the Java part.

The current version of `CodeCache::findFrameDesc` may return an incorrect `FrameDesc`, as described in this comment:
https://github.com/async-profiler/async-profiler/issues/1317#issuecomment-2911569497
I added a `fde_loc_end` to `FrameDesc`, and `CodeCache::findFrameDesc` checks the `pc` is in the range of the returned `FrameDesc`'s FDE.

I deleted the redundant `FrameDesc` to fix the possible bug described in this comment:
https://github.com/async-profiler/async-profiler/issues/1317#issuecomment-2918545682

This fix also works on JDK 11 aarch64, as I described in the comment:
https://github.com/async-profiler/async-profiler/issues/1317#issuecomment-2933584880

### Related issues
#1317

### Motivation and context


### How has this been tested?
[Reproducer.java.zip](https://github.com/user-attachments/files/20607620/Reproducer.java.zip)
```
$JAVA_HOME/bin/java Reproducer
/root/async-profiler/build/bin/asprof -e cpu -f /root/profile.html -d 10 --cstack vm jps
```
Without the patch, most native stacks are incomplete, missing the Java stack.
![image](https://github.com/user-attachments/assets/28f0fe26-7d40-429f-ba1e-169ebf6333e6)

With the patch, native stacks and Java stacks are linked together
![image](https://github.com/user-attachments/assets/f43d4f72-7705-49b3-ae24-9945fd84c672)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
