### PR TITLE
`Profile:: _symbol_map` is unused

### DIFF
--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1407,7 +1407,7 @@ Error Profiler::dump(Writer& out, Arguments& args) {
 void Profiler::printUsedMemory(Writer& out) {
     size_t call_trace_storage = _call_trace_storage.usedMemory();
     size_t flight_recording = _jfr.usedMemory();
-    size_t dictionaries = _class_map.usedMemory() + _symbol_map.usedMemory() + _thread_filter.usedMemory();
+    size_t dictionaries = _class_map.usedMemory() + _thread_filter.usedMemory();
 
     size_t code_cache = _runtime_stubs.usedMemory();
     int native_lib_count = _native_libs.count();

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -59,7 +59,6 @@ class Profiler {
     std::map<int, std::string> _thread_names;
     std::map<int, jlong> _thread_ids;
     Dictionary _class_map;
-    Dictionary _symbol_map;
     ThreadFilter _thread_filter;
     CallTraceStorage _call_trace_storage;
     FlightRecorder _jfr;


### PR DESCRIPTION
### Description
It seems that the field `Profile:: _symbol_map` is unused, let me know if I missed something.

### Related issues
n/a

### Motivation and context
If unused, we can remove it. Not really a big difference though, just 4kb in memory:

Before:
```
Call trace storage:   10244 KB
  Flight recording:       0 KB
      Dictionaries:      72 KB
        Code cache:    9942 KB
------------------------------
             Total:   20258 KB
```

After:
```
Call trace storage:   10244 KB
  Flight recording:       0 KB
      Dictionaries:      68 KB
        Code cache:    9942 KB
------------------------------
             Total:   20254 KB
```

### How has this been tested?
GHA

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
