### PR TITLE
Change stackwalker test checks to be more restrictive

### DIFF
--- a/test/test/stackwalker/StackwalkerTests.java
+++ b/test/test/stackwalker/StackwalkerTests.java
@@ -25,8 +25,8 @@ public class StackwalkerTests {
         assert output.contains("^Java_test_stackwalker_StackGenerator_largeFrame;" +
                 "doCpuTask");
 
-        // There will be no stack frame that contains both main & largeFrame method
-        assert !output.contains(".*main.*largeFrame");
+        // There will be no stack frame that contains both main & largeFrame native method
+        assert !output.contains(".*main.*Java_test_stackwalker_StackGenerator_largeFrame");
     }
 
     @Test(mainClass = StackGenerator.class, jvmArgs = "-Xss5m", args = "deepFrame",
@@ -47,8 +47,8 @@ public class StackwalkerTests {
                 "generateDeepStack[^;]*;" +
                 "doCpuTask");
 
-        // There will be no stack frame that contains both main & deepFrame method
-        assert !output.contains(".*main.*deepFrame");
+        // There will be no stack frame that contains both main & deepFrame native method
+        assert !output.contains(".*main.*Java_test_stackwalker_StackGenerator_deepFrame");
     }
 
     @Test(mainClass = StackGenerator.class, jvmArgs = "-Xss5m", args = "leafFrame",

--- a/test/test/stackwalker/StackwalkerTests.java
+++ b/test/test/stackwalker/StackwalkerTests.java
@@ -25,8 +25,8 @@ public class StackwalkerTests {
         assert output.contains("^Java_test_stackwalker_StackGenerator_largeFrame;" +
                 "doCpuTask");
 
-        // There will be no stack frame that contains both main & largeFrame native method
-        assert !output.contains(".*main.*Java_test_stackwalker_StackGenerator_largeFrame");
+        // There will be no stack frame that contains main method, largeFrame native method & doCpuTask
+        assert !output.contains(".*main.*Java_test_stackwalker_StackGenerator_largeFrame.*doCpuTask");
     }
 
     @Test(mainClass = StackGenerator.class, jvmArgs = "-Xss5m", args = "deepFrame",
@@ -47,8 +47,8 @@ public class StackwalkerTests {
                 "generateDeepStack[^;]*;" +
                 "doCpuTask");
 
-        // There will be no stack frame that contains both main & deepFrame native method
-        assert !output.contains(".*main.*Java_test_stackwalker_StackGenerator_deepFrame");
+        // There will be no stack frame that contains main method, deepFrame native method & doCpuTask
+        assert !output.contains(".*main.*Java_test_stackwalker_StackGenerator_deepFrame.*doCpuTask");
     }
 
     @Test(mainClass = StackGenerator.class, jvmArgs = "-Xss5m", args = "leafFrame",


### PR DESCRIPTION
### Description
Change the assertions on Stackwalker tests to be more restrictive to avoid false negatives
The check now explicitly checks for main with native stack frame from the JNI call which shouldn't exist due to unwinding checks 

### Related issues
N/A

### Motivation and context
reduce random failures on GHA

### How has this been tested?
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
