### PR TITLE
Reduce resonance between methods in CPU smoke test

### DIFF
--- a/test/test/smoke/Cpu.java
+++ b/test/test/smoke/Cpu.java
@@ -11,13 +11,13 @@ public class Cpu {
     private static volatile int value;
 
     private static void method1() {
-        for (int i = 0; i < 1000000; i++) {
+        for (int i = 0; i < 314159; i++) {
             value++;
         }
     }
 
     private static void method2() {
-        for (int i = 0; i < 1000000; i++) {
+        for (int i = 0; i < 271828; i++) {
             value++;
         }
     }


### PR DESCRIPTION
### Description
It was observed that it's possible for either method1 or method2 not to be sampled in certain runs
When checking the logs it was noticed that the sample distribution was 50% on method3 & the other 50% either method1 or method2.

This change makes the loop counter for each method unique to avoid possible synchronization between them & method3

### Related issues
N/A

### Motivation and context
reduce the possibility of coordination of timing between the methods

### How has this been tested?
Test was re-run 100s of times on various systems including ones where the failure was observed 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
