### PR TITLE
Use `Index` in `jfrMetadata`

### DIFF
--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -778,7 +778,7 @@ class Recording {
         buf->putVar32(0);
         buf->putVar32(0x7fffffff);  // must not clash with JFR metadata ID, or 'jfr print' will break
 
-        Index strings = JfrMetadata::strings();
+        const Index& strings = JfrMetadata::strings();
         buf->putVar32(strings.size());
         strings.forEachOrdered([&] (const std::string& s) {
             buf->putUtf8(s.c_str());

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -778,7 +778,7 @@ class Recording {
         buf->putVar32(0);
         buf->putVar32(0x7fffffff);  // must not clash with JFR metadata ID, or 'jfr print' will break
 
-        buf->putVar32(JfrMetadata::stringsSize());
+        buf->putVar32(JfrMetadata::strings().size());
         JfrMetadata::forEachStringOrdered([&] (const std::string& s) {
             buf->putUtf8(s.c_str());
         });

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -778,8 +778,9 @@ class Recording {
         buf->putVar32(0);
         buf->putVar32(0x7fffffff);  // must not clash with JFR metadata ID, or 'jfr print' will break
 
-        buf->putVar32(JfrMetadata::strings().size());
-        JfrMetadata::forEachStringOrdered([&] (const std::string& s) {
+        Index strings = JfrMetadata::strings();
+        buf->putVar32(strings.size());
+        strings.forEachOrdered([&] (const std::string& s) {
             buf->putUtf8(s.c_str());
         });
 

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -778,11 +778,10 @@ class Recording {
         buf->putVar32(0);
         buf->putVar32(0x7fffffff);  // must not clash with JFR metadata ID, or 'jfr print' will break
 
-        std::vector<std::string>& strings = JfrMetadata::strings();
-        buf->putVar32(strings.size());
-        for (int i = 0; i < strings.size(); i++) {
-            buf->putUtf8(strings[i].c_str());
-        }
+        buf->putVar32(JfrMetadata::stringsSize());
+        JfrMetadata::forEachStringOrdered([&] (const std::string& s) {
+            buf->putUtf8(s.c_str());
+        });
 
         writeElement(buf, JfrMetadata::root());
 

--- a/src/index.h
+++ b/src/index.h
@@ -18,6 +18,13 @@ class Index {
     std::unordered_map<std::string, size_t> _idx_map;
   
   public:
+    Index() = default;
+
+    Index(const Index&) = delete;
+    Index(Index&&) = delete;
+    Index& operator=(const Index&) = delete;
+    Index& operator=(Index&&) = delete;
+
     size_t indexOf(const std::string& value) {
         return _idx_map.insert({value, _idx_map.size()}).first->second;
     }

--- a/src/index.h
+++ b/src/index.h
@@ -15,15 +15,19 @@
 // Keeps track of values seen and their index of occurrence
 class Index {
   private:
-    std::unordered_map<std::string, u32> _idx_map;
+    std::unordered_map<std::string, size_t> _idx_map;
   
   public:
-    u32 indexOf(std::string value) {
+    size_t indexOf(std::string value) {
         return _idx_map.insert({value, _idx_map.size()}).first->second;
     }
 
-    u32 size() const {
+    size_t size() const {
         return _idx_map.size();
+    }
+
+    void clear() {
+        _idx_map.clear();
     }
 
     void forEachOrdered(std::function<void(const std::string&)> consumer) const {
@@ -31,7 +35,7 @@ class Index {
         for (const auto& it : _idx_map) {
             arr[it.second] = &it.first;
         }
-        for (u32 idx = 0; idx < size(); ++idx) {
+        for (size_t idx = 0; idx < size(); ++idx) {
             consumer(*arr[idx]);
         }
     }

--- a/src/index.h
+++ b/src/index.h
@@ -18,7 +18,7 @@ class Index {
     std::unordered_map<std::string, size_t> _idx_map;
   
   public:
-    size_t indexOf(std::string value) {
+    size_t indexOf(const std::string& value) {
         return _idx_map.insert({value, _idx_map.size()}).first->second;
     }
 

--- a/src/index.h
+++ b/src/index.h
@@ -26,10 +26,6 @@ class Index {
         return _idx_map.size();
     }
 
-    void clear() {
-        _idx_map.clear();
-    }
-
     void forEachOrdered(std::function<void(const std::string&)> consumer) const {
         std::vector<const std::string*> arr(_idx_map.size());
         for (const auto& it : _idx_map) {

--- a/src/jfrMetadata.cpp
+++ b/src/jfrMetadata.cpp
@@ -280,7 +280,4 @@ JfrMetadata::JfrMetadata() : Element("root") {
             << type("jdk.jfr.Percentage", T_PERCENTAGE, "Percentage"))
 
         << element("region").attribute("locale", "en_US").attribute("gmtOffset", "0");
-
-    // The map is used only during construction
-    _strings.clear();
 }

--- a/src/jfrMetadata.cpp
+++ b/src/jfrMetadata.cpp
@@ -6,8 +6,7 @@
 #include "jfrMetadata.h"
 
 
-std::map<std::string, int> Element::_string_map;
-std::vector<std::string> Element::_strings;
+Index Element::_strings;
 
 JfrMetadata JfrMetadata::_root;
 
@@ -283,5 +282,5 @@ JfrMetadata::JfrMetadata() : Element("root") {
         << element("region").attribute("locale", "en_US").attribute("gmtOffset", "0");
 
     // The map is used only during construction
-    _string_map.clear();
+    _strings.clear();
 }

--- a/src/jfrMetadata.h
+++ b/src/jfrMetadata.h
@@ -229,10 +229,6 @@ class JfrMetadata : Element {
         return &_root;
     }
 
-    static void forEachStringOrdered(std::function<void(const std::string&)> consumer) {
-        _strings.forEachOrdered(consumer);
-    }
-
     static const Index& strings() {
         return _strings;
     }

--- a/src/jfrMetadata.h
+++ b/src/jfrMetadata.h
@@ -7,7 +7,6 @@
 #define _JFRMETADATA_H
 
 #include <string>
-#include <map>
 #include <vector>
 #include <stdio.h>
 #include <string.h>

--- a/src/jfrMetadata.h
+++ b/src/jfrMetadata.h
@@ -11,6 +11,7 @@
 #include <vector>
 #include <stdio.h>
 #include <string.h>
+#include "index.h"
 
 
 enum JfrType {
@@ -93,17 +94,10 @@ class Attribute {
 
 class Element {
   protected:
-    static std::map<std::string, int> _string_map;
-    static std::vector<std::string> _strings;
+    static Index _strings;
 
     static int getId(const char* s) {
-        std::string str(s);
-        int id = _string_map[str];
-        if (id == 0) {
-            id = _string_map[str] = _string_map.size();
-            _strings.push_back(str);
-        }
-        return id - 1;
+        return _strings.indexOf(s);
     }
 
   public:
@@ -236,8 +230,12 @@ class JfrMetadata : Element {
         return &_root;
     }
 
-    static std::vector<std::string>& strings() {
-        return _strings;
+    static void forEachStringOrdered(std::function<void(const std::string&)> consumer) {
+        _strings.forEachOrdered(consumer);
+    }
+
+    static size_t stringsSize() {
+        return _strings.size();
     }
 };
 

--- a/src/jfrMetadata.h
+++ b/src/jfrMetadata.h
@@ -233,8 +233,8 @@ class JfrMetadata : Element {
         _strings.forEachOrdered(consumer);
     }
 
-    static size_t stringsSize() {
-        return _strings.size();
+    static const Index& strings() {
+        return _strings;
     }
 };
 

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1667,7 +1667,7 @@ void Profiler::dumpOtlp(Writer& out, Arguments& args) {
     struct SampleInfo {
         u64 counter;
         u64 samples;
-        u32 num_frames;
+        size_t num_frames;
     };
     std::vector<SampleInfo> samples_info;
     samples_info.reserve(call_trace_samples.size());
@@ -1678,15 +1678,15 @@ void Profiler::dumpOtlp(Writer& out, Arguments& args) {
         CallTrace* trace = cts->acquireTrace();
         if (trace == NULL || excludeTrace(&fn, trace) || cts->samples == 0) continue;
 
-        samples_info.push_back(SampleInfo{cts->samples, cts->counter, (u32)trace->num_frames});
+        samples_info.push_back(SampleInfo{cts->samples, cts->counter, (size_t)trace->num_frames});
         for (int j = 0; j < trace->num_frames; j++) {
-            u32 function_idx = functions.indexOf(fn.name(trace->frames[j]));
+            size_t function_idx = functions.indexOf(fn.name(trace->frames[j]));
             otlp_buffer.putVarInt(function_idx);
         }
     }
     otlp_buffer.commitMessage(location_indices_mark);
 
-    u64 frames_seen = 0;
+    size_t frames_seen = 0;
     for (const SampleInfo& si : samples_info) {
         protobuf_mark_t sample_mark = otlp_buffer.startMessage(Profile::sample, 1);
         otlp_buffer.field(Sample::locations_start_index, frames_seen);
@@ -1720,7 +1720,7 @@ void Profiler::dumpOtlp(Writer& out, Arguments& args) {
     });
 
     // Write location_table
-    for (u64 function_idx = 0; function_idx < functions.size(); ++function_idx) {
+    for (size_t function_idx = 0; function_idx < functions.size(); ++function_idx) {
         protobuf_mark_t location_mark = otlp_buffer.startMessage(ProfilesDictionary::location_table, 1);
         // TODO: set to the proper mapping when new mappings are added.
         // For now we keep a dummy default mapping_index for all locations because some parsers


### PR DESCRIPTION
### Description
We can clean up `jfrMetadata.cpp` a bit by using `index.h`.

### How has this been tested?
GHA

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
