### PR TITLE
#1389: Incorrect top frame for synchronous events with cstack=vm on ARM64

### DIFF
--- a/src/arch.h
+++ b/src/arch.h
@@ -15,8 +15,6 @@
 #  define unlikely(x)  (__builtin_expect(!!(x), 0))
 #endif
 
-#define callerPC()     __builtin_return_address(0)
-
 #ifdef _LP64
 #  define LP64_ONLY(code) code
 #else // !_LP64
@@ -67,6 +65,7 @@ const int PERF_REG_PC = 8;  // PERF_REG_X86_IP
 #define rmb()             asm volatile("lfence" : : : "memory")
 #define flushCache(addr)  asm volatile("mfence; clflush (%0); mfence" : : "r" (addr) : "memory")
 
+#define callerPC()        __builtin_return_address(0)
 #define callerFP()        __builtin_frame_address(1)
 #define callerSP()        ((void**)__builtin_frame_address(0) + 2)
 
@@ -88,6 +87,7 @@ const int PERF_REG_PC = 15;  // PERF_REG_ARM_PC
 #define rmb()             asm volatile("dmb ish" : : : "memory")
 #define flushCache(addr)  __builtin___clear_cache((char*)(addr), (char*)(addr) + sizeof(instruction_t))
 
+#define callerPC()        __builtin_return_address(0)
 #define callerFP()        __builtin_frame_address(1)
 #define callerSP()        __builtin_frame_address(1)
 
@@ -108,8 +108,9 @@ const int PERF_REG_PC = 32;  // PERF_REG_ARM64_PC
 #define rmb()             asm volatile("dmb ish" : : : "memory")
 #define flushCache(addr)  __builtin___clear_cache((char*)(addr), (char*)(addr) + sizeof(instruction_t))
 
-#define callerFP()        __builtin_frame_address(1)
-#define callerSP()        __builtin_frame_address(1)
+#define callerPC()        ({ void* pc; asm volatile("adr %0, ."  : "=r"(pc)); pc; })
+#define callerFP()        ({ void* fp; asm volatile("mov %0, fp" : "=r"(fp)); fp; })
+#define callerSP()        ({ void* sp; asm volatile("mov %0, sp" : "=r"(sp)); sp; })
 
 #elif defined(__PPC64__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 
@@ -130,6 +131,7 @@ const int PERF_REG_PC = 32;  // PERF_REG_POWERPC_NIP
 #define rmb()             asm volatile ("sync" : : : "memory") // lwsync would do but better safe than sorry
 #define flushCache(addr)  __builtin___clear_cache((char*)(addr), (char*)(addr) + sizeof(instruction_t))
 
+#define callerPC()        __builtin_return_address(0)
 #define callerFP()        __builtin_frame_address(1)
 #define callerSP()        __builtin_frame_address(0)
 
@@ -154,6 +156,7 @@ const int PERF_REG_PC = 0;      // PERF_REG_RISCV_PC
 #define rmb()             asm volatile ("fence" : : : "memory")
 #define flushCache(addr)  __builtin___clear_cache((char*)(addr), (char*)(addr) + sizeof(instruction_t))
 
+#define callerPC()        __builtin_return_address(0)
 #define callerFP()        __builtin_frame_address(1)
 #define callerSP()        __builtin_frame_address(0)
 
@@ -174,6 +177,7 @@ const int PERF_REG_PC = 0;      // PERF_REG_LOONGARCH_PC
 #define rmb()             asm volatile("dbar 0x0" : : : "memory")
 #define flushCache(addr)  __builtin___clear_cache((char*)(addr), (char*)(addr) + sizeof(instruction_t))
 
+#define callerPC()        __builtin_return_address(0)
 #define callerFP()        __builtin_frame_address(1)
 #define callerSP()        __builtin_frame_address(0)
 

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -18,6 +18,8 @@ const intptr_t MAX_FRAME_SIZE = 0x40000;
 const intptr_t MAX_INTERPRETER_FRAME_SIZE = 0x1000;
 const intptr_t DEAD_ZONE = 0x1000;
 
+static ucontext_t empty_context{};
+
 
 static inline bool aligned(uintptr_t ptr) {
     return (ptr & (sizeof(uintptr_t) - 1)) == 0;
@@ -201,7 +203,7 @@ int StackWalker::walkDwarf(void* ucontext, const void** callchain, int max_depth
 
 int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, StackDetail detail) {
     if (ucontext == NULL) {
-        return walkVM(ucontext, frames, max_depth, detail,
+        return walkVM(&empty_context, frames, max_depth, detail,
                       callerPC(), (uintptr_t)callerSP(), (uintptr_t)callerFP());
     } else {
         StackFrame frame(ucontext);

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -18,7 +18,7 @@ const intptr_t MAX_FRAME_SIZE = 0x40000;
 const intptr_t MAX_INTERPRETER_FRAME_SIZE = 0x1000;
 const intptr_t DEAD_ZONE = 0x1000;
 
-static ucontext_t empty_context{};
+static ucontext_t empty_ucontext{};
 
 
 static inline bool aligned(uintptr_t ptr) {
@@ -203,7 +203,7 @@ int StackWalker::walkDwarf(void* ucontext, const void** callchain, int max_depth
 
 int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, StackDetail detail) {
     if (ucontext == NULL) {
-        return walkVM(&empty_context, frames, max_depth, detail,
+        return walkVM(&empty_ucontext, frames, max_depth, detail,
                       callerPC(), (uintptr_t)callerSP(), (uintptr_t)callerFP());
     } else {
         StackFrame frame(ucontext);


### PR DESCRIPTION
### Description

VMStructs-based stack walker could crash on ARM64 for allocation or nativemem events.

### Related issues

#1389 

### Motivation and context

The crash was caused by the combination of two issues:
1. gcc 13.3 changed frame prologue on AArch64. Previously, frame base `x29` was always pointing to `sp`, but now it is no longer the case. E.g.:
```
   2ba10:       d107c3ff        sub     sp, sp, #0x1f0
                                ...
   2ba20:       a91a7bfd        stp     x29, x30, [sp, #416]
   2ba24:       910683fd        add     x29, sp, #0x1a0
```
   Therefore, the value returned by `callerSP()` was incorrect. Since there is no simple way to get caller SP, we will start stack walking from the current frame rather than a caller frame on ARM64.

2. Because of the above error, stack unwinding code attempted to access signal context when it should not. `alloc` and `nativemem` events are not triggered by a signal and thus `ucontext` passed to the stack walking code is `NULL`. To avoid similar errors in the future, we will pass a dummy `empty_context` instead.

### How has this been tested?

`make test` previously failed on Ubuntu 24 with gcc 13.3. Now, all tests pass.
Manually verified that `nativemem` flamegraphs are good with cstack=vm.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
