### PR TITLE
Add mapping info to OTLP profiling data

### DIFF
--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -778,7 +778,7 @@ class Recording {
         buf->putVar32(0);
         buf->putVar32(0x7fffffff);  // must not clash with JFR metadata ID, or 'jfr print' will break
 
-        const Index& strings = JfrMetadata::strings();
+        const Index<std::string>& strings = JfrMetadata::strings();
         buf->putVar32(strings.size());
         strings.forEachOrdered([&] (const std::string& s) {
             buf->putUtf8(s.c_str());

--- a/src/frameName.cpp
+++ b/src/frameName.cpp
@@ -340,7 +340,7 @@ FrameInfo FrameName::frameInfo(ASGCT_CallFrame& frame, bool for_matching) {
 }
 
 const char* FrameName::name(ASGCT_CallFrame& frame, bool for_matching) {
-    return frameInfo(frame).get_name();
+    return frameInfo(frame, for_matching).get_name();
 }
 
 FrameTypeId FrameName::type(ASGCT_CallFrame& frame) {

--- a/src/frameName.h
+++ b/src/frameName.h
@@ -49,6 +49,49 @@ class Matcher {
     bool matches(const char* s);
 };
 
+class FrameInfo {
+  private:
+    const char* _name;
+    // E.g. non demangled name
+    const char* _system_name;
+    const char* _file_name;
+    const CodeCache* _cc;
+    const u64 _address;
+    const u64 _line;
+
+  public:
+    FrameInfo(const char* name, const char* system_name, const char* file_name, const CodeCache* cc, u64 address, u64 line) :
+      _name(name), _system_name(system_name), _file_name(file_name), _cc(cc), _address(address), _line(line) {}
+
+    FrameInfo(const char* name, const char* system_name, const CodeCache* cc) :
+      FrameInfo(name, system_name, nullptr, cc, 0, 0) {}
+
+    FrameInfo(const char* name) : FrameInfo(name, nullptr, nullptr, nullptr, 0, 0) {}
+
+    const char* get_name() const {
+      return _name;
+    }
+
+    const char* get_system_name() const {
+      return _system_name;
+    }
+
+    const char* get_file_name() const {
+      return _file_name;
+    }
+
+    const CodeCache* get_lib() const {
+      return _cc;
+    }
+
+    u64 get_address() const {
+      return _address;
+    }
+
+    u64 get_line() const {
+      return _line;
+    }
+};
 
 class FrameName {
   private:
@@ -67,7 +110,7 @@ class FrameName {
     locale_t _saved_locale;
 
     void buildFilter(std::vector<Matcher>& vector, const char* base, int offset);
-    const char* decodeNativeSymbol(const char* name);
+    const char* decodeNativeSymbol(const char* name, const CodeCache* cc);
     const char* typeSuffix(FrameTypeId type);
     void javaMethodName(jmethodID method);
     void javaClassName(const char* symbol, size_t length, int style);
@@ -76,6 +119,7 @@ class FrameName {
     FrameName(Arguments& args, int style, int epoch, Mutex& thread_names_lock, ThreadMap& thread_names);
     ~FrameName();
 
+    FrameInfo frameInfo(ASGCT_CallFrame& frame, bool for_matching = false);
     const char* name(ASGCT_CallFrame& frame, bool for_matching = false);
     FrameTypeId type(ASGCT_CallFrame& frame);
 

--- a/src/frameName.h
+++ b/src/frameName.h
@@ -12,6 +12,7 @@
 #include <vector>
 #include <string>
 #include "arguments.h"
+#include "codeCache.h"
 #include "mutex.h"
 #include "vmEntry.h"
 

--- a/src/index.h
+++ b/src/index.h
@@ -7,15 +7,15 @@
 #define _INDEX_H
 
 #include <functional>
-#include <string>
 #include <unordered_map>
 #include <vector>
 #include "arch.h"
 
 // Keeps track of values seen and their index of occurrence
+template<class T>
 class Index {
   private:
-    std::unordered_map<std::string, size_t> _idx_map;
+    std::unordered_map<T, size_t> _idx_map;
   
   public:
     Index() = default;
@@ -25,7 +25,7 @@ class Index {
     Index& operator=(const Index&) = delete;
     Index& operator=(Index&&) = delete;
 
-    size_t indexOf(const std::string& value) {
+    size_t indexOf(const T& value) {
         return _idx_map.insert({value, _idx_map.size()}).first->second;
     }
 
@@ -33,8 +33,8 @@ class Index {
         return _idx_map.size();
     }
 
-    void forEachOrdered(std::function<void(const std::string&)> consumer) const {
-        std::vector<const std::string*> arr(_idx_map.size());
+    void forEachOrdered(std::function<void(const T&)> consumer) const {
+        std::vector<const T*> arr(_idx_map.size());
         for (const auto& it : _idx_map) {
             arr[it.second] = &it.first;
         }

--- a/src/jfrMetadata.cpp
+++ b/src/jfrMetadata.cpp
@@ -6,7 +6,7 @@
 #include "jfrMetadata.h"
 
 
-Index Element::_strings;
+Index<std::string> Element::_strings;
 
 JfrMetadata JfrMetadata::_root;
 

--- a/src/jfrMetadata.h
+++ b/src/jfrMetadata.h
@@ -93,7 +93,7 @@ class Attribute {
 
 class Element {
   protected:
-    static Index _strings;
+    static Index<std::string> _strings;
 
     static int getId(const char* s) {
         return _strings.indexOf(s);
@@ -229,7 +229,7 @@ class JfrMetadata : Element {
         return &_root;
     }
 
-    static const Index& strings() {
+    static const Index<std::string>& strings() {
         return _strings;
     }
 };

--- a/src/otlp.h
+++ b/src/otlp.h
@@ -6,65 +6,112 @@
 #ifndef _OTLP_H
 #define _OTLP_H
 
+#include <cstdint>
 #include "protobuf.h"
+
+#define NO_COPY_MOVE(TypeName)                   \
+  TypeName(const TypeName&) = delete;            \
+  TypeName(TypeName&&) = delete;                 \
+  TypeName& operator=(const TypeName&) = delete; \
+  TypeName& operator=(TypeName&&) = delete;      \
 
 namespace Otlp {
 
 const u32 OTLP_BUFFER_INITIAL_SIZE = 5120;
 
 namespace ProfilesDictionary {
-    const protobuf_index_t mapping_table = 1;
-    const protobuf_index_t location_table = 2;
-    const protobuf_index_t function_table = 3;
-    const protobuf_index_t string_table = 5;
+    const protobuf_index_t MAPPING_TABLE = 1;
+    const protobuf_index_t LOCATION_TABLE = 2;
+    const protobuf_index_t FUNCTION_TABLE = 3;
+    const protobuf_index_t STRING_TABLE = 5;
 }
 
 namespace ProfilesData {
-    const protobuf_index_t resource_profiles = 1;
-    const protobuf_index_t dictionary = 2;
+    const protobuf_index_t RESOURCE_PROFILES = 1;
+    const protobuf_index_t DICTIONARY = 2;
 }
 
 namespace ResourceProfiles {
-    const protobuf_index_t scope_profiles = 2;
+    const protobuf_index_t SCOPE_PROFILES = 2;
 }
 
 namespace ScopeProfiles {
-    const protobuf_index_t profiles = 2;
+    const protobuf_index_t PROFILES = 2;
 }
 
 namespace Profile {
-    const protobuf_index_t sample_type = 1;
-    const protobuf_index_t sample = 2;
-    const protobuf_index_t location_indices = 3;
-    const protobuf_index_t period_type = 6;
-    const protobuf_index_t period = 7;
+    const protobuf_index_t SAMPLE_TYPE = 1;
+    const protobuf_index_t SAMPLE = 2;
+    const protobuf_index_t LOCATION_INDICES = 3;
+    const protobuf_index_t PERIOD_TYPE = 6;
+    const protobuf_index_t PERIOD = 7;
 }
 
 namespace ValueType {
-    const protobuf_index_t type_strindex = 1;
-    const protobuf_index_t unit_strindex = 2;
-    const protobuf_index_t aggregation_temporality = 3;
+    const protobuf_index_t TYPE_STRINDEX = 1;
+    const protobuf_index_t UNIT_STRINDEX = 2;
+    const protobuf_index_t AGGREGATION_TEMPORALITY = 3;
 }
 
 namespace Sample {
-    const protobuf_index_t locations_start_index = 1;
-    const protobuf_index_t locations_length = 2;
-    const protobuf_index_t value = 3;
+    const protobuf_index_t LOCATIONS_START_INDEX = 1;
+    const protobuf_index_t LOCATIONS_LENGTH = 2;
+    const protobuf_index_t VALUE = 3;
 }
 
-namespace Location {
-    const protobuf_index_t mapping_index = 1;
-    const protobuf_index_t line = 3;
-}
+class Line {
+  public:
+    static const protobuf_index_t FUNCTION_INDEX = 1;
+    static const protobuf_index_t LINE = 2;
 
-namespace Function {
-    const protobuf_index_t name_strindex = 1;
-    const protobuf_index_t filename_strindex = 3;
-}
+    const size_t function_index;
+    const u64 line;
 
-namespace Line {
-    const protobuf_index_t function_index = 1;
-}
+    Line(size_t function_index, u64 line) : function_index(function_index), line(line) {}
+
+    bool operator==(const Line& other) const {
+        return function_index == other.function_index && line == other.line;
+    }
+};
+
+class Location {
+  public:
+    static const protobuf_index_t MAPPING_INDEX = 1;
+    static const protobuf_index_t ADDRESS = 2;
+    static const protobuf_index_t LINE = 3;
+
+    const size_t mapping_index;
+    const u64 address;
+    const Line line;
+
+    Location(size_t mapping_index, u64 address, Line line) :
+        mapping_index(mapping_index), address(address), line(line) {}
+
+    bool operator==(const Location& other) const {
+        return mapping_index == other.mapping_index
+            && address == other.address
+            && line == other.line;
+    }
+};
+
+class Function {
+  public:
+    static const protobuf_index_t NAME_STRINDEX = 1;
+    static const protobuf_index_t FILENAME_STRINDEX = 3;
+
+    const size_t name_strindex;
+    const size_t system_name_strindex;
+    const size_t file_name_strindex;
+
+    Function(size_t name_strindex, size_t system_name_strindex, size_t file_name_strindex) :
+        name_strindex(name_strindex), system_name_strindex(system_name_strindex), file_name_strindex(file_name_strindex) {}
+
+    bool operator==(const Function& other) const {
+        return name_strindex == other.name_strindex
+            && system_name_strindex == other.system_name_strindex
+            && file_name_strindex == other.file_name_strindex;
+    }
+};
 
 namespace AggregationTemporality {
     const u64 unspecified = 0;
@@ -72,6 +119,58 @@ namespace AggregationTemporality {
     const u64 cumulative = 2;
 }
 
+class Mapping {
+  public:
+    static const protobuf_index_t MEMORY_START = 1;
+    static const protobuf_index_t MEMORY_LIMIT = 2;
+    static const protobuf_index_t FILENAME_STRINDEX = 4;
+
+    const uintptr_t memory_start;
+    const uintptr_t memory_limit;
+    const size_t file_name_strindex;
+
+    Mapping(uintptr_t memory_start, uintptr_t memory_limit, size_t file_name_strindex) :
+        memory_start(memory_start), memory_limit(memory_limit), file_name_strindex(file_name_strindex) {}
+
+    bool operator==(const Mapping& other) const {
+        return memory_start == other.memory_start
+            && memory_limit == other.memory_limit
+            && file_name_strindex == other.file_name_strindex;
+    }
+};
+
+}
+
+namespace std {
+    template <>
+    struct hash<Otlp::Mapping> {
+        size_t operator()(const Otlp::Mapping& m) const {
+            size_t h1 = std::hash<size_t>()(m.file_name_strindex);
+            size_t h2 = std::hash<uintptr_t>()(m.memory_start);
+            size_t h3 = std::hash<uintptr_t>()(m.memory_limit);
+            return h1 ^ (h2 << 1) ^ (h3 << 2);
+        }
+    };
+
+    template <>
+    struct hash<Otlp::Function> {
+        size_t operator()(const Otlp::Function& f) const {
+            size_t h1 = std::hash<size_t>()(f.name_strindex);
+            size_t h2 = std::hash<u64>()(f.file_name_strindex);
+            return h1 ^ (h2 << 1);
+        }
+    };
+
+    template <>
+    struct hash<Otlp::Location> {
+        size_t operator()(const Otlp::Location& l) const {
+            size_t h1 = std::hash<size_t>()(l.mapping_index);
+            size_t h2 = std::hash<u64>()(l.address);
+            size_t h3 = std::hash<size_t>()(l.line.function_index);
+            size_t h4 = std::hash<u64>()(l.line.line);
+            return h1 ^ (h2 << 1) ^ (h3 << 2) ^ (h4 << 3);
+        }
+    };
 }
 
 #endif // _OTLP_H

--- a/src/otlp.h
+++ b/src/otlp.h
@@ -9,12 +9,6 @@
 #include <cstdint>
 #include "protobuf.h"
 
-#define NO_COPY_MOVE(TypeName)                   \
-  TypeName(const TypeName&) = delete;            \
-  TypeName(TypeName&&) = delete;                 \
-  TypeName& operator=(const TypeName&) = delete; \
-  TypeName& operator=(TypeName&&) = delete;      \
-
 namespace Otlp {
 
 const u32 OTLP_BUFFER_INITIAL_SIZE = 5120;

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -248,15 +248,14 @@ const void* Profiler::resolveSymbol(const char* name) {
 
 // For BCI_NATIVE_FRAME, library index is encoded ahead of the symbol name
 const char* Profiler::getLibraryName(const char* native_symbol) {
-    short lib_index = NativeFunc::libIndex(native_symbol);
-    if (lib_index >= 0 && lib_index < _native_libs.count()) {
-        const char* s = _native_libs[lib_index]->name();
-        if (s != NULL) {
-            const char* p = strrchr(s, '/');
-            return p != NULL ? p + 1 : s;
-        }
-    }
-    return NULL;
+    const CodeCache* cc = getLibrary(native_symbol);
+    if (cc == NULL) return NULL;
+
+    const char* s = cc->name();
+    if (s == NULL) return NULL;
+
+    const char* p = strrchr(s, '/');
+    return p != NULL ? p + 1 : s;
 }
 
 const CodeCache* Profiler::getLibrary(const char* native_symbol) {

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1664,7 +1664,6 @@ void Profiler::dumpOtlp(Writer& out, Arguments& args) {
     Index<Function> functions;
     Index<Mapping> mappings;
     const size_t empty_mapping_idx = mappings.indexOf(Mapping{0, 0, strings.indexOf("")});
-
     Index<Location> locations;
 
     protobuf_mark_t resource_profiles_mark = otlp_buffer.startMessage(ProfilesData::RESOURCE_PROFILES);

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -217,6 +217,7 @@ class Profiler {
     void updateSymbols(bool kernel_symbols);
     const void* resolveSymbol(const char* name);
     const char* getLibraryName(const char* native_symbol);
+    const CodeCache* getLibrary(const char* native_symbol);
     CodeCache* findJvmLibrary(const char* lib_name);
     CodeCache* findLibraryByName(const char* lib_name);
     CodeCache* findLibraryByAddress(const void* address);


### PR DESCRIPTION
### Description
In this PR I add [`Mapping`](https://github.com/open-telemetry/opentelemetry-proto/blob/fe18c4b149ed308a7af4b47075c32742e30ebd59/opentelemetry/proto/profiles/v1development/profiles.proto#L417) information to OTLP profiles. I fill the following fields:
- `memory_start`
- `memory_limit`
- `file_name_strindex`

Other changes:
- made `Index` generic, such that it can be used for other key types than `std::string`
- changed constant naming in `otlp.h` (`mapping_table` -> `MAPPING_TABLE`)
- converted `Location`, `Line` and `Function` (`otlp.h`) from namespaces to hashable classes, such that they can be used with `Index<T>` for deduplication.

### Motivation and context
Having mapping data is useful for consumers of OTLP data, since it allows showing more information about the profile. It's optional but nice to have.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
