### PR TITLE
Ensure that only files under `src/` are checked by the linter in `cpp-lint-diff`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ cpp-lint:
 
 DIFF_BASE=
 cpp-lint-diff:
-	git diff -U0 $(DIFF_BASE) -- '**/*.cpp' '**/*.h' ':!**/rustDemangle.cpp' | \
+	git diff -U0 $(DIFF_BASE) -- 'src/*.cpp' 'src/**/*.cpp' 'src/*.h' 'src/**/*.h' ':!**/rustDemangle.cpp' | \
 		clang-tidy-diff.py -p1 $(CLANG_TIDY_ARGS_EXTRA) -- -x c++ $(CXXFLAGS) $(INCLUDES) $(DEFS) $(LIBS)
 
 check-md:


### PR DESCRIPTION
### Description
I noticed that the current configuration does not filter out files out of `src/`. Example [here](https://github.com/fandreuz/async-profiler/actions/runs/16101824422/job/45431945162#step:6:109).

### Related issues
n/a

### Motivation and context
As discussed, static code analysis should not run on test code for now.

### How has this been tested?
Manual testing.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
