### PR TITLE
Add signal correlation API for OTEL integration

### DIFF
--- a/src/api/one/profiler/AsyncProfiler.java
+++ b/src/api/one/profiler/AsyncProfiler.java
@@ -281,6 +281,24 @@ public class AsyncProfiler implements AsyncProfilerMXBean {
         }
     }
 
+    /**
+     * Set trace context for signal correlation
+     * @param traceId OpenTelemetry trace identifier
+     * @param spanId OpenTelemetry span identifier
+     */
+    @Override
+    public void setTraceContext(String traceId, String spanId) {
+        setTraceContext0(traceId, spanId);
+    }
+
+    /**
+     * Clear trace context for the current thread
+     */
+    @Override
+    public void clearTraceContext() {
+        clearTraceContext0();
+    }
+
     private native void start0(String event, long interval, boolean reset) throws IllegalStateException;
 
     private native void stop0() throws IllegalStateException;
@@ -290,4 +308,8 @@ public class AsyncProfiler implements AsyncProfilerMXBean {
     private native byte[] execute1(String command) throws IllegalArgumentException, IllegalStateException, IOException;
 
     private native void filterThread0(Thread thread, boolean enable);
+
+    private native void setTraceContext0(String traceId, String spanId);
+    
+    private native void clearTraceContext0();
 }

--- a/src/api/one/profiler/AsyncProfilerMXBean.java
+++ b/src/api/one/profiler/AsyncProfilerMXBean.java
@@ -30,4 +30,7 @@ public interface AsyncProfilerMXBean {
     String dumpTraces(int maxTraces);
     String dumpFlat(int maxMethods);
     byte[] dumpOtlp();
+
+    void setTraceContext(String traceId, String spanId);
+    void clearTraceContext();
 }

--- a/src/javaApi.cpp
+++ b/src/javaApi.cpp
@@ -148,6 +148,21 @@ Java_one_profiler_AsyncProfiler_filterThread0(JNIEnv* env, jobject unused, jthre
     }
 }
 
+extern "C" DLLEXPORT void JNICALL
+Java_one_profiler_AsyncProfiler_setTraceContext0(JNIEnv* env, jobject unused, jstring traceId, jstring spanId) {
+    const char* trace_id_str = env->GetStringUTFChars(traceId, NULL);
+    const char* span_id_str = env->GetStringUTFChars(spanId, NULL);
+    
+    Profiler::instance()->setTraceContext(trace_id_str, span_id_str);
+    
+    env->ReleaseStringUTFChars(traceId, trace_id_str);
+    env->ReleaseStringUTFChars(spanId, span_id_str);
+}
+
+extern "C" DLLEXPORT void JNICALL
+Java_one_profiler_AsyncProfiler_clearTraceContext0(JNIEnv* env, jobject unused) {
+    Profiler::instance()->clearTraceContext();
+}
 
 #define F(name, sig)  {(char*)#name, (char*)sig, (void*)Java_one_profiler_AsyncProfiler_##name}
 
@@ -158,6 +173,8 @@ static const JNINativeMethod profiler_natives[] = {
     F(execute1,      "(Ljava/lang/String;)[B"),
     F(getSamples,    "()J"),
     F(filterThread0, "(Ljava/lang/Thread;Z)V"),
+    F(setTraceContext0,   "(Ljava/lang/String;Ljava/lang/String;)V"),
+    F(clearTraceContext0, "()V"),
 };
 
 static const JNINativeMethod* execute0 = &profiler_natives[2];

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -213,6 +213,9 @@ class Profiler {
     void writeLog(LogLevel level, const char* message);
     void writeLog(LogLevel level, const char* message, size_t len);
 
+    void setTraceContext(const char* traceId, const char* spanId);
+    void clearTraceContext();
+
     void updateSymbols(bool kernel_symbols);
     const void* resolveSymbol(const char* name);
     const char* getLibraryName(const char* native_symbol);


### PR DESCRIPTION
### Description
Add API methods to correlate profiling samples with OpenTelemetry trace and span IDs.Not ready for review.

### Related issues
N/A

### Motivation and context
N/A

### How has this been tested?
N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
