### PR TITLE
Fix random failures from Live profiling

### DIFF
--- a/test/test/jfr/JfrMultiModeProfiling.java
+++ b/test/test/jfr/JfrMultiModeProfiling.java
@@ -27,6 +27,8 @@ public class JfrMultiModeProfiling {
         }
         executor.shutdown();
         allocate();
+
+        System.gc();
     }
 
     private static void cpuIntensiveIncrement() {


### PR DESCRIPTION
### Description
Fixes random test failures that happens for live profiling

https://github.com/async-profiler/async-profiler/actions/runs/16172680977/job/45650081518

It seems in some cases the VM dies without ever doing any GC events that are observed by the profiler
This causes the test to randomly fail sometimes

### Related issues
N/A

### Motivation and context
solve flakey test

### How has this been tested?
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
