### PR TITLE
Temporarily disable clang-tidy automatic comments

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -33,12 +33,3 @@ jobs:
             DIFF_BASE="$(git merge-base HEAD "upstream/${{ github.event.pull_request.base.ref }}")" \
             CLANG_TIDY_ARGS_EXTRA="-export-fixes clang-tidy-fixes.yml"
         shell: bash
-      - name: Run clang-tidy-pr-comments action
-        if: github.event.pull_request.draft == false
-        uses: platisd/clang-tidy-pr-comments@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          clang_tidy_fixes: clang-tidy-fixes.yml
-          python_path: python
-          auto_resolve_conversations: true
-          suggestions_per_comment: 100


### PR DESCRIPTION
### Description
In this PR I remove the step responsible for creating review comments based on the output from clang-tidy. I'll leave the step which runs clang-tidy so developers can still look at its output.

I'll revert this change when I find a solution to have a token which can get `pull-requests:write` permissions. Our organization configuration only grants read access.

### Related issues
n/a

### Motivation and context
In the current state, the step will fail with HTTP 403 whenever the action tries to create a comment.

### How has this been tested?
n/a

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
