### PR TITLE
Add time_nanos and duration_nanos to OTLP profiles with test

### DIFF
--- a/src/otlp.h
+++ b/src/otlp.h
@@ -36,10 +36,10 @@ namespace Profile {
     const protobuf_index_t sample_type = 1;
     const protobuf_index_t sample = 2;
     const protobuf_index_t location_indices = 3;
-    const protobuf_index_t period_type = 6;
-    const protobuf_index_t period = 7;
     const protobuf_index_t time_nanos = 4;
     const protobuf_index_t duration_nanos = 5;
+    const protobuf_index_t period_type = 6;
+    const protobuf_index_t period = 7;
 }
 
 namespace ValueType {

--- a/src/otlp.h
+++ b/src/otlp.h
@@ -38,8 +38,8 @@ namespace Profile {
     const protobuf_index_t location_indices = 3;
     const protobuf_index_t period_type = 6;
     const protobuf_index_t period = 7;
-    const protobuf_index_t time_nanos = 8;
-    const protobuf_index_t duration_nanos = 9;
+    const protobuf_index_t time_nanos = 4;
+    const protobuf_index_t duration_nanos = 5;
 }
 
 namespace ValueType {

--- a/src/otlp.h
+++ b/src/otlp.h
@@ -38,6 +38,8 @@ namespace Profile {
     const protobuf_index_t location_indices = 3;
     const protobuf_index_t period_type = 6;
     const protobuf_index_t period = 7;
+    const protobuf_index_t time_nanos = 8;
+    const protobuf_index_t duration_nanos = 9;
 }
 
 namespace ValueType {

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1134,7 +1134,6 @@ Error Profiler::start(Arguments& args, bool reset) {
         _thread_names.clear();
         _thread_ids.clear();
         _first_dump = true;
-
     }
 
     // (Re-)allocate calltrace buffers
@@ -1404,11 +1403,12 @@ Error Profiler::dump(Writer& out, Arguments& args) {
             break;
         case OUTPUT_OTLP:
             dumpOtlp(out, args);
-            _first_dump = false;
             break;
         default:
             return Error("No output format selected");
     }
+    _first_dump = false;
+    
     return Error::OK;
 }
 

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1825,8 +1825,7 @@ void Profiler::stopTimer() {
 
 void Profiler::timerLoop(void* timer_id) {
     u64 current_micros = OS::micros();
-    u64 stop_micros = _stop_time;
-    u64 sleep_until = _jfr.active() ? current_micros + 1000000 : stop_micros;
+    u64 sleep_until = _jfr.active() ? current_micros + 1000000 : _stop_time;
 
     while (true) {
         {
@@ -1838,7 +1837,7 @@ void Profiler::timerLoop(void* timer_id) {
             if (_timer_id != timer_id) return;
         }
 
-        if ((current_micros = OS::micros()) >= stop_micros) {
+        if ((current_micros = OS::micros()) >= _stop_time) {
             restart(_global_args);
             return;
         }

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1751,26 +1751,26 @@ void Profiler::dumpOtlp(Writer& out, Arguments& args) {
     out.write((const char*) otlp_buffer.data(), otlp_buffer.offset());
 }
 
-u64 Profiler::addTimeout(u64 start_micros, int timeout_sec) {
-    if (timeout_sec == 0) {
+u64 Profiler::addTimeout(u64 start_micros, int timeout) {
+    if (timeout == 0) {
         return 0x7fffffffffffffffULL;
-    } else if (timeout_sec > 0) {
-        return start_micros + (u64)timeout_sec * 1000000ULL;
+    } else if (timeout > 0) {
+        return start_micros + (u64)timeout * 1000000ULL;
     }
 
     time_t start_seconds = start_micros / 1000000ULL;
     struct tm t;
     localtime_r(&start_seconds, &t);
 
-    int hh = (timeout_sec >> 16) & 0xff;
+    int hh = (timeout >> 16) & 0xff;
     if (hh < 24) {
         t.tm_hour = hh;
     }
-    int mm = (timeout_sec >> 8) & 0xff;
+    int mm = (timeout >> 8) & 0xff;
     if (mm < 60) {
         t.tm_min = mm;
     }
-    int ss = timeout_sec & 0xff;
+    int ss = timeout & 0xff;
     if (ss < 60) {
         t.tm_sec = ss;
     }

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1240,7 +1240,7 @@ Error Profiler::start(Arguments& args, bool reset) {
     switchThreadEvents(JVMTI_ENABLE);
 
     _state = RUNNING;
-    _start_time = time(NULL);
+    _start_time = OS::nanotime();
     _epoch++;
 
     if (args._timeout != 0 || args._output == OUTPUT_JFR) {
@@ -1406,7 +1406,6 @@ Error Profiler::dump(Writer& out, Arguments& args) {
         default:
             return Error("No output format selected");
     }
-    
     return Error::OK;
 }
 
@@ -1653,7 +1652,7 @@ static void recordSampleType(ProtoBuffer& otlp_buffer, Index& strings, const cha
     protobuf_mark_t sample_type_mark = otlp_buffer.startMessage(Profile::sample_type, 1);
     otlp_buffer.field(ValueType::type_strindex, strings.indexOf(type));
     otlp_buffer.field(ValueType::unit_strindex, strings.indexOf(units));
-    otlp_buffer.field(ValueType::aggregation_temporality, AggregationTemporality::cumulative); 
+    otlp_buffer.field(ValueType::aggregation_temporality, AggregationTemporality::cumulative);
     otlp_buffer.commitMessage(sample_type_mark);
 }
 
@@ -1667,8 +1666,8 @@ void Profiler::dumpOtlp(Writer& out, Arguments& args) {
     protobuf_mark_t scope_profiles_mark = otlp_buffer.startMessage(ResourceProfiles::scope_profiles);
     protobuf_mark_t profile_mark = otlp_buffer.startMessage(ScopeProfiles::profiles);
 
-    u64 time_nanos = (u64)_start_time * 1000000000ULL;
-    u64 duration_nanos = (u64)(time(NULL) - _start_time) * 1000000000ULL;
+    u64 time_nanos = _start_time;
+    u64 duration_nanos = OS::nanotime() - _start_time;
 
     otlp_buffer.field(Profile::time_nanos, time_nanos);
     otlp_buffer.field(Profile::duration_nanos, duration_nanos);

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1133,6 +1133,8 @@ Error Profiler::start(Arguments& args, bool reset) {
         MutexLocker ml(_thread_names_lock);
         _thread_names.clear();
         _thread_ids.clear();
+        _first_dump = true;
+
     }
 
     // (Re-)allocate calltrace buffers
@@ -1402,11 +1404,11 @@ Error Profiler::dump(Writer& out, Arguments& args) {
             break;
         case OUTPUT_OTLP:
             dumpOtlp(out, args);
+            _first_dump = false;
             break;
         default:
             return Error("No output format selected");
     }
-
     return Error::OK;
 }
 
@@ -1648,12 +1650,12 @@ void Profiler::dumpText(Writer& out, Arguments& args) {
     }
 }
 
-static void recordSampleType(ProtoBuffer& otlp_buffer, Index& strings, const char* type, const char* units) {
+static void recordSampleType(ProtoBuffer& otlp_buffer, Index& strings, const char* type, const char* units, u64 aggregation_temporality) {
     using namespace Otlp;
     protobuf_mark_t sample_type_mark = otlp_buffer.startMessage(Profile::sample_type, 1);
     otlp_buffer.field(ValueType::type_strindex, strings.indexOf(type));
     otlp_buffer.field(ValueType::unit_strindex, strings.indexOf(units));
-    otlp_buffer.field(ValueType::aggregation_temporality, AggregationTemporality::cumulative);
+    otlp_buffer.field(ValueType::aggregation_temporality, aggregation_temporality);
     otlp_buffer.commitMessage(sample_type_mark);
 }
 
@@ -1667,8 +1669,9 @@ void Profiler::dumpOtlp(Writer& out, Arguments& args) {
     protobuf_mark_t scope_profiles_mark = otlp_buffer.startMessage(ResourceProfiles::scope_profiles);
     protobuf_mark_t profile_mark = otlp_buffer.startMessage(ScopeProfiles::profiles);
 
-    recordSampleType(otlp_buffer, strings, _engine->type(), "count");
-    recordSampleType(otlp_buffer, strings, _engine->type(), _engine->units());
+    u64 aggregation_temporality = _first_dump ? AggregationTemporality::delta : AggregationTemporality::cumulative;
+    recordSampleType(otlp_buffer, strings, _engine->type(), "count", aggregation_temporality);
+    recordSampleType(otlp_buffer, strings, _engine->type(), _engine->units(), aggregation_temporality);
 
     std::vector<CallTraceSample*> call_trace_samples;
     _call_trace_storage.collectSamples(call_trace_samples);

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -15,6 +15,7 @@
 #include "profiler.h"
 #include "perfEvents.h"
 #include "ctimer.h"
+#include <time.h>
 #include "allocTracer.h"
 #include "mallocTracer.h"
 #include "lockTracer.h"
@@ -1750,26 +1751,26 @@ void Profiler::dumpOtlp(Writer& out, Arguments& args) {
     out.write((const char*) otlp_buffer.data(), otlp_buffer.offset());
 }
 
-u64 Profiler::addTimeout(u64 start, int timeout) {
-    if (timeout == 0) {
+u64 Profiler::addTimeout(u64 start_micros, int timeout_sec) {
+    if (timeout_sec == 0) {
         return 0x7fffffffffffffffULL;
-    } else if (timeout > 0) {
-        return start + (u64)timeout * 1000000ULL;
+    } else if (timeout_sec > 0) {
+        return start_micros + (u64)timeout_sec * 1000000ULL;
     }
 
-    time_t start_seconds = start / 1000000ULL;
+    time_t start_seconds = start_micros / 1000000ULL;
     struct tm t;
     localtime_r(&start_seconds, &t);
 
-    int hh = (timeout >> 16) & 0xff;
+    int hh = (timeout_sec >> 16) & 0xff;
     if (hh < 24) {
         t.tm_hour = hh;
     }
-    int mm = (timeout >> 8) & 0xff;
+    int mm = (timeout_sec >> 8) & 0xff;
     if (mm < 60) {
         t.tm_min = mm;
     }
-    int ss = timeout & 0xff;
+    int ss = timeout_sec & 0xff;
     if (ss < 60) {
         t.tm_sec = ss;
     }

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1244,7 +1244,7 @@ Error Profiler::start(Arguments& args, bool reset) {
     _epoch++;
 
     if (args._timeout != 0 || args._output == OUTPUT_JFR) {
-        _stop_time = addTimeout(_start_time, args._timeout);
+        _stop_time = addTimeout(_start_time / 1000000000ULL, args._timeout);
         startTimer();
     }
 
@@ -1406,6 +1406,7 @@ Error Profiler::dump(Writer& out, Arguments& args) {
         default:
             return Error("No output format selected");
     }
+
     return Error::OK;
 }
 

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1750,15 +1750,16 @@ void Profiler::dumpOtlp(Writer& out, Arguments& args) {
     out.write((const char*) otlp_buffer.data(), otlp_buffer.offset());
 }
 
-time_t Profiler::addTimeout(time_t start, int timeout) {
+u64 Profiler::addTimeout(u64 start, int timeout) {
     if (timeout == 0) {
-        return (time_t)0x7fffffff;
+        return 0x7fffffffffffffffULL;
     } else if (timeout > 0) {
-        return start + timeout;
+        return start + (u64)timeout * 1000000ULL;
     }
 
+    time_t start_seconds = start / 1000000ULL;
     struct tm t;
-    localtime_r(&start, &t);
+    localtime_r(&start_seconds, &t);
 
     int hh = (timeout >> 16) & 0xff;
     if (hh < 24) {
@@ -1774,10 +1775,10 @@ time_t Profiler::addTimeout(time_t start, int timeout) {
     }
 
     time_t result = mktime(&t);
-    if (result <= start) {
+    if (result <= start_seconds) {
         result += (hh < 24 ? 86400 : (mm < 60 ? 3600 : 60));
     }
-    return result;
+    return (u64)result * 1000000ULL;
 }
 
 void Profiler::startTimer() {

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -11,11 +11,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/param.h>
+#include <time.h>
 #include "index.h"
 #include "profiler.h"
 #include "perfEvents.h"
 #include "ctimer.h"
-#include <time.h>
 #include "allocTracer.h"
 #include "mallocTracer.h"
 #include "lockTracer.h"

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1752,7 +1752,7 @@ void Profiler::dumpOtlp(Writer& out, Arguments& args) {
 
 time_t Profiler::addTimeout(time_t start, int timeout) {
     if (timeout == 0) {
-        return 0x7fffffff;
+        return (time_t)0x7fffffff;
     } else if (timeout > 0) {
         return start + timeout;
     }

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1240,11 +1240,11 @@ Error Profiler::start(Arguments& args, bool reset) {
     switchThreadEvents(JVMTI_ENABLE);
 
     _state = RUNNING;
-    _start_time = OS::nanotime();
+    _start_time = OS::micros();
     _epoch++;
 
     if (args._timeout != 0 || args._output == OUTPUT_JFR) {
-        _stop_time = addTimeout(_start_time / 1000000000ULL, args._timeout);
+        _stop_time = addTimeout(_start_time, args._timeout);
         startTimer();
     }
 
@@ -1667,8 +1667,8 @@ void Profiler::dumpOtlp(Writer& out, Arguments& args) {
     protobuf_mark_t scope_profiles_mark = otlp_buffer.startMessage(ResourceProfiles::scope_profiles);
     protobuf_mark_t profile_mark = otlp_buffer.startMessage(ScopeProfiles::profiles);
 
-    u64 time_nanos = _start_time;
-    u64 duration_nanos = OS::nanotime() - _start_time;
+    u64 time_nanos = _start_time * 1000ULL;
+    u64 duration_nanos = (OS::micros() - _start_time) * 1000ULL;
 
     otlp_buffer.field(Profile::time_nanos, time_nanos);
     otlp_buffer.field(Profile::duration_nanos, duration_nanos);
@@ -1750,15 +1750,16 @@ void Profiler::dumpOtlp(Writer& out, Arguments& args) {
     out.write((const char*) otlp_buffer.data(), otlp_buffer.offset());
 }
 
-time_t Profiler::addTimeout(time_t start, int timeout) {
+u64 Profiler::addTimeout(u64 start, int timeout) {
     if (timeout == 0) {
-        return (time_t)0x7fffffff;
+        return 0x7fffffffffffffffULL;
     } else if (timeout > 0) {
-        return start + timeout;
+        return start + (u64)timeout * 1000000ULL;
     }
 
+    time_t start_seconds = start / 1000000ULL;
     struct tm t;
-    localtime_r(&start, &t);
+    localtime_r(&start_seconds, &t);
 
     int hh = (timeout >> 16) & 0xff;
     if (hh < 24) {
@@ -1774,10 +1775,10 @@ time_t Profiler::addTimeout(time_t start, int timeout) {
     }
 
     time_t result = mktime(&t);
-    if (result <= start) {
+    if (result <= start_seconds) {
         result += (hh < 24 ? 86400 : (mm < 60 ? 3600 : 60));
     }
-    return result;
+    return (u64)result * 1000000ULL;
 }
 
 void Profiler::startTimer() {
@@ -1825,7 +1826,7 @@ void Profiler::stopTimer() {
 
 void Profiler::timerLoop(void* timer_id) {
     u64 current_micros = OS::micros();
-    u64 stop_micros = _stop_time * 1000000ULL;
+    u64 stop_micros = _stop_time;
     u64 sleep_until = _jfr.active() ? current_micros + 1000000 : stop_micros;
 
     while (true) {

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1245,7 +1245,7 @@ Error Profiler::start(Arguments& args, bool reset) {
     _epoch++;
 
     if (args._timeout != 0 || args._output == OUTPUT_JFR) {
-        _stop_time = addTimeout(_start_time / 1000000ULL, args._timeout) * 1000000ULL;
+        _stop_time = addTimeout(_start_time, args._timeout);
         startTimer();
     }
 

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -130,7 +130,7 @@ class Profiler {
     Engine* activeEngine();
     Error checkJvmCapabilities();
 
-    time_t addTimeout(time_t start, int timeout);
+    u64 addTimeout(u64 start, int timeout);
     void startTimer();
     void stopTimer();
     void timerLoop(void* timer_id);

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -68,7 +68,7 @@ class Profiler {
     Engine* _alloc_engine;
     int _event_mask;
 
-    time_t _start_time;
+    u64 _start_time;
     time_t _stop_time;
     int _epoch;
     u32 _gc_id;
@@ -187,7 +187,7 @@ class Profiler {
     }
 
     u64 total_samples() { return _total_samples; }
-    long uptime()       { return time(NULL) - _start_time; }
+    long uptime()       { return time(NULL) - (_start_time / 1000000000ULL); }
 
     Dictionary* classMap() { return &_class_map; }
     ThreadFilter* threadFilter() { return &_thread_filter; }

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -130,7 +130,7 @@ class Profiler {
     Engine* activeEngine();
     Error checkJvmCapabilities();
 
-    u64 addTimeout(u64 start, int timeout);
+    time_t addTimeout(time_t start, int timeout);
     void startTimer();
     void stopTimer();
     void timerLoop(void* timer_id);

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -97,6 +97,9 @@ class Profiler {
     const void* _call_stub_begin;
     const void* _call_stub_end;
 
+    // reset to true when the profiler restarts
+    bool _first_dump;
+
     // dlopen() hook support
     void** _dlopen_entry;
     static void* dlopen_hook(const char* filename, int flags);
@@ -175,6 +178,7 @@ class Profiler {
         _native_libs(),
         _call_stub_begin(NULL),
         _call_stub_end(NULL),
+        _first_dump(true),
         _dlopen_entry(NULL) {
 
         for (int i = 0; i < CONCURRENCY_LEVEL; i++) {

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -129,7 +129,7 @@ class Profiler {
     Engine* activeEngine();
     Error checkJvmCapabilities();
 
-    u64 addTimeout(u64 start_micros, int timeout_sec);
+    u64 addTimeout(u64 start_micros, int timeout);
     void startTimer();
     void stopTimer();
     void timerLoop(void* timer_id);

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -97,9 +97,6 @@ class Profiler {
     const void* _call_stub_begin;
     const void* _call_stub_end;
 
-    // reset to true when the profiler restarts
-    bool _first_dump;
-
     // dlopen() hook support
     void** _dlopen_entry;
     static void* dlopen_hook(const char* filename, int flags);
@@ -178,7 +175,6 @@ class Profiler {
         _native_libs(),
         _call_stub_begin(NULL),
         _call_stub_end(NULL),
-        _first_dump(true),
         _dlopen_entry(NULL) {
 
         for (int i = 0; i < CONCURRENCY_LEVEL; i++) {

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -8,7 +8,6 @@
 
 #include <map>
 #include <string>
-#include <time.h>
 #include "arch.h"
 #include "arguments.h"
 #include "callTraceStorage.h"
@@ -130,7 +129,7 @@ class Profiler {
     Engine* activeEngine();
     Error checkJvmCapabilities();
 
-    u64 addTimeout(u64 start, int timeout);
+    u64 addTimeout(u64 start_micros, int timeout_sec);
     void startTimer();
     void stopTimer();
     void timerLoop(void* timer_id);

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -69,7 +69,7 @@ class Profiler {
     int _event_mask;
 
     u64 _start_time;
-    time_t _stop_time;
+    u64 _stop_time;
     int _epoch;
     u32 _gc_id;
     WaitableMutex _timer_lock;
@@ -130,7 +130,7 @@ class Profiler {
     Engine* activeEngine();
     Error checkJvmCapabilities();
 
-    time_t addTimeout(time_t start, int timeout);
+    u64 addTimeout(u64 start, int timeout);
     void startTimer();
     void stopTimer();
     void timerLoop(void* timer_id);
@@ -187,7 +187,7 @@ class Profiler {
     }
 
     u64 total_samples() { return _total_samples; }
-    long uptime()       { return time(NULL) - (_start_time / 1000000000ULL); }
+    long uptime()       { return (OS::micros() - _start_time) / 1000000ULL; }
 
     Dictionary* classMap() { return &_class_map; }
     ThreadFilter* threadFilter() { return &_thread_filter; }

--- a/test/one/profiler/test/TestProcess.java
+++ b/test/one/profiler/test/TestProcess.java
@@ -141,6 +141,7 @@ public class TestProcess implements Closeable {
                 cmd.add("-XX:+DebugNonSafepoints");
             }
             cmd.add("-Djava.library.path=" + System.getProperty("java.library.path"));
+            cmd.add("-ea");
             addArgs(cmd, test.jvmArgs());
             if (!test.agentArgs().isEmpty()) {
                 cmd.add("-agentpath:" + profilerLibPath() + "=" +

--- a/test/test/otlp/OtlpTemporalityTest.java
+++ b/test/test/otlp/OtlpTemporalityTest.java
@@ -25,7 +25,7 @@ public class OtlpTemporalityTest {
         long durationNanos2 = profile2.getDurationNanos();
         
         assert timeNanos1 == timeNanos2;
-        assert durationNanos2 > durationNanos1;
+        assert durationNanos2 - durationNanos1 >= 100_000_000L;
         
         profiler.stop();
         profiler.start(Events.CPU, 1_000_000);
@@ -33,7 +33,7 @@ public class OtlpTemporalityTest {
         Profile profile3 = dumpAndGetProfile(profiler);
         long timeNanos3 = profile3.getTimeNanos();
         
-        assert timeNanos3 != timeNanos1;
+        assert timeNanos3 > timeNanos1;
         
         profiler.stop();
     }

--- a/test/test/otlp/OtlpTemporalityTest.java
+++ b/test/test/otlp/OtlpTemporalityTest.java
@@ -1,0 +1,50 @@
+package test.otlp;
+
+import one.profiler.AsyncProfiler;
+import one.profiler.Events;
+import one.profiler.Counter;
+import java.nio.ByteBuffer;
+import io.opentelemetry.proto.profiles.v1development.*;
+
+public class OtlpTemporalityTest {
+
+    public static void main(String[] args) throws Exception {
+        AsyncProfiler profiler = AsyncProfiler.getInstance();
+        profiler.start(Events.CPU, 1_000_000);
+        
+        for (int i = 0; i < 3; i++) {
+            byte[] dump = profiler.dumpOtlp();
+            ProfilesData data = ProfilesData.parseFrom(dump);
+            Profile profile = data.getResourceProfiles(0).getScopeProfiles(0).getProfiles(0);
+            ValueType sampleType = profile.getSampleType(0);
+            
+            AggregationTemporality expected = (i == 0) ? 
+                AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA : 
+                AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE;
+                
+            assert sampleType.getAggregationTemporality() == expected : 
+                "Dump " + i + " should be " + expected;
+        }
+
+        profiler.stop();
+        profiler.start(Events.CPU, 1_000_000);
+        
+        
+        for (int i = 0; i < 3; i++) {
+            byte[] dump = profiler.dumpOtlp();
+            ProfilesData data = ProfilesData.parseFrom(dump);
+            Profile profile = data.getResourceProfiles(0).getScopeProfiles(0).getProfiles(0);
+            ValueType sampleType = profile.getSampleType(0);
+            
+            AggregationTemporality expected = (i == 0) ? 
+                AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA : 
+                AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE;
+                
+            assert sampleType.getAggregationTemporality() == expected : 
+                "After restart, dump " + i + " should be " + expected;
+        }
+        
+        System.out.println("All temporality tests passed!");
+        profiler.stop();
+    }
+}

--- a/test/test/otlp/OtlpTemporalityTest.java
+++ b/test/test/otlp/OtlpTemporalityTest.java
@@ -11,40 +11,42 @@ public class OtlpTemporalityTest {
     public static void main(String[] args) throws Exception {
         AsyncProfiler profiler = AsyncProfiler.getInstance();
         profiler.start(Events.CPU, 1_000_000);
-        
-        for (int i = 0; i < 3; i++) {
-            byte[] dump = profiler.dumpOtlp();
-            ProfilesData data = ProfilesData.parseFrom(dump);
-            Profile profile = data.getResourceProfiles(0).getScopeProfiles(0).getProfiles(0);
-            ValueType sampleType = profile.getSampleType(0);
-            
-            AggregationTemporality expected = (i == 0) ? 
-                AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA : 
-                AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE;
-                
-            assert sampleType.getAggregationTemporality() == expected : 
-                "Dump " + i + " should be " + expected;
-        }
+
+        ValueType sampleType = getSampleType(profiler);
+        assert sampleType.getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA : 
+            "First dump should be DELTA";
+
+        sampleType = getSampleType(profiler);
+        assert sampleType.getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE : 
+            "Second dump should be CUMULATIVE";
+
+        sampleType = getSampleType(profiler);
+        assert sampleType.getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE : 
+            "Third dump should be CUMULATIVE";
 
         profiler.stop();
         profiler.start(Events.CPU, 1_000_000);
-        
-        
-        for (int i = 0; i < 3; i++) {
-            byte[] dump = profiler.dumpOtlp();
-            ProfilesData data = ProfilesData.parseFrom(dump);
-            Profile profile = data.getResourceProfiles(0).getScopeProfiles(0).getProfiles(0);
-            ValueType sampleType = profile.getSampleType(0);
-            
-            AggregationTemporality expected = (i == 0) ? 
-                AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA : 
-                AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE;
-                
-            assert sampleType.getAggregationTemporality() == expected : 
-                "After restart, dump " + i + " should be " + expected;
-        }
-        
-        System.out.println("All temporality tests passed!");
+
+        sampleType = getSampleType(profiler);
+        assert sampleType.getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA : 
+            "After restart, first dump should be DELTA";
+
+        sampleType = getSampleType(profiler);
+        assert sampleType.getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE : 
+            "After restart, second dump should be CUMULATIVE";
+
+        sampleType = getSampleType(profiler);
+        assert sampleType.getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE : 
+            "After restart, third dump should be CUMULATIVE";
+
         profiler.stop();
     }
+
+    public static ValueType getSampleType(AsyncProfiler profiler) throws Exception {
+        byte[] dump = profiler.dumpOtlp();
+        ProfilesData data = ProfilesData.parseFrom(dump);
+        Profile profile = data.getResourceProfiles(0).getScopeProfiles(0).getProfiles(0);
+        return profile.getSampleType(0);
+    }
+
 }

--- a/test/test/otlp/OtlpTemporalityTest.java
+++ b/test/test/otlp/OtlpTemporalityTest.java
@@ -12,37 +12,21 @@ public class OtlpTemporalityTest {
         AsyncProfiler profiler = AsyncProfiler.getInstance();
         profiler.start(Events.CPU, 1_000_000);
 
-        ValueType sampleType = getSampleType(profiler);
-        assert sampleType.getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA : 
-            "First dump should be DELTA";
-
-        sampleType = getSampleType(profiler);
-        assert sampleType.getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE : 
-            "Second dump should be CUMULATIVE";
-
-        sampleType = getSampleType(profiler);
-        assert sampleType.getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE : 
-            "Third dump should be CUMULATIVE";
+        assert dumpAndGetSampleType(profiler).getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA;
+        assert dumpAndGetSampleType(profiler).getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE;
+        assert dumpAndGetSampleType(profiler).getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE;
 
         profiler.stop();
         profiler.start(Events.CPU, 1_000_000);
 
-        sampleType = getSampleType(profiler);
-        assert sampleType.getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA : 
-            "After restart, first dump should be DELTA";
-
-        sampleType = getSampleType(profiler);
-        assert sampleType.getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE : 
-            "After restart, second dump should be CUMULATIVE";
-
-        sampleType = getSampleType(profiler);
-        assert sampleType.getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE : 
-            "After restart, third dump should be CUMULATIVE";
+        assert dumpAndGetSampleType(profiler).getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA;
+        assert dumpAndGetSampleType(profiler).getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE;
+        assert dumpAndGetSampleType(profiler).getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE;
 
         profiler.stop();
     }
 
-    public static ValueType getSampleType(AsyncProfiler profiler) throws Exception {
+    public static ValueType dumpAndGetSampleType(AsyncProfiler profiler) throws Exception {
         byte[] dump = profiler.dumpOtlp();
         ProfilesData data = ProfilesData.parseFrom(dump);
         Profile profile = data.getResourceProfiles(0).getScopeProfiles(0).getProfiles(0);

--- a/test/test/otlp/OtlpTemporalityTest.java
+++ b/test/test/otlp/OtlpTemporalityTest.java
@@ -1,9 +1,11 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package test.otlp;
 
 import one.profiler.AsyncProfiler;
 import one.profiler.Events;
-import one.profiler.Counter;
-import java.nio.ByteBuffer;
 import io.opentelemetry.proto.profiles.v1development.*;
 
 public class OtlpTemporalityTest {
@@ -12,25 +14,33 @@ public class OtlpTemporalityTest {
         AsyncProfiler profiler = AsyncProfiler.getInstance();
         profiler.start(Events.CPU, 1_000_000);
 
-        assert dumpAndGetSampleType(profiler).getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA;
-        assert dumpAndGetSampleType(profiler).getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE;
-        assert dumpAndGetSampleType(profiler).getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE;
-
+        Profile profile1 = dumpAndGetProfile(profiler);
+        long timeNanos1 = profile1.getTimeNanos();
+        long durationNanos1 = profile1.getDurationNanos();
+        
+        Thread.sleep(100);
+        
+        Profile profile2 = dumpAndGetProfile(profiler);
+        long timeNanos2 = profile2.getTimeNanos();
+        long durationNanos2 = profile2.getDurationNanos();
+        
+        assert timeNanos1 == timeNanos2;
+        assert durationNanos2 > durationNanos1;
+        
         profiler.stop();
         profiler.start(Events.CPU, 1_000_000);
-
-        assert dumpAndGetSampleType(profiler).getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA;
-        assert dumpAndGetSampleType(profiler).getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE;
-        assert dumpAndGetSampleType(profiler).getAggregationTemporality() == AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE;
-
+        
+        Profile profile3 = dumpAndGetProfile(profiler);
+        long timeNanos3 = profile3.getTimeNanos();
+        
+        assert timeNanos3 != timeNanos1;
+        
         profiler.stop();
     }
 
-    public static ValueType dumpAndGetSampleType(AsyncProfiler profiler) throws Exception {
+    public static Profile dumpAndGetProfile(AsyncProfiler profiler) throws Exception {
         byte[] dump = profiler.dumpOtlp();
         ProfilesData data = ProfilesData.parseFrom(dump);
-        Profile profile = data.getResourceProfiles(0).getScopeProfiles(0).getProfiles(0);
-        return profile.getSampleType(0);
+        return data.getResourceProfiles(0).getScopeProfiles(0).getProfiles(0);
     }
-
 }

--- a/test/test/otlp/OtlpTests.java
+++ b/test/test/otlp/OtlpTests.java
@@ -53,6 +53,12 @@ public class OtlpTests {
         assert collapsed.contains("test/otlp/CpuBurner.main;test/otlp/CpuBurner.burn");
     }
 
+    @Test(mainClass = OtlpTemporalityTest.class, jvmArgs = "-Djava.library.path=build/lib")
+public void otlpAggregationTemporalityTest(TestProcess p) throws Exception {
+    p.waitForExit();
+    assert p.exitCode() == 0;
+}
+
     private static ProfilesData waitAndGetProfilesData(TestProcess p) throws Exception {
         p.waitForExit();
         assert p.exitCode() == 0;

--- a/test/test/otlp/OtlpTests.java
+++ b/test/test/otlp/OtlpTests.java
@@ -54,10 +54,10 @@ public class OtlpTests {
     }
 
     @Test(mainClass = OtlpTemporalityTest.class, jvmArgs = "-Djava.library.path=build/lib")
-public void otlpAggregationTemporalityTest(TestProcess p) throws Exception {
-    p.waitForExit();
-    assert p.exitCode() == 0;
-}
+    public void otlpAggregationTemporalityTest(TestProcess p) throws Exception {
+        p.waitForExit();
+        assert p.exitCode() == 0;
+    }
 
     private static ProfilesData waitAndGetProfilesData(TestProcess p) throws Exception {
         p.waitForExit();


### PR DESCRIPTION
### Description
Implemented proper temporal aggregation support where consecutive dumps maintain the same time_nanos (session start) but show increasing duration_nanos, while profiler restarts generate new time_nanos values. Converted _start_time to nanosecond precision.

### Related issues
Not available

### Motivation and context
This change ensures proper temporal data interpretation across profiler sessions by providing precise timing information that allows OTLP consumers to distinguish between different profiling periods.

### How has this been tested?
Added a new test

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
