### PR TITLE
Rework crash protection

### DIFF
--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -65,10 +65,10 @@ jobs:
           case "${{ matrix.runson.display }}" in
             macos*)
               brew install gcovr
-              make COMMIT_TAG=$HASH FAT_BINARY=true release coverage -j
+              make COMMIT_TAG=$HASH FAT_BINARY=true release -j
             ;;
             *)
-              make COMMIT_TAG=$HASH CC=/usr/local/musl/bin/musl-gcc release coverage -j
+              make COMMIT_TAG=$HASH CC=/usr/local/musl/bin/musl-gcc release -j
               echo "debug_archive=$(find . -type f -name "async-profiler-*-debug*" -exec basename {} \;)" >> $GITHUB_OUTPUT
             ;;
           esac
@@ -97,6 +97,7 @@ jobs:
           if-no-files-found: error
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
+        if: false
         with:
           name: test-coverage-${{ matrix.runson.display }}
           path: build/test/coverage/

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -64,7 +64,6 @@ jobs:
           HASH=${GITHUB_SHA:0:7}
           case "${{ matrix.runson.display }}" in
             macos*)
-              brew install gcovr
               make COMMIT_TAG=$HASH FAT_BINARY=true release -j
               make COMMIT_TAG=$HASH FAT_BINARY=false test-cpp -j
             ;;
@@ -95,13 +94,6 @@ jobs:
         with:
           name: ${{ steps.set_artifact_name.outputs.artifact_name }}-debug
           path: ${{ steps.build.outputs.debug_archive }}
-          if-no-files-found: error
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v4
-        if: false
-        with:
-          name: test-coverage-${{ matrix.runson.display }}
-          path: build/test/coverage/
           if-no-files-found: error
   integration-tests:
     needs: build-and-upload-binaries

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -66,9 +66,10 @@ jobs:
             macos*)
               brew install gcovr
               make COMMIT_TAG=$HASH FAT_BINARY=true release -j
+              make COMMIT_TAG=$HASH FAT_BINARY=false test-cpp -j
             ;;
             *)
-              make COMMIT_TAG=$HASH CC=/usr/local/musl/bin/musl-gcc release -j
+              make COMMIT_TAG=$HASH CC=/usr/local/musl/bin/musl-gcc release test-cpp -j
               echo "debug_archive=$(find . -type f -name "async-profiler-*-debug*" -exec basename {} \;)" >> $GITHUB_OUTPUT
             ;;
           esac

--- a/src/incbin.h
+++ b/src/incbin.h
@@ -18,10 +18,10 @@
     extern "C" const char NAME[];\
     extern "C" const char NAME##_END[];\
     asm(INCBIN_SECTION "\n"\
-        ".global " INCBIN_SYMBOL #NAME "\n"\
+        ".globl " INCBIN_SYMBOL #NAME "\n"\
         INCBIN_SYMBOL #NAME ":\n"\
         ".incbin \"" FILE "\"\n"\
-        ".global " INCBIN_SYMBOL #NAME "_END\n"\
+        ".globl " INCBIN_SYMBOL #NAME "_END\n"\
         INCBIN_SYMBOL #NAME "_END:\n"\
         ".byte 0x00\n"\
         ".previous\n"\

--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -262,10 +262,14 @@ SigAction OS::installSignalHandler(int signo, SigAction action, SigHandler handl
     return oldsa.sa_sigaction;
 }
 
+static void restoreSignalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
+    signal(signo, SIG_DFL);
+}
+
 SigAction OS::replaceCrashHandler(SigAction action) {
     struct sigaction sa;
     sigaction(SIGSEGV, NULL, &sa);
-    SigAction old_action = sa.sa_sigaction;
+    SigAction old_action = sa.sa_handler == SIG_DFL ? restoreSignalHandler : sa.sa_sigaction;
     sa.sa_sigaction = action;
     sa.sa_flags |= SA_SIGINFO | SA_RESTART;
     sigaction(SIGSEGV, &sa, NULL);

--- a/src/os_macos.cpp
+++ b/src/os_macos.cpp
@@ -97,6 +97,8 @@ JitWriteProtection::~JitWriteProtection() {
 
 
 static SigAction installed_sigaction[32];
+static SigAction orig_sigbus_handler;
+static SigAction orig_sigsegv_handler;
 
 const size_t OS::page_size = sysconf(_SC_PAGESIZE);
 const size_t OS::page_mask = OS::page_size - 1;
@@ -227,13 +229,32 @@ SigAction OS::installSignalHandler(int signo, SigAction action, SigHandler handl
     return oldsa.sa_sigaction;
 }
 
+static void restoreSignalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
+    signal(signo, SIG_DFL);
+}
+
 SigAction OS::replaceCrashHandler(SigAction action) {
+    // It is not well specified when macOS raises SIGBUS and when SIGSEGV.
+    // HotSpot handles both similarly, so do we.
     struct sigaction sa;
+
     sigaction(SIGBUS, NULL, &sa);
-    SigAction old_action = sa.sa_sigaction;
+    orig_sigbus_handler = sa.sa_handler == SIG_DFL ? restoreSignalHandler : sa.sa_sigaction;
     sa.sa_sigaction = action;
+    sa.sa_flags |= SA_SIGINFO | SA_RESTART;
     sigaction(SIGBUS, &sa, NULL);
-    return old_action;
+
+    sigaction(SIGSEGV, NULL, &sa);
+    orig_sigsegv_handler = sa.sa_handler == SIG_DFL ? restoreSignalHandler : sa.sa_sigaction;
+    sa.sa_sigaction = action;
+    sa.sa_flags |= SA_SIGINFO | SA_RESTART;
+    sigaction(SIGSEGV, &sa, NULL);
+
+    // Return an action that dispatches to one of the original handlers depending on signo,
+    // so that the caller does not need to deal with multiple handlers
+    return [](int signo, siginfo_t* siginfo, void* ucontext) {
+        (signo == SIGBUS ? orig_sigbus_handler : orig_sigsegv_handler)(signo, siginfo, ucontext);
+    };
 }
 
 int OS::getProfilingSignal(int mode) {

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -45,7 +45,7 @@
 Profiler* const Profiler::_instance = new Profiler();
 
 static SigAction orig_trapHandler = NULL;
-static SigAction orig_segvHandler = NULL;
+static SigAction orig_crashHandler = NULL;
 
 static uintptr_t profiler_lib_start = 0;
 static uintptr_t profiler_lib_end = 0;
@@ -853,21 +853,13 @@ void Profiler::trapHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     }
 }
 
-void Profiler::segvHandler(int signo, siginfo_t* siginfo, void* ucontext) {
+void Profiler::crashHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     StackFrame frame(ucontext);
     uintptr_t pc = frame.pc();
 
-    uintptr_t length = SafeAccess::skipLoad(pc);
+    uintptr_t length = SafeAccess::skipLoad((instruction_t*)pc);
     if (length > 0) {
-        // Skip the fault instruction, as if it successfully loaded NULL
-        frame.pc() += length;
-        frame.retval() = 0;
-        return;
-    }
-
-    length = SafeAccess::skipLoadArg(pc);
-    if (length > 0) {
-        // Act as if the load returned default_value argument
+        // Skip the fault instruction as if it successfully loaded default_value
         frame.pc() += length;
         frame.retval() = frame.arg1();
         return;
@@ -886,7 +878,7 @@ void Profiler::segvHandler(int signo, siginfo_t* siginfo, void* ucontext) {
         return;
     }
 
-    orig_segvHandler(signo, siginfo, ucontext);
+    orig_crashHandler(signo, siginfo, ucontext);
 }
 
 void Profiler::wakeupHandler(int signo) {
@@ -904,14 +896,14 @@ void Profiler::setupSignalHandlers() {
 
     // HotSpot tolerates interposed SIGSEGV/SIGBUS handler; other JVMs don't
     if (!VM::isOpenJ9() && !VM::isZing()) {
-        CodeCache* profiler_lib = instance()->findLibraryByAddress((void*)setupSignalHandlers);
+        CodeCache* profiler_lib = instance()->findLibraryByAddress((void*)wakeupHandler);
         if (profiler_lib != NULL) {
             // Record boundaries of our own library for the signal handler to check
             // if a crash has happened in the profiler code
             profiler_lib_start = (uintptr_t)profiler_lib->minAddress();
             profiler_lib_end = (uintptr_t)profiler_lib->maxAddress();
         }
-        orig_segvHandler = OS::replaceCrashHandler(segvHandler);
+        orig_crashHandler = OS::replaceCrashHandler(crashHandler);
     }
 
     OS::installSignalHandler(WAKEUP_SIGNAL, NULL, wakeupHandler);

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -857,8 +857,8 @@ void Profiler::crashHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     StackFrame frame(ucontext);
     uintptr_t pc = frame.pc();
 
-    uintptr_t length = SafeAccess::skipLoad((instruction_t*)pc);
-    if (length > 0) {
+    u32 length = SafeAccess::skipLoad((instruction_t*)pc);
+    if (length != 0) {
         // Skip the fault instruction as if it successfully loaded default_value
         frame.pc() += length;
         frame.retval() = frame.arg1();

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -224,7 +224,7 @@ class Profiler {
     bool isAddressInCode(const void* pc);
 
     void trapHandler(int signo, siginfo_t* siginfo, void* ucontext);
-    static void segvHandler(int signo, siginfo_t* siginfo, void* ucontext);
+    static void crashHandler(int signo, siginfo_t* siginfo, void* ucontext);
     static void wakeupHandler(int signo);
     static void setupSignalHandlers();
 

--- a/src/safeAccess.cpp
+++ b/src/safeAccess.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "safeAccess.h"
+
+#ifdef __clang__
+#  define NOINLINE __attribute__((noinline))
+#else
+#  define NOINLINE __attribute__((noinline,noclone))
+#endif
+
+#ifdef __APPLE__
+#  define LABEL(sym) asm volatile(".globl _" #sym "\n_" #sym ":" : : "r"(default_value))
+#else
+#  define LABEL(sym) asm volatile(".globl " #sym "\n" #sym ":" : : "r"(default_value))
+#endif
+
+extern instruction_t load_end[];
+extern instruction_t load32_end[];
+
+NOINLINE
+void* SafeAccess::load(void** ptr, void* default_value) {
+    void* ret = *ptr;
+    LABEL(load_end);
+    return ret;
+}
+
+NOINLINE
+u32 SafeAccess::load32(u32* ptr, u32 default_value) {
+    u32 ret = *ptr;
+    LABEL(load32_end);
+    return ret;
+}
+
+u32 SafeAccess::skipLoad(instruction_t* pc) {
+    if ((pc >= (void*)load && pc < load_end) ||
+        (pc >= (void*)load32 && pc < load32_end)) {
+#if defined(__x86_64__) || defined(__i386__)
+        if (pc[0] == 0x8b) return 2;                   // mov eax, [reg]
+        if (pc[0] == 0x48 && pc[1] == 0x8b) return 3;  // mov rax, [reg]
+#else
+        return sizeof(instruction_t);
+#endif
+    }
+    return 0;
+}

--- a/src/safeAccess.cpp
+++ b/src/safeAccess.cpp
@@ -12,9 +12,9 @@
 #endif
 
 #ifdef __APPLE__
-#  define LABEL(sym) asm volatile(".globl _" #sym "\n_" #sym ":")
+#  define LABEL(sym) asm volatile("_" #sym ":")
 #else
-#  define LABEL(sym) asm volatile(".globl " #sym "\n" #sym ":")
+#  define LABEL(sym) asm volatile(#sym ":")
 #endif
 
 extern instruction_t load_end[];

--- a/src/safeAccess.cpp
+++ b/src/safeAccess.cpp
@@ -12,9 +12,9 @@
 #endif
 
 #ifdef __APPLE__
-#  define LABEL(sym) asm volatile(".globl _" #sym "\n_" #sym ":" : : "r"(default_value))
+#  define LABEL(sym) asm volatile(".globl _" #sym "\n_" #sym ":")
 #else
-#  define LABEL(sym) asm volatile(".globl " #sym "\n" #sym ":" : : "r"(default_value))
+#  define LABEL(sym) asm volatile(".globl " #sym "\n" #sym ":")
 #endif
 
 extern instruction_t load_end[];
@@ -22,6 +22,7 @@ extern instruction_t load32_end[];
 
 NOINLINE
 void* SafeAccess::load(void** ptr, void* default_value) {
+    asm volatile("" : : "r"(default_value));
     void* ret = *ptr;
     LABEL(load_end);
     return ret;
@@ -29,6 +30,7 @@ void* SafeAccess::load(void** ptr, void* default_value) {
 
 NOINLINE
 u32 SafeAccess::load32(u32* ptr, u32 default_value) {
+    asm volatile("" : : "r"(default_value));
     u32 ret = *ptr;
     LABEL(load32_end);
     return ret;

--- a/src/safeAccess.h
+++ b/src/safeAccess.h
@@ -10,7 +10,7 @@
 
 class SafeAccess {
   public:
-    static void* load(void** ptr, void* default_value = NULL);
+    static void* load(void** ptr, void* default_value = nullptr);
     static u32 load32(u32* ptr, u32 default_value = 0);
 
     static u32 skipLoad(instruction_t* pc);

--- a/src/safeAccess.h
+++ b/src/safeAccess.h
@@ -17,9 +17,9 @@
 #endif
 
 #ifdef __APPLE__
-#  define DEFINE_LABEL(sym) asm volatile("_" #sym ":")
+#  define DEFINE_LABEL(sym) asm volatile(".globl _" #sym "\n_" #sym ":")
 #else
-#  define DEFINE_LABEL(sym) asm volatile(#sym ":")
+#  define DEFINE_LABEL(sym) asm volatile(".globl " #sym "\n" #sym ":")
 #endif
 
 extern instruction_t sa_load_start[];

--- a/src/safeAccess.h
+++ b/src/safeAccess.h
@@ -6,53 +6,14 @@
 #ifndef _SAFEACCESS_H
 #define _SAFEACCESS_H
 
-#include <stdint.h>
 #include "arch.h"
-
-
-#ifdef __clang__
-#  define NOINLINE __attribute__((noinline))
-#else
-#  define NOINLINE __attribute__((noinline,noclone))
-#endif
-
-#ifdef __APPLE__
-#  define LABEL(sym) asm volatile(".globl _" #sym "\n_" #sym ":")
-#else
-#  define LABEL(sym) asm volatile(".globl " #sym "\n" #sym ":")
-#endif
-
-extern instruction_t load_end[];
-extern instruction_t load32_end[];
 
 class SafeAccess {
   public:
-    NOINLINE
-    static void* load(void** ptr, void* default_value = NULL) {
-        void* ret = *ptr;
-        LABEL(load_end);
-        return ret;
-    }
+    static void* load(void** ptr, void* default_value = NULL);
+    static u32 load32(u32* ptr, u32 default_value = 0);
 
-    NOINLINE
-    static u32 load32(u32* ptr, u32 default_value = 0) {
-        u32 ret = *ptr;
-        LABEL(load32_end);
-        return ret;
-    }
-
-    static uintptr_t skipLoad(instruction_t* pc) {
-        if ((pc >= (void*)load && pc < load_end) ||
-            (pc >= (void*)load32 && pc < load32_end)) {
-#if defined(__x86_64__) || defined(__i386__)
-            if (pc[0] == 0x8b) return 2;                   // mov eax, [reg]
-            if (pc[0] == 0x48 && pc[1] == 0x8b) return 3;  // mov rax, [reg]
-#else
-            return sizeof(instruction_t);
-#endif
-        }
-        return 0;
-    }
+    static u32 skipLoad(instruction_t* pc);
 };
 
 #endif // _SAFEACCESS_H

--- a/src/safeAccess.h
+++ b/src/safeAccess.h
@@ -17,37 +17,33 @@
 #endif
 
 #ifdef __APPLE__
-#  define DEFINE_LABEL(sym) asm volatile(".globl _" #sym "\n_" #sym ":")
+#  define LABEL(sym) asm volatile(".globl _" #sym "\n_" #sym ":")
 #else
-#  define DEFINE_LABEL(sym) asm volatile(".globl " #sym "\n" #sym ":")
+#  define LABEL(sym) asm volatile(".globl " #sym "\n" #sym ":")
 #endif
 
-extern instruction_t sa_load_start[];
-extern instruction_t sa_load_end[];
-extern instruction_t sa_load32_start[];
-extern instruction_t sa_load32_end[];
+extern instruction_t load_end[];
+extern instruction_t load32_end[];
 
 class SafeAccess {
   public:
     NOINLINE
     static void* load(void** ptr, void* default_value = NULL) {
-        DEFINE_LABEL(sa_load_start);
         void* ret = *ptr;
-        DEFINE_LABEL(sa_load_end);
+        LABEL(load_end);
         return ret;
     }
 
     NOINLINE
     static u32 load32(u32* ptr, u32 default_value = 0) {
-        DEFINE_LABEL(sa_load32_start);
         u32 ret = *ptr;
-        DEFINE_LABEL(sa_load32_end);
+        LABEL(load32_end);
         return ret;
     }
 
     static uintptr_t skipLoad(instruction_t* pc) {
-        if ((pc >= sa_load_start && pc < sa_load_end) ||
-            (pc >= sa_load32_start && pc < sa_load32_end)) {
+        if ((pc >= (void*)load && pc < load_end) ||
+            (pc >= (void*)load32 && pc < load32_end)) {
 #if defined(__x86_64__) || defined(__i386__)
             if (pc[0] == 0x8b) return 2;                   // mov eax, [reg]
             if (pc[0] == 0x48 && pc[1] == 0x8b) return 3;  // mov rax, [reg]

--- a/src/stackFrame_aarch64.cpp
+++ b/src/stackFrame_aarch64.cpp
@@ -275,7 +275,7 @@ bool StackFrame::checkInterruptedSyscall() {
         if (nr == SYS_ppoll || (nr == SYS_epoll_pwait && (int)arg3() == -1)) {
             // Check against unreadable page for the loop below
             const uintptr_t max_distance = 24;
-            if ((pc() & 0xfff) < max_distance && SafeAccess::load32((u32*)(pc() - max_distance), 0) == 0) {
+            if ((pc() & 0xfff) < max_distance && SafeAccess::load32((u32*)(pc() - max_distance)) == 0) {
                 return true;
             }
             // Try to restore the original value of x0 saved in another register

--- a/src/vmStructs.cpp
+++ b/src/vmStructs.cpp
@@ -579,7 +579,7 @@ void VMStructs::patchSafeFetch() {
     } else if (WX_MEMORY && VM::hotspot_version() == 11) {
         void** entry = (void**)_libjvm->findSymbol("_ZN12StubRoutines17_safefetchN_entryE");
         if (entry != NULL) {
-            *entry = (void*)SafeAccess::loadPtr;
+            *entry = (void*)SafeAccess::load;
         }
     }
 }

--- a/test/native/safeAccessTest.cpp
+++ b/test/native/safeAccessTest.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "testRunner.hpp"
+#include "profiler.h"
+#include "safeAccess.h"
+
+TEST_CASE(SafeAccess_load) {
+    Profiler::instance()->updateSymbols(false);
+    Profiler::instance()->setupSignalHandlers();
+
+    void** bad_ptr = (void**)(uintptr_t)0xbaad0000ffffbaadULL;
+    void* good_ptr = (void*)(uintptr_t)0x123456789abcdef0ULL;
+    void* deadbeef = (void*)(uintptr_t)0xdeadbeefdeadbeefULL;
+
+    ASSERT_EQ(SafeAccess::load(bad_ptr), 0);
+    ASSERT_EQ(SafeAccess::load(&good_ptr), good_ptr);
+
+    ASSERT_EQ(SafeAccess::load(bad_ptr, deadbeef), deadbeef);
+    ASSERT_EQ(SafeAccess::load(&good_ptr, deadbeef), good_ptr);
+
+    ASSERT_EQ(SafeAccess::load32((u32*)bad_ptr, 0x87654321), 0x87654321);
+    ASSERT_EQ(SafeAccess::load32((u32*)&good_ptr, 0x87654321), 0x9abcdef0);
+}


### PR DESCRIPTION
### Description

Revised implementation of the mechanism for loading from potentially unsafe locations (aka SafeAccess). Previous implementation was fragile and worked incorrectly in certain cases.

### Summary of changes

1. Previous implementation assumed that the load instruction was always within 16 bytes from the beginning of the function. This was not true for debug builds. I added a label that explicitly marks the end of the critical code.
2. Label also protects from specialization of `SafeAccess` for constant arguments. This is needed when compiling with clang, which does not support `noclone` attribute.
3. Fixed clang issue when a seemingly unused argument was optimized away.
4. If a native application did not install custom SIGSEGV handler, async-profiler could loop forever in its own handler. Now it restores SIG_DFL to pass control to the OS crash handler.
5. macOS can raise either SIGSEGV or SIGBUS. Previously, async-profiler handled SIGBUS only; now it handles both.
6. Unified `SafeAccess::load` functions. Now there are just 2 variants of `load` and a single `skipLoad`.
7. Added unit tests for SafeAccess.
8. Removed gcov, since instrumentation spoiled code in incompatible way.

### Related issues

#1412

### How has this been tested?

Added SafeAccess unit tests.
Compiled with gcc and clang with different levels of optimizations.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
