### PR TITLE
Change SmokeTests.cpu test to be more deterministic

### DIFF
--- a/test/test/smoke/Cpu.java
+++ b/test/test/smoke/Cpu.java
@@ -6,25 +6,32 @@
 package test.smoke;
 
 import java.io.File;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class Cpu {
     private static volatile int value;
 
     private static void method1() {
-        for (int i = 0; i < 1000000; i++) {
-            value++;
+        long startTime = System.currentTimeMillis();
+        while (System.currentTimeMillis() - startTime < 20) {
+            for (int i = 0; i < 1000000; i++) {
+                value += ThreadLocalRandom.current().nextInt();
+            }
         }
     }
 
     private static void method2() {
-        for (int i = 0; i < 1000000; i++) {
-            value++;
+        long startTime = System.currentTimeMillis();
+        while (System.currentTimeMillis() - startTime < 20) {
+            for (int i = 0; i < 1000000; i++) {
+                value += ThreadLocalRandom.current().nextInt();
+            }
         }
     }
 
-    private static void method3() throws Exception {
+    private static void method3() {
         long startTime = System.currentTimeMillis();
-        while (System.currentTimeMillis() - startTime < 10) {
+        while (System.currentTimeMillis() - startTime < 20) {
             for (String s : new File("/").list()) {
                 value += s.hashCode();
             }


### PR DESCRIPTION
### Description
In old implementation of the test both method1 & method2 could end up taking different time depending on various factors (Faster CPU cores is one example)

It's possible that under bad circumstances that method1/2 timing could coordinate with method3 leading to one of the method1/2 not being sampled 

This change guarantees a sample is collected in each method by running each method for at least 20ms at each cycle which is higher than the default sampling interval 

### Related issues
N/A

### Motivation and context
Make tests less likely to fail

### How has this been tested?
manual testing & test was re-run 100 times on GHA

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
