### PR TITLE
Cancel redundant in-progress GHA runs

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -1,7 +1,11 @@
 name: code-check
 
 on:
-- pull_request
+  - pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   cpp-lint:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -4,6 +4,10 @@ on:
   - push
   - pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   license-header:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -4,6 +4,10 @@ on:  # We are very liberal in terms of triggering builds. This should be revisit
   - push
   - pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   java_default_distribution: corretto
   java_default_version: 11


### PR DESCRIPTION
### Description
In this PR I introduce some changes to cancel in-progress GHA runs when they are superseded by a new run:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```
This advices the workflow orchestrator to cancel any previous run of group `${{ github.workflow }}-${{ github.ref }}`. Variable references [here](https://docs.github.com/en/actions/reference/contexts-reference#github-context), more info in [GHA docs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow).

### Related issues
n/a

### Motivation and context
Keeping redundant runs is generally not useful: 
- it does not provide useful information for the developer, since the most recent run is what we're interested in
- it clutters the GitHub Actions UI and CLI
- it consumes computing resources

### How has this been tested?
n/a

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
