### PR TITLE
improve terminate logic in dwarf and vm stack walking mode

### DIFF
--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -166,6 +166,7 @@ int StackWalker::walkDwarf(void* ucontext, const void** callchain, int max_depth
             break;
         }
 
+        const void* prev_pc = pc; 
         if (f->fp_off & DW_PC_OFFSET) {
             pc = (const char*)pc + (f->fp_off >> 1);
         } else {
@@ -190,7 +191,7 @@ int StackWalker::walkDwarf(void* ucontext, const void** callchain, int max_depth
             }
         }
 
-        if (inDeadZone(pc)) {
+        if (inDeadZone(pc) || (pc == prev_pc && sp == prev_sp)) {
             break;
         }
     }
@@ -408,6 +409,7 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
             break;
         }
 
+        const void* prev_pc = pc; 
         if (f->fp_off & DW_PC_OFFSET) {
             pc = (const char*)pc + (f->fp_off >> 1);
         } else {
@@ -432,7 +434,7 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
             }
         }
 
-        if (inDeadZone(pc)) {
+        if (inDeadZone(pc) || (pc == prev_pc && sp == prev_sp)) {
             break;
         }
     }


### PR DESCRIPTION
### Description
In Alpine, we have seen cases where unwinding does not terminate properly (only terminates after we reach maxDepth value). This results in flamegraphs with a lot of "duplicate" frames. This happens because during unwinding, the next "pc" is always equal to current "pc" after a certain point. 
In this PR, we add a check where we terminate the unwinding if `prev_sp == new_sp and prev_pc == new_pc`.

### Related issues
N/A

### How has this been tested?
Attached are before and after images of flame graphs for CPU profiling for [this application](https://github.com/async-profiler/async-profiler/blob/master/test/test/lock/DatagramTest.java) in Alpine

#### Before
<img width="2529" height="1350" alt="image" src="https://github.com/user-attachments/assets/89e841a3-95f9-4ecc-af06-000f6199d58f" />

#### After
<img width="2544" height="569" alt="image" src="https://github.com/user-attachments/assets/4d2ad59e-d214-43d9-a611-0c83e38b6cd2" />

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
