### PR TITLE
fix crashes when using instrument profiling

### DIFF
--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -123,18 +123,9 @@ jobs:
             # ARM MacOS should take fat binaries built on ARM
             asprof-binaries-job: macos
           - runson:
-              display: macos-x64
-              name: macos-13
-            java-version: 11
-            java-distribution: corretto
-            architecture: x64
-            image: ""
-            # x64 MacOS should take fat binaries built on ARM
-            asprof-binaries-job: macos
-          - runson:
               display: macos-arm64
               name: macos-15
-            java-version: 17
+            java-version: 21
             java-distribution: corretto
             # Not using container for mac-os as we have images only for linux
             image: ""

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -132,6 +132,24 @@ jobs:
             # x64 MacOS should take fat binaries built on ARM
             asprof-binaries-job: macos
           - runson:
+              display: macos-arm64
+              name: macos-15
+            java-version: 17
+            java-distribution: corretto
+            # Not using container for mac-os as we have images only for linux
+            image: ""
+            # ARM MacOS should take fat binaries built on ARM
+            asprof-binaries-job: macos
+          - runson:
+              display: macos-x64
+              name: macos-13
+            java-version: 17
+            java-distribution: corretto
+            architecture: x64
+            image: ""
+            # x64 MacOS should take fat binaries built on ARM
+            asprof-binaries-job: macos
+          - runson:
               display: linux-arm64
               # There is no "latest" tag available (yet) as ARM runners are still in public preview
               name: ubuntu-24.04-arm

--- a/src/instrument.cpp
+++ b/src/instrument.cpp
@@ -356,8 +356,7 @@ void BytecodeRewriter::rewriteStackMapTable() {
         } else if (frame_type <= 254) {
             // append_frame
             put16(get16());
-            // Explicit casting is done here to avoid bad implicit casting by compiler (frame_type is u8)
-            u8 count = frame_type - (u8)251;
+            u8 count = frame_type - (u8)251; // explicit cast to workaround clang type promotion bug
             for (u8 j = 0; j < count; j++) {
                 rewriteVerificationTypeInfo();
             }

--- a/src/instrument.cpp
+++ b/src/instrument.cpp
@@ -356,7 +356,9 @@ void BytecodeRewriter::rewriteStackMapTable() {
         } else if (frame_type <= 254) {
             // append_frame
             put16(get16());
-            for (u8 j = 0; j < frame_type - (u8)251; j++) {
+            // Explicit casting is done here to avoid bad implicit casting by compiler (frame_type is u8)
+            u8 count = frame_type - (u8)251;
+            for (u8 j = 0; j < count; j++) {
                 rewriteVerificationTypeInfo();
             }
         } else {

--- a/src/instrument.cpp
+++ b/src/instrument.cpp
@@ -356,7 +356,7 @@ void BytecodeRewriter::rewriteStackMapTable() {
         } else if (frame_type <= 254) {
             // append_frame
             put16(get16());
-            for (int j = 0; j < frame_type - 251; j++) {
+            for (u8 j = 0; j < frame_type - (u8)251; j++) {
                 rewriteVerificationTypeInfo();
             }
         } else {


### PR DESCRIPTION
### Description
From the looks of it for certain compilers an implicit casting was causing wrong logical & mathematical operations 
This in turn caused bad byte modification by the profiler for the Java class 

### Related issues
#1380

### Motivation and context
Fix bug in instrument profiling

### How has this been tested?
GHA added for macOs JDK 17 which was causing the issue to happen consistently 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
