### PR TITLE
Encode a default invalid RA for ARM FrameDesc 

### DIFF
--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -55,7 +55,7 @@ enum {
 };
 
 
-FrameDesc FrameDesc::empty_frame = {0, DW_REG_SP | EMPTY_FRAME_SIZE << 8, DW_SAME_FP, DEFAULT_PC_OFF};
+FrameDesc FrameDesc::empty_frame = {0, DW_REG_SP | EMPTY_FRAME_SIZE << 8, DW_SAME_FP, INITIAL_PC_OFFSET};
 FrameDesc FrameDesc::default_frame = {0, DW_REG_FP | LINKED_FRAME_SIZE << 8, -LINKED_FRAME_SIZE, -LINKED_FRAME_SIZE + DW_STACK_SLOT};
 
 
@@ -136,12 +136,12 @@ void DwarfParser::parseInstructions(u32 loc, const char* end) {
     u32 cfa_reg = DW_REG_SP;
     int cfa_off = EMPTY_FRAME_SIZE;
     int fp_off = DW_SAME_FP;
-    int pc_off = DEFAULT_PC_OFF;
+    int pc_off = INITIAL_PC_OFFSET;
 
     u32 rem_cfa_reg = DW_REG_SP;
     int rem_cfa_off = EMPTY_FRAME_SIZE;
     int rem_fp_off = DW_SAME_FP;
-    int rem_pc_off = DEFAULT_PC_OFF;
+    int rem_pc_off = INITIAL_PC_OFFSET;
 
     while (_ptr < end) {
         u8 op = get8();
@@ -271,7 +271,7 @@ void DwarfParser::parseInstructions(u32 loc, const char* end) {
                 if ((op & 0x3f) == DW_REG_FP) {
                     fp_off = DW_SAME_FP;
                 } else if ((op & 0x3f) == DW_REG_PC) {
-                    pc_off = DEFAULT_PC_OFF;
+                    pc_off = INITIAL_PC_OFFSET;
                 }
                 break;
         }

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -55,7 +55,7 @@ enum {
 };
 
 
-FrameDesc FrameDesc::empty_frame = {0, DW_REG_SP | EMPTY_FRAME_SIZE << 8, DW_SAME_FP, -EMPTY_FRAME_SIZE};
+FrameDesc FrameDesc::empty_frame = {0, DW_REG_SP | EMPTY_FRAME_SIZE << 8, DW_SAME_FP, DEFAULT_PC_OFF};
 FrameDesc FrameDesc::default_frame = {0, DW_REG_FP | LINKED_FRAME_SIZE << 8, -LINKED_FRAME_SIZE, -LINKED_FRAME_SIZE + DW_STACK_SLOT};
 
 
@@ -136,12 +136,12 @@ void DwarfParser::parseInstructions(u32 loc, const char* end) {
     u32 cfa_reg = DW_REG_SP;
     int cfa_off = EMPTY_FRAME_SIZE;
     int fp_off = DW_SAME_FP;
-    int pc_off = -EMPTY_FRAME_SIZE;
+    int pc_off = DEFAULT_PC_OFF;
 
     u32 rem_cfa_reg = DW_REG_SP;
     int rem_cfa_off = EMPTY_FRAME_SIZE;
     int rem_fp_off = DW_SAME_FP;
-    int rem_pc_off = -EMPTY_FRAME_SIZE;
+    int rem_pc_off = DEFAULT_PC_OFF;
 
     while (_ptr < end) {
         u8 op = get8();
@@ -270,6 +270,8 @@ void DwarfParser::parseInstructions(u32 loc, const char* end) {
             case DW_CFA_restore:
                 if ((op & 0x3f) == DW_REG_FP) {
                     fp_off = DW_SAME_FP;
+                } else if ((op & 0x3f) == DW_REG_PC) {
+                    pc_off = DEFAULT_PC_OFF;
                 }
                 break;
         }

--- a/src/dwarf.h
+++ b/src/dwarf.h
@@ -28,7 +28,7 @@ const int DW_REG_SP = 7;
 const int DW_REG_PC = 16;
 const int EMPTY_FRAME_SIZE = DW_STACK_SLOT;
 const int LINKED_FRAME_SIZE = 2 * DW_STACK_SLOT;
-const int DEFAULT_PC_OFF = -EMPTY_FRAME_SIZE;
+const int INITIAL_PC_OFFSET = -EMPTY_FRAME_SIZE;
 
 #elif defined(__i386__)
 
@@ -39,7 +39,7 @@ const int DW_REG_SP = 4;
 const int DW_REG_PC = 8;
 const int EMPTY_FRAME_SIZE = DW_STACK_SLOT;
 const int LINKED_FRAME_SIZE = 2 * DW_STACK_SLOT;
-const int DEFAULT_PC_OFF = -EMPTY_FRAME_SIZE;
+const int INITIAL_PC_OFFSET = -EMPTY_FRAME_SIZE;
 
 #elif defined(__aarch64__)
 
@@ -50,7 +50,7 @@ const int DW_REG_SP = 31;
 const int DW_REG_PC = 30;
 const int EMPTY_FRAME_SIZE = 0;
 const int LINKED_FRAME_SIZE = 0;
-const int DEFAULT_PC_OFF = DW_LINK_REGISTER;
+const int INITIAL_PC_OFFSET = DW_LINK_REGISTER;
 
 #else
 
@@ -61,7 +61,7 @@ const int DW_REG_SP = 1;
 const int DW_REG_PC = 2;
 const int EMPTY_FRAME_SIZE = 0;
 const int LINKED_FRAME_SIZE = 0;
-const int DEFAULT_PC_OFF = DW_LINK_REGISTER;
+const int INITIAL_PC_OFFSET = DW_LINK_REGISTER;
 
 #endif
 

--- a/src/dwarf.h
+++ b/src/dwarf.h
@@ -15,7 +15,7 @@ const int DW_REG_INVALID = 255;  // denotes unsupported configuration
 
 const int DW_PC_OFFSET = 1;
 const int DW_SAME_FP = 0x80000000;
-const int DW_PC_RA = 0x80000000;
+const int DW_LINK_REGISTER = 0x80000000;
 const int DW_STACK_SLOT = sizeof(void*);
 
 
@@ -50,7 +50,7 @@ const int DW_REG_SP = 31;
 const int DW_REG_PC = 30;
 const int EMPTY_FRAME_SIZE = 0;
 const int LINKED_FRAME_SIZE = 0;
-const int DEFAULT_PC_OFF = DW_PC_RA;
+const int DEFAULT_PC_OFF = DW_LINK_REGISTER;
 
 #else
 
@@ -61,7 +61,7 @@ const int DW_REG_SP = 1;
 const int DW_REG_PC = 2;
 const int EMPTY_FRAME_SIZE = 0;
 const int LINKED_FRAME_SIZE = 0;
-const int DEFAULT_PC_OFF = DW_PC_RA;
+const int DEFAULT_PC_OFF = DW_LINK_REGISTER;
 
 #endif
 

--- a/src/dwarf.h
+++ b/src/dwarf.h
@@ -15,6 +15,7 @@ const int DW_REG_INVALID = 255;  // denotes unsupported configuration
 
 const int DW_PC_OFFSET = 1;
 const int DW_SAME_FP = 0x80000000;
+const int DW_PC_RA = 0x80000000;
 const int DW_STACK_SLOT = sizeof(void*);
 
 
@@ -27,6 +28,7 @@ const int DW_REG_SP = 7;
 const int DW_REG_PC = 16;
 const int EMPTY_FRAME_SIZE = DW_STACK_SLOT;
 const int LINKED_FRAME_SIZE = 2 * DW_STACK_SLOT;
+const int DEFAULT_PC_OFF = -EMPTY_FRAME_SIZE;
 
 #elif defined(__i386__)
 
@@ -37,6 +39,7 @@ const int DW_REG_SP = 4;
 const int DW_REG_PC = 8;
 const int EMPTY_FRAME_SIZE = DW_STACK_SLOT;
 const int LINKED_FRAME_SIZE = 2 * DW_STACK_SLOT;
+const int DEFAULT_PC_OFF = -EMPTY_FRAME_SIZE;
 
 #elif defined(__aarch64__)
 
@@ -47,6 +50,7 @@ const int DW_REG_SP = 31;
 const int DW_REG_PC = 30;
 const int EMPTY_FRAME_SIZE = 0;
 const int LINKED_FRAME_SIZE = 0;
+const int DEFAULT_PC_OFF = DW_PC_RA;
 
 #else
 
@@ -57,6 +61,7 @@ const int DW_REG_SP = 1;
 const int DW_REG_PC = 2;
 const int EMPTY_FRAME_SIZE = 0;
 const int LINKED_FRAME_SIZE = 0;
+const int DEFAULT_PC_OFF = DW_PC_RA;
 
 #endif
 

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -176,15 +176,16 @@ int StackWalker::walkDwarf(void* ucontext, const void** callchain, int max_depth
                 fp = (uintptr_t)SafeAccess::load((void**)(sp + f->fp_off));
             }
 
-            if (EMPTY_FRAME_SIZE == 0 && depth == 1 && f->pc_off == DW_PC_RA) {
+            if (EMPTY_FRAME_SIZE == 0 && depth == 1 && f->pc_off == DW_LINK_REGISTER) {
                 pc = (const void*)frame.link();
-            } else if (f->pc_off != DW_PC_RA) {
+            } else if (f->pc_off != DW_LINK_REGISTER) {
                 pc = stripPointer(SafeAccess::load((void**)(sp + f->pc_off)));
             } else {
                 break;
             }
 
             if (EMPTY_FRAME_SIZE == 0 && cfa_off == 0 && f->fp_off != DW_SAME_FP) {
+                // AArch64 default_frame
                 sp = defaultSenderSP(sp, fp);
                 if (sp < prev_sp || sp >= bottom || !aligned(sp)) {
                     break;
@@ -422,15 +423,16 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
                 fp = *(uintptr_t*)(sp + f->fp_off);
             }
 
-            if (EMPTY_FRAME_SIZE == 0 && depth == 1 && f->pc_off == DW_PC_RA) {
+            if (EMPTY_FRAME_SIZE == 0 && depth == 1 && f->pc_off == DW_LINK_REGISTER) {
                 pc = (const void*)frame.link();
-            } else if (f->pc_off != DW_PC_RA) {
+            } else if (f->pc_off != DW_LINK_REGISTER) {
                 pc = stripPointer(*(void**)(sp + f->pc_off));
             } else {
                 break;
             }
 
             if (EMPTY_FRAME_SIZE == 0 && cfa_off == 0 && f->fp_off != DW_SAME_FP) {
+                // AArch64 default_frame
                 sp = defaultSenderSP(sp, fp);
                 if (sp < prev_sp || sp >= bottom || !aligned(sp)) {
                     break;

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -179,7 +179,7 @@ int StackWalker::walkDwarf(void* ucontext, const void** callchain, int max_depth
             if (EMPTY_FRAME_SIZE == 0 && depth == 1 && f->pc_off == DW_PC_RA) {
                 pc = (const void*)frame.link();
             } else if (f->pc_off != DW_PC_RA) {
-                pc = stripPointer(*(void**)(sp + f->pc_off));
+                pc = stripPointer(SafeAccess::load((void**)(sp + f->pc_off)));
             } else {
                 break;
             }
@@ -425,7 +425,7 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
             if (EMPTY_FRAME_SIZE == 0 && depth == 1 && f->pc_off == DW_PC_RA) {
                 pc = (const void*)frame.link();
             } else if (f->pc_off != DW_PC_RA) {
-                pc = stripPointer(SafeAccess::load((void**)(sp + f->pc_off)));
+                pc = stripPointer(*(void**)(sp + f->pc_off));
             } else {
                 break;
             }

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -176,10 +176,10 @@ int StackWalker::walkDwarf(void* ucontext, const void** callchain, int max_depth
                 fp = (uintptr_t)SafeAccess::load((void**)(sp + f->fp_off));
             }
 
-            if (EMPTY_FRAME_SIZE == 0 && depth == 1 && f->pc_off == DW_LINK_REGISTER) {
-                pc = (const void*)frame.link();
-            } else if (f->pc_off != DW_LINK_REGISTER) {
+            if (EMPTY_FRAME_SIZE > 0 || f->pc_off != DW_LINK_REGISTER) {
                 pc = stripPointer(SafeAccess::load((void**)(sp + f->pc_off)));
+            } else if (depth == 1) {
+                pc = (const void*)frame.link();
             } else {
                 break;
             }
@@ -423,10 +423,10 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
                 fp = *(uintptr_t*)(sp + f->fp_off);
             }
 
-            if (EMPTY_FRAME_SIZE == 0 && depth == 1 && f->pc_off == DW_LINK_REGISTER) {
-                pc = (const void*)frame.link();
-            } else if (f->pc_off != DW_LINK_REGISTER) {
+            if (EMPTY_FRAME_SIZE > 0 || f->pc_off != DW_LINK_REGISTER) {
                 pc = stripPointer(*(void**)(sp + f->pc_off));
+            } else if (depth == 1) {
+                pc = (const void*)frame.link();
             } else {
                 break;
             }

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -423,7 +423,7 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
         } else {
             // Adjust FP
             if (f->fp_off != DW_SAME_FP && f->fp_off < MAX_FRAME_SIZE && f->fp_off > -MAX_FRAME_SIZE) {
-                fp = (uintptr_t)SafeAccess::load((void**)(sp + f->fp_off));
+                fp = *(uintptr_t*)(sp + f->fp_off);
             }
 
             // Adjust PC

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -172,21 +172,18 @@ int StackWalker::walkDwarf(void* ucontext, const void** callchain, int max_depth
         if (f->fp_off & DW_PC_OFFSET) {
             pc = (const char*)pc + (f->fp_off >> 1);
         } else {
-            // Adjust FP
             if (f->fp_off != DW_SAME_FP && f->fp_off < MAX_FRAME_SIZE && f->fp_off > -MAX_FRAME_SIZE) {
                 fp = (uintptr_t)SafeAccess::load((void**)(sp + f->fp_off));
             }
 
-            // Adjust PC
             if (EMPTY_FRAME_SIZE == 0 && depth == 1 && f->pc_off == DW_PC_RA) {
                 pc = (const void*)frame.link();
             } else if (f->pc_off != DW_PC_RA) {
-                pc = stripPointer(SafeAccess::load((void**)(sp + f->pc_off)));
+                pc = stripPointer(*(void**)(sp + f->pc_off));
             } else {
                 break;
             }
 
-            /// Adjust SP via FP
             if (EMPTY_FRAME_SIZE == 0 && cfa_off == 0 && f->fp_off != DW_SAME_FP) {
                 sp = defaultSenderSP(sp, fp);
                 if (sp < prev_sp || sp >= bottom || !aligned(sp)) {
@@ -421,12 +418,10 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
         if (f->fp_off & DW_PC_OFFSET) {
             pc = (const char*)pc + (f->fp_off >> 1);
         } else {
-            // Adjust FP
             if (f->fp_off != DW_SAME_FP && f->fp_off < MAX_FRAME_SIZE && f->fp_off > -MAX_FRAME_SIZE) {
                 fp = *(uintptr_t*)(sp + f->fp_off);
             }
 
-            // Adjust PC
             if (EMPTY_FRAME_SIZE == 0 && depth == 1 && f->pc_off == DW_PC_RA) {
                 pc = (const void*)frame.link();
             } else if (f->pc_off != DW_PC_RA) {
@@ -435,7 +430,6 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
                 break;
             }
 
-            /// Adjust SP via FP
             if (EMPTY_FRAME_SIZE == 0 && cfa_off == 0 && f->fp_off != DW_SAME_FP) {
                 sp = defaultSenderSP(sp, fp);
                 if (sp < prev_sp || sp >= bottom || !aligned(sp)) {

--- a/test/native/libs/jninativestacks.c
+++ b/test/native/libs/jninativestacks.c
@@ -6,6 +6,18 @@
 #include <jni.h>
 #include <math.h>
 
+JNIEXPORT double largeInnerFrameFinal(int i) {
+    char frame[0x10000];
+    // Prevent from being optimized by compiler
+    (void)frame;
+
+    return sqrt(i) + pow(i, sqrt(i));
+}
+
+JNIEXPORT double largeInnerFrameIntermediate(int i) {
+    return largeInnerFrameFinal(i) + largeInnerFrameFinal(i + 1);
+}
+
 JNIEXPORT double doCpuTask() {
     int i = 0;
     double result = 0;
@@ -46,4 +58,12 @@ JNIEXPORT jdouble JNICALL Java_test_stackwalker_StackGenerator_deepFrame(JNIEnv*
 
 JNIEXPORT jdouble JNICALL Java_test_stackwalker_StackGenerator_leafFrame(JNIEnv* env, jclass cls) {
     return doCpuTask();
+}
+
+JNIEXPORT jdouble JNICALL Java_test_stackwalker_StackGenerator_largeInnerFrame(JNIEnv* env, jclass cls) {
+    double result = 0;
+    for (int i = 0; i < 100000000; i++) {
+        result += largeInnerFrameIntermediate(i);
+    }
+    return result;
 }

--- a/test/test/stackwalker/StackGenerator.java
+++ b/test/test/stackwalker/StackGenerator.java
@@ -13,6 +13,8 @@ public class StackGenerator {
 
     public static native double leafFrame();
 
+    public static native double largeInnerFrame();
+
     static {
         System.loadLibrary("jninativestacks");
     }
@@ -29,6 +31,8 @@ public class StackGenerator {
             deepFrame();
         } else if (args[0].equals("leafFrame")) {
             leafFrame();
+        } else if (args[0].equals("largeInnerFrame")) {
+            largeInnerFrame();
         } else {
             System.err.println("Unknown test: " + args[0]);
             System.exit(1);

--- a/test/test/stackwalker/StackwalkerTests.java
+++ b/test/test/stackwalker/StackwalkerTests.java
@@ -92,6 +92,6 @@ public class StackwalkerTests {
         assert p.exitCode() == 0;
 
         Output output = Output.convertJfrToCollapsed(p.getFilePath("%f"));
-        assert !output.contains("Java_test_stackwalker_StackGenerator_largeInnerFrame;\\[unknown\\];largeInnerFrameFinal");
+        assert !output.contains("Java_test_stackwalker_StackGenerator_largeInnerFrame;unknown;largeInnerFrameFinal");
     }
 }

--- a/test/test/stackwalker/StackwalkerTests.java
+++ b/test/test/stackwalker/StackwalkerTests.java
@@ -86,7 +86,7 @@ public class StackwalkerTests {
     }
 
     @Test(mainClass = StackGenerator.class, jvmArgs = "-Xss5m", args = "largeInnerFrame",
-            agentArgs = "start,event=cpu,cstack=vmx,file=%f.jfr")
+            agentArgs = "start,event=cpu,cstack=vm,file=%f.jfr")
     public void largeInnerFrameVM(TestProcess p) throws Exception {
         p.waitForExit();
         assert p.exitCode() == 0;

--- a/test/test/stackwalker/StackwalkerTests.java
+++ b/test/test/stackwalker/StackwalkerTests.java
@@ -92,11 +92,6 @@ public class StackwalkerTests {
         assert p.exitCode() == 0;
 
         Output output = Output.convertJfrToCollapsed(p.getFilePath("%f"));
-        output.stream().forEach(stack -> {
-            // There should be no unknown frames between largeInnerFrameFinal & Java_test_stackwalker_StackGenerator_largeInnerFrame
-            if (stack.contains("test/stackwalker/StackGenerator.main_[0];test/stackwalker/StackGenerator.largeInnerFrame_[0];")) {
-                assert !stack.matches("Java_test_stackwalker_StackGenerator_largeInnerFrame;\\[unknown];largeInnerFrameFinal");
-            }
-        });
+        assert !output.contains("Java_test_stackwalker_StackGenerator_largeInnerFrame;\\[unknown\\];largeInnerFrameFinal");
     }
 }

--- a/test/test/stackwalker/StackwalkerTests.java
+++ b/test/test/stackwalker/StackwalkerTests.java
@@ -93,8 +93,6 @@ public class StackwalkerTests {
 
         Output output = Output.convertJfrToCollapsed(p.getFilePath("%f"));
         output.stream().forEach(stack -> {
-            // There should be multiple frames per sample
-            assert !stack.matches("^([^\\[;]+)\\s+\\d+$");
             // There should be no unknown frames between largeInnerFrameFinal & Java_test_stackwalker_StackGenerator_largeInnerFrame
             if (stack.contains("test/stackwalker/StackGenerator.main_[0];test/stackwalker/StackGenerator.largeInnerFrame_[0];")) {
                 assert !stack.matches("Java_test_stackwalker_StackGenerator_largeInnerFrame;\\[unknown];largeInnerFrameFinal");


### PR DESCRIPTION
### Description
For the following FDE in DWARF, if a sample was captured between instructions at locations **0x2f544** & **0x2f55c**,
The profiler will use the following FrameDesc `loc = 0x2f544, cfa_reg = 0x1f, cfa_off = 32, fp_off = 0x80000000, pc_off = 0`

In this case the DWARF denotes the RA as invalid for these instructions so we should use the `lr` register ,
However the encoded FrameDesc would result in reading the return address from the `sp` rather than using `lr`
That results in reading random values, which results in `unknown` frame or just fail to unwind

```
000045f8 0000000000000024 000045fc FDE cie=00000000 pc=000000000002f540..000000000002f870
   LOC           CFA      x29   ra    
000000000002f540 sp+0     u     u     
000000000002f544 sp+32    u     u     
000000000002f55c sp+32    c-16  c-8   
000000000002f560 x29+16   c-16  c-8   
000000000002f5ec sp+0     u     u     
000000000002f5f0 x29+16   c-16  c-8 
```

This change encodes those cases with  `0x80000000` for the `pc_off` as to mark these cases to use the `lr` register

### Related issues
#1408

### Motivation and context
Fix unwinding failures for ARM that happen on top frame

### How has this been tested?
new test added
manual testing on X86 & ARM using dacapo benchmarks 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
