### PR TITLE
Fix threading flaky tests

### DIFF
--- a/test/test/jfr/JfrMultiModeProfiling.java
+++ b/test/test/jfr/JfrMultiModeProfiling.java
@@ -21,7 +21,7 @@ public class JfrMultiModeProfiling {
     private static int count = 0;
 
     public static void main(String[] args) throws InterruptedException {
-        ExecutorService executor = Executors.newFixedThreadPool(2);
+        ExecutorService executor = Executors.newFixedThreadPool(Math.max(2, Runtime.getRuntime().availableProcessors()));
         for (int i = 0; i < 10; i++) {
             executor.submit(JfrMultiModeProfiling::cpuIntensiveIncrement);
         }

--- a/test/test/lock/DatagramTest.java
+++ b/test/test/lock/DatagramTest.java
@@ -50,7 +50,7 @@ public class DatagramTest {
         ch.bind(new InetSocketAddress(0));
         ch.configureBlocking(false);
 
-        Executor pool = Executors.newCachedThreadPool();
+        Executor pool = Executors.newFixedThreadPool(Math.max(2, Runtime.getRuntime().availableProcessors()));
         for (int i = 0; i < 10; i++) {
             pool.execute(DatagramTest::sendLoop);
         }


### PR DESCRIPTION
### Description
Fixes flakiness of some tests in async-profiler 

[datagramSocketLock](https://github.com/async-profiler/async-profiler/actions/runs/16151504646/job/45583762864)
Tests checks that CPU samples are taken in locks, however if not enough contention is created that would fail 
The idea is to allow as many threads as possible to run to create more contention on the resources

[parseMultiModeRecording](https://github.com/async-profiler/async-profiler/actions/runs/16167564928/job/45633054150)
Tests checks that a certain amount of contention happens on a synchronous lock 
The idea is to allow as many threads as possible to run to create more contention on the resources

[regularPeek](https://github.com/async-profiler/async-profiler/actions/runs/16144510319/job/45559845528)
Tests that certain events/samples are captured within certain time periods 
From what I could tell the executor.scheduleAtFixedRate starts the execution of the thread without waiting the full 4 seconds 
The idea of the fix to replace that logic with a simple `sleep` & while loop


### Related issues
#1343

### Motivation and context
reduce random failures on GHA

### How has this been tested?
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
