### PR TITLE
#1412: Handle both SIGBUS and SIGSEGV on macOS

### DIFF
--- a/src/os_macos.cpp
+++ b/src/os_macos.cpp
@@ -97,6 +97,8 @@ JitWriteProtection::~JitWriteProtection() {
 
 
 static SigAction installed_sigaction[32];
+static SigAction orig_sigbus_handler;
+static SigAction orig_sigsegv_handler;
 
 const size_t OS::page_size = sysconf(_SC_PAGESIZE);
 const size_t OS::page_mask = OS::page_size - 1;
@@ -228,12 +230,27 @@ SigAction OS::installSignalHandler(int signo, SigAction action, SigHandler handl
 }
 
 SigAction OS::replaceCrashHandler(SigAction action) {
+    // It's not well specified when macOS raises SIGBUS and when SIGSEGV.
+    // HotSpot handles both similarly, so do we.
     struct sigaction sa;
+
     sigaction(SIGBUS, NULL, &sa);
-    SigAction old_action = sa.sa_sigaction;
+    orig_sigbus_handler = sa.sa_sigaction;
     sa.sa_sigaction = action;
+    sa.sa_flags |= SA_SIGINFO | SA_RESTART;
     sigaction(SIGBUS, &sa, NULL);
-    return old_action;
+
+    sigaction(SIGSEGV, NULL, &sa);
+    orig_sigsegv_handler = sa.sa_sigaction;
+    sa.sa_sigaction = action;
+    sa.sa_flags |= SA_SIGINFO | SA_RESTART;
+    sigaction(SIGSEGV, &sa, NULL);
+
+    // Return an action that dispatches to one of the original handlers depending on signo,
+    // so that the caller does not need to deal with multiple handlers
+    return [](int signo, siginfo_t* siginfo, void* ucontext) {
+        (signo == SIGBUS ? orig_sigbus_handler : orig_sigsegv_handler)(signo, siginfo, ucontext);
+    };
 }
 
 int OS::getProfilingSignal(int mode) {

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -44,7 +44,7 @@
 Profiler* const Profiler::_instance = new Profiler();
 
 static SigAction orig_trapHandler = NULL;
-static SigAction orig_segvHandler = NULL;
+static SigAction orig_crashHandler = NULL;
 
 static uintptr_t profiler_lib_start = 0;
 static uintptr_t profiler_lib_end = 0;
@@ -852,7 +852,7 @@ void Profiler::trapHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     }
 }
 
-void Profiler::segvHandler(int signo, siginfo_t* siginfo, void* ucontext) {
+void Profiler::crashHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     StackFrame frame(ucontext);
     uintptr_t pc = frame.pc();
 
@@ -885,7 +885,7 @@ void Profiler::segvHandler(int signo, siginfo_t* siginfo, void* ucontext) {
         return;
     }
 
-    orig_segvHandler(signo, siginfo, ucontext);
+    orig_crashHandler(signo, siginfo, ucontext);
 }
 
 void Profiler::wakeupHandler(int signo) {
@@ -903,14 +903,14 @@ void Profiler::setupSignalHandlers() {
 
     // HotSpot tolerates interposed SIGSEGV/SIGBUS handler; other JVMs don't
     if (!VM::isOpenJ9() && !VM::isZing()) {
-        CodeCache* profiler_lib = instance()->findLibraryByAddress((void*)setupSignalHandlers);
+        CodeCache* profiler_lib = instance()->findLibraryByAddress((void*)wakeupHandler);
         if (profiler_lib != NULL) {
             // Record boundaries of our own library for the signal handler to check
             // if a crash has happened in the profiler code
             profiler_lib_start = (uintptr_t)profiler_lib->minAddress();
             profiler_lib_end = (uintptr_t)profiler_lib->maxAddress();
         }
-        orig_segvHandler = OS::replaceCrashHandler(segvHandler);
+        orig_crashHandler = OS::replaceCrashHandler(crashHandler);
     }
 
     OS::installSignalHandler(WAKEUP_SIGNAL, NULL, wakeupHandler);

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -225,7 +225,7 @@ class Profiler {
     bool isAddressInCode(const void* pc);
 
     void trapHandler(int signo, siginfo_t* siginfo, void* ucontext);
-    static void segvHandler(int signo, siginfo_t* siginfo, void* ucontext);
+    static void crashHandler(int signo, siginfo_t* siginfo, void* ucontext);
     static void wakeupHandler(int signo);
     static void setupSignalHandlers();
 

--- a/test/native/safeAccessTest.cpp
+++ b/test/native/safeAccessTest.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "testRunner.hpp"
+#include "profiler.h"
+#include "safeAccess.h"
+
+TEST_CASE(SafeAccess_load) {
+    Profiler::instance()->updateSymbols(false);
+    Profiler::instance()->setupSignalHandlers();
+
+    void** bad_ptr = (void**)(uintptr_t)0xbaad0000ffffbaadULL;
+    void* good_ptr = (void*)(uintptr_t)0x123456789abcdef0ULL;
+    void* deadbeef = (void*)(uintptr_t)0xdeadbeefdeadbeefULL;
+
+    ASSERT_EQ(SafeAccess::load(bad_ptr), 0);
+    ASSERT_EQ(SafeAccess::load(&good_ptr), good_ptr);
+
+    ASSERT_EQ(SafeAccess::load32((u32*)bad_ptr, 0x87654321), 0x87654321);
+    ASSERT_EQ(SafeAccess::load32((u32*)&good_ptr, 0x87654321), 0x9abcdef0);
+
+    ASSERT_EQ(SafeAccess::loadPtr(bad_ptr, deadbeef), deadbeef);
+    ASSERT_EQ(SafeAccess::loadPtr(&good_ptr, deadbeef), good_ptr);
+}


### PR DESCRIPTION
### Description

Avoid crashes on macOS by handling SIGSEGV the same way as SIGBUS.

### Related issues

#1412

### Motivation and context

Most often, memory access failures result in SIGBUS on macOS, but sometimes SIGSEGV is raised instead.
Async-profiler previously handled SIGBUS only. The suggested fix is to install crash handler both for SIGBUS and SIGSEGV. That's what HotSpot does too.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
