### PR TITLE
set stubs sections in CodeCache for macOS

### DIFF
--- a/src/symbols_macos.cpp
+++ b/src/symbols_macos.cpp
@@ -99,6 +99,8 @@ class MachOParser {
                 _cc->add(stubs_start + i * stubs_section->reserved2, stubs_section->reserved2, stub_name);
             }
         }
+
+        _cc->setPlt(stubs_section->addr, isym_count * stubs_section->reserved2);
     }
 
     void loadImports(const symtab_command* symtab, const dysymtab_command* dysymtab,


### PR DESCRIPTION
### Description
While working on #1418, I found that it's possible for the library to have no unwind information (always use FP) or to have some symbols that don't have unwind information.

While checking which symbols don't have unwind information I did observe that it were the stub symbols, which means that implement the unwinding in macOS won't solve all unwinding issues.

For stubs the general recommendation is to recover from the `link()` register (From the resources I managed to find regarding the subject)

By setting the `plt` section information inside the code cache, it would result in the FrameDesc being resolved as `FrameDesc::empty_frame` for stubs, which emulates the mentioned behavior above 

This change is safe as it would keep the FP unwinding for all symbols other than the stub symbols,

=> Please note as FP are mandatory in macOS ARM, this should be sufficient for correct unwinding on ARM for macOS

### Related issues
#1418 

### Motivation and context
allow correct unwinding for macOS from stubs

### How has this been tested?
manual testing on both ARM & X86 using the `jninativestacks.c` file & tests

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
