### PR TITLE
Add `manual-test` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,9 @@ coverage: clean-coverage
 
 test: test-cpp test-java
 
+manual-test: build-test-java
+	echo "-Djava.library.path=$(TEST_LIB_DIR)" -ea -cp "build/$(TEST_JAR):build/jar/*:$(TEST_DEPS_DIR)/*:$(TEST_GEN_DIR)/*"
+
 $(TEST_DEPS_DIR):
 	mkdir -p $@
 

--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,8 @@ test-cpp: build-test-cpp
 
 test-java: build-test-java
 	echo "Running tests against $(LIB_PROFILER)"
-	$(JAVA) "-Djava.library.path=$(TEST_LIB_DIR)" $(TEST_FLAGS) -ea -cp "build/$(TEST_JAR):build/jar/*:build/lib/*:$(TEST_DEPS_DIR)/*:$(TEST_GEN_DIR)/*" one.profiler.test.Runner $(subst $(COMMA), ,$(TESTS))
+	PATH_ARGS=$$($(MAKE) -s manual-test) && \
+	$(JAVA) $$PATH_ARGS -ea $(TEST_FLAGS) one.profiler.test.Runner $(subst $(COMMA), ,$(TESTS))
 
 coverage: override FAT_BINARY=false
 coverage: clean-coverage
@@ -269,7 +270,7 @@ coverage: clean-coverage
 test: test-cpp test-java
 
 manual-test: build-test-java
-	echo "-Djava.library.path=$(TEST_LIB_DIR)" -ea -cp "build/$(TEST_JAR):build/jar/*:$(TEST_DEPS_DIR)/*:$(TEST_GEN_DIR)/*"
+	echo "-Djava.library.path=$(TEST_LIB_DIR)" -cp "build/$(TEST_JAR):build/jar/*:$(TEST_DEPS_DIR)/*:$(TEST_GEN_DIR)/*"
 
 $(TEST_DEPS_DIR):
 	mkdir -p $@


### PR DESCRIPTION
### Description
Sometimes I want to gdb into the `mainClass` of a test. I thought adding a dedicated `Makefile` target to set up the classpath would be useful.

### Related issues
n/a

### Motivation and context
Before:
```
java -Djava.library.path=build/test/lib -cp build/test.jar:build/jar/*:test/deps/*:test/gen/* 
-agentpath:./build/lib/libasyncProfiler.so=start,threads,event=test.instrument.CpuBurner.burn,latency=100ms,collapsed 
test.instrument.CpuBurner
```

After:
```
java $(make -s manual-test) -agentpath:./build/lib/libasyncProfiler.so=start,threads,event=test.instrument.CpuBurner.burn,latency=100ms,collapsed 
test.instrument.CpuBurner
```

### How has this been tested?
Manual testing

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
