### PR TITLE
Expose profiler metrics via API

### DIFF
--- a/src/api/one/profiler/AsyncProfiler.java
+++ b/src/api/one/profiler/AsyncProfiler.java
@@ -281,6 +281,16 @@ public class AsyncProfiler implements AsyncProfilerMXBean {
         }
     }
 
+    /**
+     * Get profiler metrics
+     * @return Array with: call_trace_storage_kb, flight_recording_kb, dictionaries_kb, code_cache_kb, discarded_samples
+     */
+    public int[] getMetrics() {
+        int[] metrics = new int[5];
+        getMetrics0(metrics);
+        return metrics;
+    }
+
     private native void start0(String event, long interval, boolean reset) throws IllegalStateException;
 
     private native void stop0() throws IllegalStateException;
@@ -290,4 +300,6 @@ public class AsyncProfiler implements AsyncProfilerMXBean {
     private native byte[] execute1(String command) throws IllegalArgumentException, IllegalStateException, IOException;
 
     private native void filterThread0(Thread thread, boolean enable);
+
+    private native void getMetrics0(int[] metrics);
 }

--- a/src/javaApi.cpp
+++ b/src/javaApi.cpp
@@ -148,6 +148,12 @@ Java_one_profiler_AsyncProfiler_filterThread0(JNIEnv* env, jobject unused, jthre
     }
 }
 
+extern "C" DLLEXPORT void JNICALL
+Java_one_profiler_AsyncProfiler_getMetrics0(JNIEnv* env, jobject unused, jintArray metrics) {
+    int buffer[5];
+    Profiler::instance()->getMetrics(buffer);
+    env->SetIntArrayRegion(metrics, 0, 5, buffer);
+}
 
 #define F(name, sig)  {(char*)#name, (char*)sig, (void*)Java_one_profiler_AsyncProfiler_##name}
 
@@ -158,6 +164,7 @@ static const JNINativeMethod profiler_natives[] = {
     F(execute1,      "(Ljava/lang/String;)[B"),
     F(getSamples,    "()J"),
     F(filterThread0, "(Ljava/lang/Thread;Z)V"),
+    F(getMetrics0,   "([I)V"),
 };
 
 static const JNINativeMethod* execute0 = &profiler_natives[2];

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1430,6 +1430,26 @@ void Profiler::printUsedMemory(Writer& out) {
     out << buf;
 }
 
+void Profiler::getMetrics(int* metrics) {
+    size_t call_trace_storage = _call_trace_storage.usedMemory() / 1024;
+    size_t flight_recording = _jfr.usedMemory() / 1024;
+    size_t dictionaries = (_class_map.usedMemory() + _symbol_map.usedMemory() + 
+                          _thread_filter.usedMemory()) / 1024;
+    
+    size_t code_cache = _runtime_stubs.usedMemory();
+    int native_lib_count = _native_libs.count();
+    for (int i = 0; i < native_lib_count; i++) {
+        code_cache += _native_libs[i]->usedMemory();
+    }
+    code_cache = (code_cache + native_lib_count * sizeof(CodeCache)) / 1024;
+    
+    metrics[0] = (int)call_trace_storage;
+    metrics[1] = (int)flight_recording;
+    metrics[2] = (int)dictionaries;
+    metrics[3] = (int)code_cache;
+    metrics[4] = (int)_failures[-ticks_skipped];
+}
+
 void Profiler::logStats() {
     if (!_features.stats) return;
 

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -96,6 +96,8 @@ class Profiler {
     const void* _call_stub_begin;
     const void* _call_stub_end;
 
+    int _metrics[5];  // Call trace storage, Flight recording, Dictionaries, Code cache, Discarded Samples
+
     // dlopen() hook support
     void** _dlopen_entry;
     static void* dlopen_hook(const char* filename, int flags);
@@ -212,6 +214,7 @@ class Profiler {
     void tryResetCounters();
     void writeLog(LogLevel level, const char* message);
     void writeLog(LogLevel level, const char* message, size_t len);
+    void getMetrics(int* metrics);
 
     void updateSymbols(bool kernel_symbols);
     const void* resolveSymbol(const char* name);


### PR DESCRIPTION
### Description
Add `getMetrics()` API to expose internal metrics including memory usage for call trace storage, flight recording, dictionaries, code cache, and discarded samples count.

### Related issues
N/A

### Motivation and context
N/A

### How has this been tested?
N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
