### PR TITLE
Enhance arm unwinding

### DIFF
--- a/src/codeCache.cpp
+++ b/src/codeCache.cpp
@@ -130,7 +130,7 @@ CodeBlob* CodeCache::findBlobByAddress(const void* address) {
     return NULL;
 }
 
-const char* CodeCache::binarySearch(const void* address) {
+const char* CodeCache::binarySearch(const void* address, const void** start_address) {
     int low = 0;
     int high = _count - 1;
 
@@ -141,6 +141,7 @@ const char* CodeCache::binarySearch(const void* address) {
         } else if (_blobs[mid]._start > address) {
             high = mid - 1;
         } else {
+            *start_address = _blobs[mid]._start;
             return _blobs[mid]._name;
         }
     }
@@ -148,8 +149,10 @@ const char* CodeCache::binarySearch(const void* address) {
     // Symbols with zero size can be valid functions: e.g. ASM entry points or kernel code.
     // Also, in some cases (endless loop) the return address may point beyond the function.
     if (low > 0 && (_blobs[low - 1]._start == _blobs[low - 1]._end || _blobs[low - 1]._end == address)) {
+        *start_address = _blobs[low - 1]._start;
         return _blobs[low - 1]._name;
     }
+    *start_address = NULL;
     return _name;
 }
 

--- a/src/codeCache.h
+++ b/src/codeCache.h
@@ -198,7 +198,7 @@ class CodeCache {
 
     CodeBlob* findBlob(const char* name);
     CodeBlob* findBlobByAddress(const void* address);
-    const char* binarySearch(const void* address);
+    const char* binarySearch(const void* address, const void** start_address);
     const void* findSymbol(const char* name);
     const void* findSymbolByPrefix(const char* prefix);
     const void* findSymbolByPrefix(const char* prefix, int prefix_len);

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -291,9 +291,9 @@ CodeCache* Profiler::findLibraryByAddress(const void* address) {
     return NULL;
 }
 
-const char* Profiler::findNativeMethod(const void* address) {
+const char* Profiler::findNativeMethod(const void* address, const void** start_address) {
     CodeCache* lib = findLibraryByAddress(address);
-    return lib == NULL ? NULL : lib->binarySearch(address);
+    return lib == NULL ? NULL : lib->binarySearch(address, start_address);
 }
 
 CodeBlob* Profiler::findRuntimeStub(const void* address) {
@@ -340,9 +340,10 @@ int Profiler::getNativeTrace(void* ucontext, ASGCT_CallFrame* frames, EventType 
 int Profiler::convertNativeTrace(int native_frames, const void** callchain, ASGCT_CallFrame* frames, EventType event_type) {
     int depth = 0;
     jmethodID prev_method = NULL;
+    const void* start_addr;
 
     for (int i = 0; i < native_frames; i++) {
-        const char* current_method_name = findNativeMethod(callchain[i]);
+        const char* current_method_name = findNativeMethod(callchain[i], &start_addr);
         char mark;
         if (current_method_name != NULL && (mark = NativeFunc::mark(current_method_name)) != 0) {
             if (mark == MARK_VM_RUNTIME && event_type >= ALLOC_SAMPLE) {

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -218,7 +218,7 @@ class Profiler {
     CodeCache* findJvmLibrary(const char* lib_name);
     CodeCache* findLibraryByName(const char* lib_name);
     CodeCache* findLibraryByAddress(const void* address);
-    const char* findNativeMethod(const void* address);
+    const char* findNativeMethod(const void* address, const void** start_address);
     CodeBlob* findRuntimeStub(const void* address);
     bool isAddressInCode(const void* pc);
 

--- a/src/stackFrame.h
+++ b/src/stackFrame.h
@@ -79,6 +79,8 @@ class StackFrame {
 
     bool checkInterruptedSyscall();
 
+    bool completeNativeFrame(uintptr_t start_addr, uintptr_t pc);
+
     // Check if PC points to a syscall instruction
     static bool isSyscall(instruction_t* pc);
 };

--- a/src/stackFrame_aarch64.cpp
+++ b/src/stackFrame_aarch64.cpp
@@ -402,4 +402,23 @@ bool StackFrame::isSyscall(instruction_t* pc) {
     return (*pc & 0xffffefff) == 0xd4000001;
 }
 
+bool StackFrame::completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
+    // {stack_bang}
+    // stp	x29, x30, [sp, #offset]
+
+    if (pc >= start_addr + 100) { // if PC has progressed enough distance from base, assume frame is complete
+        return true;
+    }
+
+    instruction_t* ip = (instruction_t*)pc - 1;
+    while (ip >= (instruction_t*)start_addr) {
+        if ((*ip & 0xff407fff) == 0xa9007bfd) { // stp	x29, x30, [sp, #offset]
+            return true;
+        }
+        ip--;
+    }
+
+    return false;
+}
+
 #endif // __aarch64__

--- a/src/stackFrame_arm.cpp
+++ b/src/stackFrame_arm.cpp
@@ -138,4 +138,8 @@ bool StackFrame::isSyscall(instruction_t* pc) {
     return *pc == 0xef000000;
 }
 
+bool completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
+    return true;
+}
+
 #endif // defined(__arm__) || defined(__thumb__)

--- a/src/stackFrame_arm.cpp
+++ b/src/stackFrame_arm.cpp
@@ -138,7 +138,7 @@ bool StackFrame::isSyscall(instruction_t* pc) {
     return *pc == 0xef000000;
 }
 
-bool completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
+bool StackFrame::completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
     return true;
 }
 

--- a/src/stackFrame_i386.cpp
+++ b/src/stackFrame_i386.cpp
@@ -159,7 +159,7 @@ bool StackFrame::isSyscall(instruction_t* pc) {
     return pc[0] == 0xcd && pc[1] == 0x80;
 }
 
-bool completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
+bool StackFrame::completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
     return true;
 }
 

--- a/src/stackFrame_i386.cpp
+++ b/src/stackFrame_i386.cpp
@@ -159,4 +159,8 @@ bool StackFrame::isSyscall(instruction_t* pc) {
     return pc[0] == 0xcd && pc[1] == 0x80;
 }
 
+bool completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
+    return true;
+}
+
 #endif // __i386__

--- a/src/stackFrame_loongarch64.cpp
+++ b/src/stackFrame_loongarch64.cpp
@@ -113,7 +113,7 @@ bool StackFrame::isSyscall(instruction_t* pc) {
     return (*pc) == 0x002b0000;
 }
 
-bool completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
+bool StackFrame::completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
     return true;
 }
 

--- a/src/stackFrame_loongarch64.cpp
+++ b/src/stackFrame_loongarch64.cpp
@@ -113,4 +113,8 @@ bool StackFrame::isSyscall(instruction_t* pc) {
     return (*pc) == 0x002b0000;
 }
 
+bool completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
+    return true;
+}
+
 #endif // __loongarch_lp64

--- a/src/stackFrame_ppc64.cpp
+++ b/src/stackFrame_ppc64.cpp
@@ -159,7 +159,7 @@ bool StackFrame::isSyscall(instruction_t* pc) {
     return (*pc & 0x1f) == 17;
 }
 
-bool completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
+bool StackFrame::completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
     return true;
 }
 

--- a/src/stackFrame_ppc64.cpp
+++ b/src/stackFrame_ppc64.cpp
@@ -159,4 +159,8 @@ bool StackFrame::isSyscall(instruction_t* pc) {
     return (*pc & 0x1f) == 17;
 }
 
+bool completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
+    return true;
+}
+
 #endif // defined(__PPC64__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)

--- a/src/stackFrame_riscv64.cpp
+++ b/src/stackFrame_riscv64.cpp
@@ -115,7 +115,7 @@ bool StackFrame::isSyscall(instruction_t* pc) {
     return (*pc) == 0x00000073;
 }
 
-bool completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
+bool StackFrame::completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
     return true;
 }
 

--- a/src/stackFrame_riscv64.cpp
+++ b/src/stackFrame_riscv64.cpp
@@ -115,4 +115,8 @@ bool StackFrame::isSyscall(instruction_t* pc) {
     return (*pc) == 0x00000073;
 }
 
+bool completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
+    return true;
+}
+
 #endif // riscv

--- a/src/stackFrame_x64.cpp
+++ b/src/stackFrame_x64.cpp
@@ -319,7 +319,7 @@ bool StackFrame::isSyscall(instruction_t* pc) {
     return pc[0] == 0x0f && pc[1] == 0x05;
 }
 
-bool completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
+bool StackFrame::completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
     return true;
 }
 

--- a/src/stackFrame_x64.cpp
+++ b/src/stackFrame_x64.cpp
@@ -319,4 +319,8 @@ bool StackFrame::isSyscall(instruction_t* pc) {
     return pc[0] == 0x0f && pc[1] == 0x05;
 }
 
+bool completeNativeFrame(uintptr_t start_addr, uintptr_t pc) {
+    return true;
+}
+
 #endif // __x86_64__


### PR DESCRIPTION
### Description
If a sample is captured in a native function prologue before the execution of the `stp x29, x30...` command, it would result in a failure of the unwinder.

That happens as we try to read the new PC by de-referencing the SP (with offset), but the since the PC was yet to be stored into the frame, the read we do would result in garbage values which would either result in:
* immediate failure (PC is in deadzone)
* [Unkown] frame on the top of the reported stack

This change fixes the issue by reading the instructions from the PC to the function base address & checking if `stp x29, x30...` was executed, if yes we assume dwarf worked as expected, if not we assume dwarf failed & use `lr` register to get the new PC

```

000000000002f540 <__exp1>:
   2f540:	d10083ff                                     	sub	sp, sp, #0x20
   2f544:	90000481                                     	adrp	x1, bf000 <__FRAME_END__+0x14e44>
   2f548:	9e660004                                     	fmov	x4, d0
   2f54c:	52b86e00                                     	mov	w0, #0xc3700000            	// #-1016070144
   2f550:	52840026                                     	mov	w6, #0x2001                	// #8193
   2f554:	d2800005                                     	mov	x5, #0x0                   	// #0
   2f558:	a9017bfd                                     	stp	x29, x30, [sp, #16]
   2f55c:	910043fd                                     	add	x29, sp, #0x10
   2f560:	72a07ec6                                     	movk	w6, #0x3f6, lsl #16
```

We might still see the occasional weird frames of
```
test/stackwalker/StackGenerator.main_[0];test/stackwalker/StackGenerator.leafFrame_[0];Java_test_stackwalker_StackGenerator_leafFrame;__kernel_standard 1
```
This seems to be happening because in some cases the assembly code shows a branch rather than a function call `b vs bl`

```
    92d4:	a8c27bfd                                     	ldp	x29, x30, [sp], #32
    92d8:	140001ea                                     	b	9a80 <__kernel_standard>
```

GDB reports the same stacks as async-profiler

```
#5  0x0000fffff6c21ad8 in __kernel_standard () from /lib64/libm.so.6
#6  0x0000fffff583fa38 in Java_test_stackwalker_StackGenerator_leafFrame () from /workplace/bhashesh/async-profiler/build/test/lib/libjninativestacks.so
#7  0x0000ffffd87d1cfc in ?? ()
#8  0x00000000fcb7e1c8 in ?? 
```

Check was made using ARM documentation on bit values [here](https://developer.arm.com/documentation/ddi0602/2025-06/Base-Instructions/STP--Store-pair-of-registers-?lang=en#Wt1OrWZR)


### Related issues
#1408

### Motivation and context
make ARM64 stackwalking more accurate 

### How has this been tested?
manual testing

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
