### PR TITLE
Allow wildcards in `Instrument` profiling engine

### DIFF
--- a/test/test/instrument/CpuBurner.java
+++ b/test/test/instrument/CpuBurner.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package test.instrument;
+
+import java.time.Duration;
+import java.util.Random;
+
+public class CpuBurner {
+    private static final Random random = new Random();
+
+    static void burn(Duration duration) {
+        long start = System.nanoTime();
+        while (System.nanoTime() - start < duration.toNanos()) {
+            long n = random.nextLong();
+            if (Long.toString(n).hashCode() == 0) {
+                System.out.println(n);
+            }
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        Thread t1 = new Thread(() -> {
+            burn(Duration.ofMillis(500));
+            burn(Duration.ofMillis(10));
+        }, "thread1");
+        Thread t2 = new Thread(() -> {
+            burn(Duration.ofMillis(300));
+            burn(Duration.ofMillis(30));
+            burn(Duration.ofMillis(150));
+        }, "thread2");
+        Thread t3 = new Thread(() -> burn(Duration.ofMillis(50)), "thread3");
+        Thread t4 = new Thread(() -> burn(Duration.ofMillis(10)), "thread4");
+        t1.start();
+        t2.start();
+        t3.start();
+        t4.start();
+        t1.join();
+        t2.join();
+        t3.join();
+        t4.join();
+    }
+}

--- a/test/test/instrument/InstrumentTests.java
+++ b/test/test/instrument/InstrumentTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package test.instrument;
+
+import one.profiler.test.*;
+
+public class InstrumentTests {
+
+    @Test(
+        mainClass = CpuBurner.class,
+        agentArgs = "start,threads,event=test.instrument.CpuBurner.burn,collapsed,file=%f"
+    )
+    public void instrument(TestProcess p) throws Exception {
+        Output out = p.waitForExit("%f");
+        assert p.exitCode() == 0;
+
+        assert out.samples("\\[thread1 .*;test\\/instrument\\/CpuBurner\\.lambda\\$main\\$0;test\\/instrument\\/CpuBurner\\.burn") == 2;
+        assert out.samples("\\[thread2 .*;test\\/instrument\\/CpuBurner\\.lambda\\$main\\$1;test\\/instrument\\/CpuBurner\\.burn") == 3;
+        assert out.samples("\\[thread3 .*;test\\/instrument\\/CpuBurner\\.lambda\\$main\\$2;test\\/instrument\\/CpuBurner\\.burn") == 1;
+        assert out.samples("\\[thread4 .*;test\\/instrument\\/CpuBurner\\.lambda\\$main\\$3;test\\/instrument\\/CpuBurner\\.burn") == 1;
+    }
+
+    // Smoke test: if any validation failure happens Instrument::BytecodeRewriter has a bug
+    @Test(
+        mainClass = CpuBurner.class,
+        agentArgs = "start,event=*.*,collapsed,file=%f"
+    )
+    public void instrumentAll(TestProcess p) throws Exception {
+        Output out = p.waitForExit("%f");
+        assert p.exitCode() == 0;
+
+        assert out.samples("^java\\/lang\\/Thread\\.run ") > 0;
+        assert out.samples("java\\/lang\\/String\\.<init> ") > 0;
+    }
+
+}

--- a/test/test/instrument/InstrumentTests.java
+++ b/test/test/instrument/InstrumentTests.java
@@ -36,4 +36,16 @@ public class InstrumentTests {
         assert out.samples("java\\/lang\\/String\\.<init> ") > 0;
     }
 
+    @Test(
+        mainClass = CpuBurner.class,
+        agentArgs = "start,event=*.<init>,collapsed,file=%f"
+    )
+    public void instrumentAllInit(TestProcess p) throws Exception {
+        Output out = p.waitForExit("%f");
+        assert p.exitCode() == 0;
+
+        assert out.samples("^java\\/lang\\/Thread\\.run ") == 0;
+        assert out.samples("java\\/lang\\/String\\.<init> ") > 0;
+    }
+
 }

--- a/test/test/instrument/InstrumentTests.java
+++ b/test/test/instrument/InstrumentTests.java
@@ -32,7 +32,7 @@ public class InstrumentTests {
         Output out = p.waitForExit("%f");
         assert p.exitCode() == 0;
 
-        assert out.samples("^java\\/lang\\/Thread\\.run ") > 0;
+        assert out.samples("java\\/lang\\/Thread\\.run ") > 0;
         assert out.samples("java\\/lang\\/String\\.<init> ") > 0;
     }
 
@@ -44,8 +44,21 @@ public class InstrumentTests {
         Output out = p.waitForExit("%f");
         assert p.exitCode() == 0;
 
-        assert out.samples("^java\\/lang\\/Thread\\.run ") == 0;
+        assert out.samples("java\\/lang\\/Thread\\.run ") == 0;
         assert out.samples("java\\/lang\\/String\\.<init> ") > 0;
+    }
+
+    @Test(
+        mainClass = CpuBurner.class,
+        agentArgs = "start,event=java.lang.Thread.*,collapsed,file=%f"
+    )
+    public void instrumentAllMethodsInClass(TestProcess p) throws Exception {
+        Output out = p.waitForExit("%f");
+        assert p.exitCode() == 0;
+
+        assert out.samples("java\\/lang\\/Thread\\.run ") > 0;
+        assert out.samples("java\\/lang\\/Thread\\.<init> ") > 0;
+        assert out.samples("java\\/lang\\/String\\.<init> ") == 0;
     }
 
 }

--- a/test/test/instrument/InstrumentTests.java
+++ b/test/test/instrument/InstrumentTests.java
@@ -32,8 +32,8 @@ public class InstrumentTests {
         Output out = p.waitForExit("%f");
         assert p.exitCode() == 0;
 
-        assert out.samples("java\\/lang\\/Thread\\.run ") > 0;
-        assert out.samples("java\\/lang\\/String\\.<init> ") > 0;
+        assert out.contains("java\\/lang\\/Thread\\.run ");
+        assert out.contains("java\\/lang\\/String\\.<init> ");
     }
 
     @Test(
@@ -44,8 +44,8 @@ public class InstrumentTests {
         Output out = p.waitForExit("%f");
         assert p.exitCode() == 0;
 
-        assert out.samples("java\\/lang\\/Thread\\.run ") == 0;
-        assert out.samples("java\\/lang\\/String\\.<init> ") > 0;
+        assert !out.contains("java\\/lang\\/Thread\\.run ");
+        assert out.contains("java\\/lang\\/String\\.<init> ");
     }
 
     @Test(
@@ -56,9 +56,9 @@ public class InstrumentTests {
         Output out = p.waitForExit("%f");
         assert p.exitCode() == 0;
 
-        assert out.samples("java\\/lang\\/Thread\\.run ") > 0;
-        assert out.samples("java\\/lang\\/Thread\\.<init> ") > 0;
-        assert out.samples("java\\/lang\\/String\\.<init> ") == 0;
+        assert out.contains("java\\/lang\\/Thread\\.run ");
+        assert out.contains("java\\/lang\\/Thread\\.<init> ");
+        assert !out.contains("java\\/lang\\/String\\.<init> ");
     }
 
 }


### PR DESCRIPTION
### Description
In this PR I introduce support for simple `*` wildcards (both for class and method) in the event selector for the `Instrument` engine. This is now valid:
- `event=*.*`
- `event=*.<init>`
- `event=java.lang.Thread.*`

### Related issues
#1421

### Motivation and context
This feature is mainly aimed at testing extensively #1421. Instrumenting all methods in a run loading a considerable amount of classes will give us confidence about the changes.

### How has this been tested?
`make test-java -j TESTS=instrument`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
