### PR TITLE
Proactively check classpath in tests spawning a child process

### DIFF
--- a/test/test/otlp/OtlpTests.java
+++ b/test/test/otlp/OtlpTests.java
@@ -55,6 +55,8 @@ public class OtlpTests {
 
     @Test(mainClass = OtlpTemporalityTest.class, jvmArgs = "-Djava.library.path=build/lib")
     public void otlpAggregationTemporalityTest(TestProcess p) throws Exception {
+        classpathCheck();
+
         p.waitForExit();
         assert p.exitCode() == 0;
     }
@@ -110,5 +112,13 @@ public class OtlpTests {
     private static void assertCloseTo(long value, long target, String message) {
         Assert.isGreaterOrEqual(value, target * 0.75, message);
         Assert.isLessOrEqual(value, target * 1.25, message);
+    }
+
+    // Simple check to make sure the classpath contains the required dependencies.
+    // If not, it will throw a NoClassDefFoundError, which will be caught by the test runner.
+    // It's useful to anticipate the same NoClassDefFoundError to happen in the child process,
+    // where it's harder to detect.
+    private static void classpathCheck() {
+        ProfilesData.newBuilder();
     }
 }


### PR DESCRIPTION
### Description
The recently introduced test `OtlpTests.otlpAggregationTemporalityTest` spawns a child process. If a `NoClassDefFoundError` happens in the child, it's harder to detect for the test runner.

### Related issues
#1413

### Motivation and context
The expected behavior is to see the test listed in the `SKIP (missing JAR)` category.

Instead, we got this:
```
INFO: Running OtlpTests.otlpAggregationTemporalityTest...
Error: Unable to initialize main class test.otlp.OtlpTemporalityTest
Caused by: java.lang.NoClassDefFoundError: com/google/protobuf/MessageOrBuilder
FAIL [1/1] OtlpTests.otlpAggregationTemporalityTest took 0.748 s
java.lang.AssertionError
        at test.otlp.OtlpTests.otlpAggregationTemporalityTest(OtlpTests.java:61)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at one.profiler.test.Runner.run(Runner.java:124)
        at one.profiler.test.Runner.main(Runner.java:188)
```

### How has this been tested?
Manual testing.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
