### PR TITLE
Simple smoke tests for JFR converter

### DIFF
--- a/test/test/jfrconverter/CpuBurner.java
+++ b/test/test/jfrconverter/CpuBurner.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package test.jfrconverter;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Random;
+
+public class CpuBurner {
+    private static final Random RANDOM = new Random();
+    private static final Duration TEST_DURATION = Duration.ofSeconds(1);
+
+    static void burn() {
+        long n = RANDOM.nextLong();
+        if (Long.toString(n).hashCode() == 0) {
+            System.out.println(n);
+        }
+    }
+
+    public static void main(String[] args) {
+        Instant start = Instant.now();
+        while (Duration.between(start, Instant.now()).compareTo(TEST_DURATION) < 0) {
+            burn();
+        }
+    }
+}

--- a/test/test/jfrconverter/JfrconverterTests.java
+++ b/test/test/jfrconverter/JfrconverterTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package test.jfrconverter;
+
+import one.convert.*;
+import one.profiler.test.*;
+
+// Simple smoke tests for JFR converter. The output is not inspected for errors,
+// we only verify that the conversion completes successfully.
+public class JfrconverterTests {
+
+    private static final String TMP_DIR = System.getProperty("java.io.tmpdir");
+
+    @Test(mainClass = CpuBurner.class, agentArgs = "start,jfr,file=%f")
+    public void testAllocationHeatmapConversion(TestProcess p) throws Exception {
+        Output out = p.waitForExit("%f");
+        assert p.exitCode() == 0;
+        JfrToHeatmap.convert(p.getFilePath("%f"), "/dev/null", new Arguments("alloc"));
+    }
+
+    @Test(mainClass = CpuBurner.class, agentArgs = "start,jfr,file=%f")
+    public void testCpuHeatmapConversion(TestProcess p) throws Exception {
+        Output out = p.waitForExit("%f");
+        assert p.exitCode() == 0;
+        JfrToHeatmap.convert(p.getFilePath("%f"), "/dev/null", new Arguments("cpu"));
+    }
+
+    @Test(mainClass = CpuBurner.class, agentArgs = "start,jfr,file=%f")
+    public void testFlamegraphConversion(TestProcess p) throws Exception {
+        Output out = p.waitForExit("%f");
+        assert p.exitCode() == 0;
+        JfrToFlame.convert(p.getFilePath("%f"), "/dev/null", new Arguments());
+    }
+}

--- a/test/test/jfrconverter/JfrconverterTests.java
+++ b/test/test/jfrconverter/JfrconverterTests.java
@@ -18,14 +18,14 @@ public class JfrconverterTests {
     public void testAllocationHeatmapConversion(TestProcess p) throws Exception {
         Output out = p.waitForExit("%f");
         assert p.exitCode() == 0;
-        JfrToHeatmap.convert(p.getFilePath("%f"), "/dev/null", new Arguments("alloc"));
+        JfrToHeatmap.convert(p.getFilePath("%f"), "/dev/null", new Arguments("--alloc"));
     }
 
     @Test(mainClass = CpuBurner.class, agentArgs = "start,jfr,file=%f")
     public void testCpuHeatmapConversion(TestProcess p) throws Exception {
         Output out = p.waitForExit("%f");
         assert p.exitCode() == 0;
-        JfrToHeatmap.convert(p.getFilePath("%f"), "/dev/null", new Arguments("cpu"));
+        JfrToHeatmap.convert(p.getFilePath("%f"), "/dev/null", new Arguments("--cpu"));
     }
 
     @Test(mainClass = CpuBurner.class, agentArgs = "start,jfr,file=%f")


### PR DESCRIPTION
### Description
In this PR I add a few simple tests to verify that JFR conversion completes successfully. The output is not inspected.

### Related issues
#1378 introduced a bug (fixed in #1431) in the allocation heatmap converter.

### Motivation and context
We should have some basic protection from bugs in JFR converter.

### How has this been tested?
New tests.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
