### PR TITLE
Save all generated logs for debug purposes

### DIFF
--- a/test/one/profiler/test/TestProcess.java
+++ b/test/one/profiler/test/TestProcess.java
@@ -246,7 +246,7 @@ public class TestProcess implements Closeable {
 
             for (String key : tmpFiles.keySet()) {
                 if (!key.equals(STDERR) && !key.equals(STDOUT)) {
-                    moveLog(tmpFiles.get(key), key.replaceAll("%", ""), true);
+                    moveLog(tmpFiles.get(key), key.substring(1), true);
                 }
             }
         } catch (IOException e) {


### PR DESCRIPTION
### Description
keep all logs for debugging purposes 
This fix the following problems:
* If multiple profiling sessions are done, each session will overwrite the previous one logs 
* If a test depends on both profiler session logs & process logs only one of those logs will be kept
* Not all generated profiler logs were saved

### Related issues
N/A

### Motivation and context
Make debugging flakey tests easier

### How has this been tested?
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
