### PR TITLE
Fix sized string writer method in protobuf writer

### DIFF
--- a/src/protobuf.cpp
+++ b/src/protobuf.cpp
@@ -58,7 +58,7 @@ void ProtoBuffer::field(protobuf_index_t index, const char* s) {
 }
 
 void ProtoBuffer::field(protobuf_index_t index, const char* s, size_t len) {
-    field(index, (const unsigned char*) s, strlen(s));
+    field(index, (const unsigned char*) s, len);
 }
 
 void ProtoBuffer::field(protobuf_index_t index, const unsigned char* s, size_t len) {

--- a/test/native/protobufBufferTest.cpp
+++ b/test/native/protobufBufferTest.cpp
@@ -183,3 +183,18 @@ TEST_CASE(Buffer_test_VarIntByteSize) {
     CHECK_EQ(ProtoBuffer::varIntSize(0x7FFFFFFFFFFFFFFF), 9);
     CHECK_EQ(ProtoBuffer::varIntSize(0xFFFFFFFFFFFFFFFF), 10);
 }
+
+TEST_CASE(Buffer_test_string_with_explicit_length) {
+    ProtoBuffer buf(100);
+    
+    const char* longString = "hello_world_this_is_a_long_string";
+    size_t partialLength = 5;
+
+    buf.field(1, longString, partialLength);
+    
+    CHECK_EQ(buf.offset(), 1 + 1 + partialLength);
+    CHECK_EQ(buf.data()[0], (1 << 3) | LEN);
+    CHECK_EQ(buf.data()[1], partialLength);
+    CHECK_EQ(strncmp((const char*) buf.data() + 2, "hello", partialLength), 0);
+    
+}


### PR DESCRIPTION
### Description
Fix bug in ProtoBuffer::field(protobuf_index_t index, const char* s, size_t len) where the function was using strlen(s) instead of the provided len parameter, causing it to write more data than intended.

### Related issues
N/A

### Motivation and context
Discovered while debugging an OTLP test failure in the context of signal correlation. This could lead to buffer overruns and incorrect protobuf serialization when the caller wants to write only a portion of a string.

### How has this been tested?
Added unit test.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
