### PR TITLE
Fix crash when using VMX

### DIFF
--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <assert.h>
 #include <map>
 #include <string>
 #include <arpa/inet.h>
@@ -58,7 +59,7 @@ static jmethodID _start_method;
 static jmethodID _stop_method;
 static jmethodID _box_method;
 
-static const char* const SETTING_CSTACK[] = {NULL, "no", "fp", "dwarf", "lbr", "vm"};
+static const char* const SETTING_CSTACK[] = {NULL, "no", "fp", "dwarf", "lbr", "vm", "vmx"};
 
 
 struct CpuTime {
@@ -816,6 +817,7 @@ class Recording {
     }
 
     void writeSettings(Buffer* buf, Arguments& args) {
+        assert(args._cstack < sizeof(SETTING_CSTACK) / sizeof(char*));
         writeStringSetting(buf, T_ACTIVE_RECORDING, "version", PROFILER_VERSION);
         writeStringSetting(buf, T_ACTIVE_RECORDING, "engine", Profiler::instance()->_engine->type());
         writeStringSetting(buf, T_ACTIVE_RECORDING, "cstack", SETTING_CSTACK[args._cstack]);


### PR DESCRIPTION
### Description
VMX was messing from the `SETTING_CSTACK` array
This was causing crashes when running profiler in VMX 

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x0000f0aace283010, pid=6542, tid=6543
#
# JRE version: OpenJDK Runtime Environment Corretto-24.0.1.9.1 (24.0.1+9) (build 24.0.1+9-FR)
# Java VM: OpenJDK 64-Bit Server VM Corretto-24.0.1.9.1 (24.0.1+9-FR, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-aarch64)
# Problematic frame:
# C  [libc.so.6+0xa3010]
#
# Core dump will be written. Default location: Core dumps may be processed with "/usr/share/apport/apport -p%p -s%s -c%c -d%d -P%P -u%u -g%g -F%F -- %E" (or dumping to /home/ubuntu/async-profiler/core.6542)
#
# If you would like to submit a bug report, please visit:
#   https://github.com/corretto/corretto-24/issues/
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#

---------------  S U M M A R Y ------------

Command Line: -Djava.library.path=/home/ubuntu/async-profiler/build/test/lib -agentpath:/home/ubuntu/async-profiler/build/lib/libasyncProfiler.so=start,event=cpu,cstack=vmx,file=output.jfr --add-modules=ALL-DEFAULT jdk.compiler/com.sun.tools.javac.launcher.SourceLauncher test/test/stackwalker/StackGenerator.java deepFrame

Host: AArch64, 8 cores, 15G, Ubuntu 24.04.2 LTS
Time: Fri Jul 11 11:33:38 2025 UTC elapsed time: 0.062575 seconds (0d 0h 0m 0s)

---------------  T H R E A D  ---------------

Current thread (0x0000f0aac8596000):  JavaThread "main"             [_thread_in_native, id=6543, stack(0x0000f0aacca82000,0x0000f0aaccc80000) (2040K)]

Stack: [0x0000f0aacca82000,0x0000f0aaccc80000],  sp=0x0000f0aaccc7bfe0,  free space=2023k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libc.so.6+0xa3010]
C  [libasyncProfiler.so+0x32670]  Recording::writeSettings(Buffer*, Arguments&)+0xb0
C  [libasyncProfiler.so+0x41c54]  Profiler::start(Arguments&, bool)+0x1ac4
C  [libasyncProfiler.so+0x49890]  Profiler::run(Arguments&)+0x80
C  [libasyncProfiler.so+0x4a5e0]  VM::VMInit(_jvmtiEnv*, JNIEnv_*, _jobject*)+0x150
V  [libjvm.so+0xa32ff0]  JvmtiExport::post_vm_initialized()+0x300
V  [libjvm.so+0xe70270]  Threads::create_vm(JavaVMInitArgs*, bool*)+0x740
V  [libjvm.so+0x8e6d1c]  JNI_CreateJavaVM+0x7c
C  [libjli.so+0x3e20]  JavaMain+0x80
C  [libjli.so+0x78dc]  ThreadJavaMain+0xc
C  [libc.so.6+0x8595c]
```

This small change solves this crash & add a hard assertion to remind future developers about updating this array

### Related issues
N/A

### Motivation and context
solve crashes for VMX

### How has this been tested?
`make test` & local testing on various machines

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
