### PR TITLE
Preserve compatibility with old JFR reader

### DIFF
--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -784,8 +784,8 @@ class Recording {
 
         buf->putVar32(11);
 
-        Index packages;
-        Index symbols;
+        Index packages(1);
+        Index symbols(1);
         Lookup lookup(&_method_map, Profiler::instance()->classMap(), &packages, &symbols, OUTPUT_JFR);
         writeFrameTypes(buf);
         writeThreadStates(buf);

--- a/src/index.h
+++ b/src/index.h
@@ -19,9 +19,7 @@ class Index {
     size_t _start_index;
   
   public:
-    Index() : Index(0) {}
-
-    Index(size_t start_index) : _start_index(start_index) {
+    Index(size_t start_index = 0) : _start_index(start_index) {
         // The first index should contain the empty string
         indexOf("");
     }

--- a/src/index.h
+++ b/src/index.h
@@ -16,10 +16,13 @@
 class Index {
   private:
     std::unordered_map<std::string, size_t> _idx_map;
+    size_t _start_index;
   
   public:
-    Index() {
-        // Index 0 should contain the empty string
+    Index() : Index(0) {}
+
+    Index(size_t start_index) : _start_index(start_index) {
+        // The first index should contain the empty string
         indexOf("");
     }
 
@@ -37,11 +40,11 @@ class Index {
     }
 
     size_t indexOf(const std::string& value) {
-        return _idx_map.insert({value, _idx_map.size()}).first->second;
+        return _idx_map.insert({value, _start_index + _idx_map.size()}).first->second;
     }
 
     size_t indexOf(std::string&& value) {
-        return _idx_map.insert({std::move(value), _idx_map.size()}).first->second;
+        return _idx_map.insert({std::move(value), _start_index + _idx_map.size()}).first->second;
     }
 
     size_t size() const {
@@ -51,10 +54,10 @@ class Index {
     void forEachOrdered(const std::function<void(size_t idx, const std::string&)>& consumer) const {
         std::vector<const std::string*> arr(_idx_map.size());
         for (const auto& it : _idx_map) {
-            arr[it.second] = &it.first;
+            arr[it.second - _start_index] = &it.first;
         }
         for (size_t idx = 0; idx < size(); ++idx) {
-            consumer(idx, *arr[idx]);
+            consumer(idx + _start_index, *arr[idx]);
         }
     }
 };


### PR DESCRIPTION
### Description
In this PR I fix the incompatibility between newly written JFR files, and the previous version of Async-Profiler's JFR reader.

### Related issues
Incompatibility introduced in #1378.

### Motivation and context
JFR produced by Async-Profiler should be backward compatible.

### How has this been tested?
Manual testing.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
