### PR TITLE
Reduce assert threshold for `GetProcessIds_returns_valid_pids` test

### DIFF
--- a/test/native/processInfoTest.cpp
+++ b/test/native/processInfoTest.cpp
@@ -36,7 +36,7 @@ TEST_CASE(GetProcessIds_returns_valid_pids) {
     int pids[100];
     int count = OS::getProcessIds(pids, 100);
     ASSERT_GT(count, 0);
-    ASSERT_GT(count, 5);
+    ASSERT_GT(count, 1);
     ASSERT_LTE(count, 100);
 
     for (int i = 0; i < count; i++) {


### PR DESCRIPTION
### Description
`GetProcessIds_returns_valid_pids` fails when number of process discovered are less than 5. In this change, I am relaxing the threshold to 1.

### Related issues
N/A

### Motivation and context
N/A

### How has this been tested?
Tested before and after running the same steps manually from docker initialization [here](https://github.com/async-profiler/async-profiler/blob/master/docker/amazonlinux2023.Dockerfile)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
