### PR TITLE
Fix randomly failing tests

### DIFF
--- a/test/test/jfr/JfrMultiModeProfiling.java
+++ b/test/test/jfr/JfrMultiModeProfiling.java
@@ -21,7 +21,7 @@ public class JfrMultiModeProfiling {
     private static int count = 0;
 
     public static void main(String[] args) throws InterruptedException {
-        ExecutorService executor = Executors.newFixedThreadPool(2);
+        ExecutorService executor = Executors.newFixedThreadPool(Math.max(2, Runtime.getRuntime().availableProcessors()));
         for (int i = 0; i < 10; i++) {
             executor.submit(JfrMultiModeProfiling::cpuIntensiveIncrement);
         }

--- a/test/test/lock/LockTests.java
+++ b/test/test/lock/LockTests.java
@@ -15,7 +15,7 @@ public class LockTests {
     public void datagramSocketLock(TestProcess p) throws Exception {
         Output out = p.profile("-e cpu -d 3 -o collapsed --cstack dwarf");
         assert out.ratio("(PlatformEvent::.ark|PlatformEvent::.npark)") > 0.1
-                || ((out.ratio("ReentrantLock.lock") + out.ratio("ReentrantLock.unlock")) > 0.1 && out.contains("Unsafe_.ark"));
+                || ((out.ratio("ReentrantLock.lock") + out.ratio("ReentrantLock.unlock")) > 0.1 && out.contains("Unsafe_.{1,3}ark"));
         out = p.profile("-e lock -d 3 -o collapsed");
         assert out.contains("sun/nio/ch/DatagramChannelImpl.send");
     }


### PR DESCRIPTION
### Description
Fixes 2 randomly failing tests

[datagramSocketLock](https://github.com/async-profiler/async-profiler/actions/runs/16151504646/job/45583762864)
Failure happens as no samples exists that matches `Unsafe_.ark`
Regex updated to `Unsafe_.{1,3}ark` to match both `Unsafe_Park` & `Unsafe_Unpark`

[parseMultiModeRecording](https://github.com/async-profiler/async-profiler/actions/runs/16167564928/job/45633054150)
Tests checks that a certain amount of Lock samples happen on a synchronous lock
The idea is to allow as many threads as possible to run as to create more samples for that lock

### Related issues
#1343

### Motivation and context
reduce amount of random failures on GHA

### How has this been tested?
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
