### PR TITLE
Create `test/deps` if it does not exist before running Makefile recipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ coverage: clean-coverage
 test: test-cpp test-java
 
 $(TEST_DEPS_DIR):
-	mkdir -p test/deps
+	mkdir -p $@
 
 build/$(TEST_JAR): build/$(API_JAR) $(TEST_SOURCES) build/$(CONVERTER_JAR) $(TEST_DEPS_DIR)
 	rm -rf build/test/classes

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ ifneq (,$(findstring $(ARCH_TAG),x86 x64 arm64))
   CXXFLAGS += -momit-leaf-frame-pointer
 endif
 
+
 .PHONY: all jar release build-test test clean coverage clean-coverage build-test-java build-test-cpp build-test-libs build-test-bins test-cpp test-java check-md format-md
 
 all: build/bin build/lib build/$(LIB_PROFILER) build/$(ASPROF) jar build/$(JFRCONV) build/$(ASPROF_HEADER)

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,9 @@ ifneq (,$(findstring $(ARCH_TAG),x86 x64 arm64))
   CXXFLAGS += -momit-leaf-frame-pointer
 endif
 
+# TEST_DEPS_DIR is a dependency for build/$(TEST_JAR), thus it must exist before the
+# recipe dependencies are evaluated.
+$(shell mkdir -p $(TEST_DEPS_DIR))
 
 .PHONY: all jar release build-test test clean coverage clean-coverage build-test-java build-test-cpp build-test-libs build-test-bins test-cpp test-java check-md format-md
 
@@ -272,6 +275,7 @@ coverage: clean-coverage
 
 test: test-cpp test-java
 
+# We should rebuild the JAR when a new file is added to $(TEST_DEPS_DIR)
 build/$(TEST_JAR): build/$(API_JAR) $(TEST_SOURCES) build/$(CONVERTER_JAR) $(TEST_DEPS_DIR)
 	rm -rf build/test/classes
 	mkdir -p build/test/classes

--- a/Makefile
+++ b/Makefile
@@ -133,10 +133,6 @@ ifneq (,$(findstring $(ARCH_TAG),x86 x64 arm64))
   CXXFLAGS += -momit-leaf-frame-pointer
 endif
 
-# TEST_DEPS_DIR is a dependency for build/$(TEST_JAR), thus it must exist before the
-# recipe dependencies are evaluated.
-$(shell mkdir -p $(TEST_DEPS_DIR))
-
 .PHONY: all jar release build-test test clean coverage clean-coverage build-test-java build-test-cpp build-test-libs build-test-bins test-cpp test-java check-md format-md
 
 all: build/bin build/lib build/$(LIB_PROFILER) build/$(ASPROF) jar build/$(JFRCONV) build/$(ASPROF_HEADER)
@@ -275,7 +271,9 @@ coverage: clean-coverage
 
 test: test-cpp test-java
 
-# We should rebuild the JAR when a new file is added to $(TEST_DEPS_DIR)
+$(TEST_DEPS_DIR):
+	mkdir -p test/deps
+
 build/$(TEST_JAR): build/$(API_JAR) $(TEST_SOURCES) build/$(CONVERTER_JAR) $(TEST_DEPS_DIR)
 	rm -rf build/test/classes
 	mkdir -p build/test/classes


### PR DESCRIPTION
### Description
`build/test.jar` has a dependency on `test/deps`, because the JAR should be rebuilt when a new dependency JAR is pulled in. In this PR I add an invocation to `mkdir` at the beginning of the Makefile to make sure that the directory exists.

### Related issues
@Baraa-Hasheesh experienced the problem in his local environment. We did not spot that during GHA runs because we pull in dependencies there (Protobuf Java runtime). 

### Motivation and context
The recipe should not fail if the directory does not exist.

### How has this been tested?
Tested locally.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
