### PR TITLE
Correctly check if profiler is preloaded

### DIFF
--- a/src/os.h
+++ b/src/os.h
@@ -104,6 +104,7 @@ class OS {
     static void copyFile(int src_fd, int dst_fd, off_t offset, size_t size);
     static void freePageCache(int fd, off_t start_offset);
     static int mprotect(void* addr, size_t size, int prot);
+    static bool checkPreloaded();
 };
 
 #endif // _OS_H

--- a/src/os.h
+++ b/src/os.h
@@ -104,6 +104,7 @@ class OS {
     static void copyFile(int src_fd, int dst_fd, off_t offset, size_t size);
     static void freePageCache(int fd, off_t start_offset);
     static int mprotect(void* addr, size_t size, int prot);
+
     static bool checkPreloaded();
 };
 

--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -394,14 +394,12 @@ static int checkPreloadedCallback(dl_phdr_info* info, size_t size, void* data) {
     Dl_info* dl_info = (Dl_info*)data;
 
     Dl_info current_info = dl_info[0];
-    Dl_info sigaction_info = dl_info[1];
+    Dl_info exit_info = dl_info[1];
 
-    if (info->dlpi_name == NULL) {
-        return 0;
-    } else if ((void*)info->dlpi_addr == current_info.dli_fbase) {
+    if ((void*)info->dlpi_addr == current_info.dli_fbase) {
         // async-profiler found first
         return 1;
-    } else if ((void*)info->dlpi_addr == sigaction_info.dli_fbase) {
+    } else if ((void*)info->dlpi_addr == exit_info.dli_fbase) {
         // libc found first
         return -1;
     }
@@ -418,17 +416,17 @@ bool OS::checkPreloaded() {
 
     // Find async-profiler shared objects
     Dl_info current_info;
-    if (dladdr((const void*)OS::checkPreloaded, &current_info) == 0 || current_info.dli_fname == NULL) {
+    if (dladdr((const void*)OS::checkPreloaded, &current_info) == 0 || current_info.dli_fbase == NULL) {
         return false;
     }
 
     // Find libc shared objects
-    Dl_info sigaction_info;
-    if (dladdr((const void*)sigaction, &sigaction_info) == 0 || sigaction_info.dli_fname == NULL) {
+    Dl_info exit_info;
+    if (dladdr((const void*)exit, &exit_info) == 0 || exit_info.dli_fbase == NULL) {
         return false;
     }
 
-    Dl_info info[2] = {current_info, sigaction_info};
+    Dl_info info[2] = {current_info, exit_info};
 
     return dl_iterate_phdr(checkPreloadedCallback, (void*)info) == 1;
 }

--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -393,13 +393,13 @@ int OS::mprotect(void* addr, size_t size, int prot) {
 static int checkPreloadedCallback(dl_phdr_info* info, size_t size, void* data) {
     Dl_info* dl_info = (Dl_info*)data;
 
-    Dl_info current_info = dl_info[0];
-    Dl_info exit_info = dl_info[1];
+    Dl_info libprofiler = dl_info[0];
+    Dl_info libc = dl_info[1];
 
-    if ((void*)info->dlpi_addr == current_info.dli_fbase) {
+    if ((void*)info->dlpi_addr == libprofiler.dli_fbase) {
         // async-profiler found first
         return 1;
-    } else if ((void*)info->dlpi_addr == exit_info.dli_fbase) {
+    } else if ((void*)info->dlpi_addr == libc.dli_fbase) {
         // libc found first
         return -1;
     }
@@ -414,19 +414,19 @@ bool OS::checkPreloaded() {
         return false;
     }
 
-    // Find async-profiler shared objects
-    Dl_info current_info;
-    if (dladdr((const void*)OS::checkPreloaded, &current_info) == 0 || current_info.dli_fbase == NULL) {
+    // Find async-profiler shared object
+    Dl_info libprofiler;
+    if (dladdr((const void*)OS::checkPreloaded, &libprofiler) == 0) {
         return false;
     }
 
-    // Find libc shared objects
-    Dl_info exit_info;
-    if (dladdr((const void*)exit, &exit_info) == 0 || exit_info.dli_fbase == NULL) {
+    // Find libc shared object
+    Dl_info libc;
+    if (dladdr((const void*)exit, &libc) == 0) {
         return false;
     }
 
-    Dl_info info[2] = {current_info, exit_info};
+    Dl_info info[2] = {libprofiler, libc};
 
     return dl_iterate_phdr(checkPreloadedCallback, (void*)info) == 1;
 }

--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -407,8 +407,8 @@ static int checkPreloadedCallback(dl_phdr_info* info, size_t size, void* data) {
     return 0;
 }
 
-// Checks if the async is included in the preload list defined in the LD_PRELOAD env variable
-// This check is done by checking if the async-profiler is loaded before libc shared objects
+// Checks if async-profiler is preloaded through the LD_PRELOAD mechanism.
+// This is done by analyzing the order of loaded dynamic libraries.
 bool OS::checkPreloaded() {
     if (getenv("LD_PRELOAD") == NULL) {
         return false;
@@ -427,7 +427,6 @@ bool OS::checkPreloaded() {
     }
 
     Dl_info info[2] = {libprofiler, libc};
-
     return dl_iterate_phdr(checkPreloadedCallback, (void*)info) == 1;
 }
 

--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -431,5 +431,4 @@ bool OS::checkPreloaded() {
     return dl_iterate_phdr(checkPreloadedCallback, (void*)info) == 1;
 }
 
-
 #endif // __linux__

--- a/src/os_macos.cpp
+++ b/src/os_macos.cpp
@@ -377,15 +377,15 @@ bool OS::checkPreloaded() {
         return false;
     }
 
-    // Find async-profiler shared objects
-    Dl_info current_info;
-    if (dladdr((const void*)OS::checkPreloaded, &current_info) == 0 || current_info.dli_fbase == NULL) {
+    // Find async-profiler shared object
+    Dl_info libprofiler;
+    if (dladdr((const void*)OS::checkPreloaded, &libprofiler) == 0) {
         return false;
     }
 
-    // Find libc shared objects
-    Dl_info exit_info;
-    if (dladdr((const void*)exit, &exit_info) == 0 || exit_info.dli_fbase == NULL) {
+    // Find libc shared object
+    Dl_info libc;
+    if (dladdr((const void*)exit, &libc) == 0) {
         return false;
     }
 
@@ -393,10 +393,10 @@ bool OS::checkPreloaded() {
     for (uint32_t i = 0; i < images; i++) {
         void* image = (void*)_dyld_get_image_header(i);
 
-        if (image == current_info.dli_fbase) {
+        if (image == libprofiler.dli_fbase) {
             // async-profiler found first
             return true;
-        } else if (image == exit_info.dli_fbase) {
+        } else if (image == libc.dli_fbase) {
             // libc found first
             return false;
         }

--- a/src/os_macos.cpp
+++ b/src/os_macos.cpp
@@ -379,25 +379,24 @@ bool OS::checkPreloaded() {
 
     // Find async-profiler shared objects
     Dl_info current_info;
-    if (dladdr((const void*)OS::checkPreloaded, &current_info) == 0 || current_info.dli_fname == NULL) {
+    if (dladdr((const void*)OS::checkPreloaded, &current_info) == 0 || current_info.dli_fbase == NULL) {
         return false;
     }
 
     // Find libc shared objects
-    Dl_info sigaction_info;
-    if (dladdr((const void*)sigaction, &sigaction_info) == 0 || sigaction_info.dli_fname == NULL) {
+    Dl_info exit_info;
+    if (dladdr((const void*)exit, &exit_info) == 0 || exit_info.dli_fbase == NULL) {
         return false;
     }
 
     uint32_t images = _dyld_image_count();
     for (uint32_t i = 0; i < images; i++) {
-        const char* image_name = _dyld_get_image_name(i);
-        if (image_name == NULL) {
-            continue;
-        } else if (strcmp(image_name, current_info.dli_fname) == 0) {
+        void* image = (void*)_dyld_get_image_header(i);
+
+        if (image == current_info.dli_fbase) {
             // async-profiler found first
             return true;
-        } else if (strcmp(image_name, sigaction_info.dli_fname) == 0) {
+        } else if (image == exit_info.dli_fbase) {
             // libc found first
             return false;
         }

--- a/src/os_macos.cpp
+++ b/src/os_macos.cpp
@@ -370,8 +370,8 @@ int OS::mprotect(void* addr, size_t size, int prot) {
     return vm_protect(mach_task_self(), (vm_address_t)addr, size, 0, prot);
 }
 
-// Checks if the async is included in the preload list defined in the DYLD_INSERT_LIBRARIES env variable
-// This check is done by checking if the async-profiler is loaded before libc shared objects
+// Checks if async-profiler is preloaded through the DYLD_INSERT_LIBRARIES mechanism.
+// This is done by analyzing the order of loaded dynamic libraries.
 bool OS::checkPreloaded() {
     if (getenv("DYLD_INSERT_LIBRARIES") == NULL) {
         return false;
@@ -391,12 +391,12 @@ bool OS::checkPreloaded() {
 
     uint32_t images = _dyld_image_count();
     for (uint32_t i = 0; i < images; i++) {
-        void* image = (void*)_dyld_get_image_header(i);
+        void* image_base = (void*)_dyld_get_image_header(i);
 
-        if (image == libprofiler.dli_fbase) {
+        if (image_base == libprofiler.dli_fbase) {
             // async-profiler found first
             return true;
-        } else if (image == libc.dli_fbase) {
+        } else if (image_base == libc.dli_fbase) {
             // libc found first
             return false;
         }

--- a/src/zInit.cpp
+++ b/src/zInit.cpp
@@ -23,7 +23,7 @@ class LateInitializer {
             dlopen(dl_info.dli_fname, RTLD_LAZY | RTLD_NODELETE);
         }
 
-        if (!checkJvmLoaded()) {
+        if (!checkJvmLoaded() && OS::checkPreloaded()) {
             const char* command = getenv("ASPROF_COMMAND");
             if (command != NULL && Hooks::init(false)) {
                 startProfiler(command);

--- a/src/zInit.cpp
+++ b/src/zInit.cpp
@@ -23,9 +23,9 @@ class LateInitializer {
             dlopen(dl_info.dli_fname, RTLD_LAZY | RTLD_NODELETE);
         }
 
-        if (!checkJvmLoaded() && OS::checkPreloaded()) {
+        if (!checkJvmLoaded()) {
             const char* command = getenv("ASPROF_COMMAND");
-            if (command != NULL && Hooks::init(false)) {
+            if (command != NULL && OS::checkPreloaded() && Hooks::init(false)) {
                 startProfiler(command);
             }
         }

--- a/test/one/profiler/test/TestProcess.java
+++ b/test/one/profiler/test/TestProcess.java
@@ -36,7 +36,7 @@ public class TestProcess implements Closeable {
 
     private static final String JAVA_HOME = System.getProperty("java.home");
 
-    private static final Pattern filePattern = Pattern.compile("(%[a-z]+)(\\.[a-z]+)?");
+    private static final Pattern filePattern = Pattern.compile("(%[a-z][a-z0-9_]*)(\\.[a-z]+)?");
 
     private static final MethodHandle pid = getPidHandle();
 

--- a/test/test/c/CTests.java
+++ b/test/test/c/CTests.java
@@ -9,14 +9,21 @@ import one.profiler.test.Output;
 import one.profiler.test.Test;
 import one.profiler.test.TestProcess;
 
+import java.io.File;
+
 public class CTests {
 
-    @Test(sh = "%testbin/native_api %f.jfr", output = true)
+    @Test(sh = "%testbin/native_api %api_file.jfr", output = true)
+    @Test(sh = "%testbin/native_api %api_file.jfr", env = {"ASPROF_COMMAND=start,cpu,file=%preload_file.jfr"},
+            output = true, nameSuffix="fake-preload")
     public void nativeApi(TestProcess p) throws Exception {
         Output out = p.waitForExit(TestProcess.STDOUT);
         assert p.exitCode() == 0;
         assert out.contains("Starting profiler");
         assert out.contains("Stopping profiler");
-        assert p.getFile("%f").length() > 0;
+        assert p.getFile("%api_file").length() > 0;
+
+        File preloadFile = p.getFile("%preload_file");
+        assert preloadFile == null || preloadFile.length() == 0;
     }
 }


### PR DESCRIPTION
### Description
Add proper checking to validate that the profiler was preloaded as to avoid false starts

Currently if `ASPROF_COMMAND` env variable is defined any dlopen on the profiler will cause it to start which means the profiler might start with incorrect profiling options

Furthermore in this case async-profiler will assume that preload hooks exists which might not be true, which will to incomplete profiling by the profiler

### Related issues
N/A

### Motivation and context
Avoid false early starts for the async-profiler

### How has this been tested?
New test added
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
