### PR TITLE
Remove some clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >
   readability-static-definition-in-anonymous-namespace,
   readability-string-compare,
   readability-uniqueptr-delete-release,
-  readability-uppercase-literal-suffix,
   readability-use-anyofallof,
 # TODO: Consider these
 # bugprone-switch-missing-default-case

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,5 @@
 Checks: >
   -*,
-  google-readability-braces-around-statements,
   bugprone-assert-side-effect,
   bugprone-bool-pointer-implicit-conversion,
   bugprone-chained-comparison,
@@ -129,5 +128,3 @@ CheckOptions:
     value: '(KB|Thread|setDaemon|klassOop|nVMs|loadLibrary|getTicksFrequency|counterTime|System|M|R|s_)'
   - key: readability-identifier-naming.PrivateMemberPrefix
     value: _
-  - key: google-readability-braces-around-statements.ShortStatementLines
-    value: '1'


### PR DESCRIPTION
### Description
These checks proved to be too harsh.

### Related issues
n/a

### Motivation and context
https://github.com/async-profiler/async-profiler/pull/1411#discussion_r2236703796

https://github.com/async-profiler/async-profiler/pull/1411#discussion_r2236704079

### How has this been tested?
n/a

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
