### PR TITLE
Vtable

### DIFF
--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -324,6 +324,7 @@ Error Arguments::parse(const char* args) {
             CASE("features")
                 if (value != NULL) {
                     if (strstr(value, "stats"))    _features.stats = 1;
+                    if (strstr(value, "jnienv"))   _features.jnienv = 1;
                     if (strstr(value, "probesp"))  _features.probe_sp = 1;
                     if (strstr(value, "vtable"))   _features.vtable_target = 1;
                     if (strstr(value, "comptask")) _features.comp_task = 1;

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -106,14 +106,15 @@ struct StackWalkFeatures {
     unsigned short stats         : 1;
 
     // Additional HotSpot-specific features
+    unsigned short jnienv        : 1;
     unsigned short probe_sp      : 1;
     unsigned short vtable_target : 1;
     unsigned short comp_task     : 1;
     unsigned short pc_addr       : 1;
-    unsigned short _reserved     : 5;
+    unsigned short _reserved     : 4;
 
     StackWalkFeatures() : unknown_java(1), unwind_stub(1), unwind_comp(1), unwind_native(1), java_anchor(1), gc_traces(1),
-                          stats(0), probe_sp(0), vtable_target(0), comp_task(0), pc_addr(0), _reserved(0) {
+                          stats(0), jnienv(0), probe_sp(0), vtable_target(0), comp_task(0), pc_addr(0), _reserved(0) {
     }
 };
 

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -539,7 +539,7 @@ class Recording {
     }
 
     static const char* getFeaturesString(char* str, size_t size, StackWalkFeatures& f) {
-        snprintf(str, size, "%s %s %s %s %s %s %s %s %s %s %s",
+        snprintf(str, size, "%s %s %s %s %s %s %s %s %s %s %s %s",
                  f.unknown_java  ? "unknown_java"  : "-",
                  f.unwind_stub   ? "unwind_stub"   : "-",
                  f.unwind_comp   ? "unwind_comp"   : "-",
@@ -547,6 +547,7 @@ class Recording {
                  f.java_anchor   ? "java_anchor"   : "-",
                  f.gc_traces     ? "gc_traces"     : "-",
                  f.stats         ? "stats"         : "-",
+                 f.jnienv        ? "jnienv"        : "-",
                  f.probe_sp      ? "probesp"       : "-",
                  f.vtable_target ? "vtable"        : "-",
                  f.comp_task     ? "comptask"      : "-",

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <algorithm>
+#include <assert.h>
 #include <dlfcn.h>
 #include <unistd.h>
 #include <stdint.h>

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -389,7 +389,7 @@ int Profiler::getJavaTraceAsync(void* ucontext, ASGCT_CallFrame* frames, int max
         return 0;
     }
 
-    JNIEnv* jni = VM::jni();
+    JNIEnv* jni = vm_thread->jni();
     if (jni == NULL) {
         // Not a Java thread
         return 0;

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -390,6 +390,11 @@ int Profiler::getJavaTraceAsync(void* ucontext, ASGCT_CallFrame* frames, int max
     }
 
     JNIEnv* jni = vm_thread->jni();
+    if (_features.jnienv) {
+        // jnienv feature is only used in tests to validate JNIEnv discovery through VMStructs.
+        // Normally, we avoid calling VM::jni() inside a signal handler as it may deadlock.
+        assert(jni == VM::jni());
+    }
     if (jni == NULL) {
         // Not a Java thread
         return 0;

--- a/src/vmStructs.cpp
+++ b/src/vmStructs.cpp
@@ -112,6 +112,7 @@ jfieldID VMStructs::_eetop;
 jfieldID VMStructs::_tid;
 jfieldID VMStructs::_klass = NULL;
 int VMStructs::_tls_index = -1;
+void* VMStructs::_java_thread_vtbl[6];
 
 VMStructs::LockFunc VMStructs::_lock_func;
 VMStructs::LockFunc VMStructs::_unlock_func;
@@ -626,6 +627,7 @@ void VMStructs::initThreadBridge() {
         if (vm_thread != NULL) {
             _has_native_thread_id = _thread_osthread_offset >= 0 && _osthread_id_offset >= 0;
             initTLS(vm_thread);
+            memcpy(_java_thread_vtbl, vm_thread->vtable(), sizeof(_java_thread_vtbl));
         }
     }
 }

--- a/src/vmStructs.h
+++ b/src/vmStructs.h
@@ -118,6 +118,7 @@ class VMStructs {
     static jfieldID _tid;
     static jfieldID _klass;
     static int _tls_index;
+    static intptr_t _env_offset;
     static void* _java_thread_vtbl[6];
 
     typedef void (*LockFunc)(void*);
@@ -352,6 +353,8 @@ class VMThread : VMStructs {
     static int nativeThreadId(JNIEnv* jni, jthread thread);
 
     int osThreadId();
+
+    JNIEnv* jni();
 
     const void** vtable() {
         return *(const void***)this;

--- a/src/vmStructs.h
+++ b/src/vmStructs.h
@@ -360,10 +360,9 @@ class VMThread : VMStructs {
         return *(const void***)this;
     }
 
-    // Carefully chosen heuristics: we consider this thread a JavaThread
-    // if at least 2 of the selected 3 vtable entries match those of a known
-    // JavaThread (which is either application thread or AttachListener).
-    // Verified on OpenJDK 8 to 25: product, fastdebug and slowdebug builds.
+    // This thread is considered a JavaThread if at least 2 of the selected 3 vtable entries
+    // match those of a known JavaThread (which is either application thread or AttachListener).
+    // Indexes were carefully chosen to work on OpenJDK 8 to 25, both product an debug builds.
     bool isJavaThread() {
         const void** vtbl = vtable();
         return (vtbl[1] == _java_thread_vtbl[1]) +

--- a/test/test/vmstructs/VmstructsTests.java
+++ b/test/test/vmstructs/VmstructsTests.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package test.vmstructs;
+
+import one.profiler.test.Output;
+import one.profiler.test.Test;
+import one.profiler.test.TestProcess;
+import test.smoke.Alloc;
+
+public class VmstructsTests {
+
+    @Test(mainClass = Alloc.class, jvmArgs = "-XX:StartFlightRecording=filename=%f.jfr,settings=profile")
+    public void jnienv(TestProcess p) throws Exception {
+        Output out = p.profile("-d 2 --wall 50ms -F jnienv -o collapsed");
+        assert out.contains("Alloc.allocate");
+    }
+
+    @Test(mainClass = Alloc.class, jvmArgs = "-XX:StartFlightRecording=filename=%f.jfr,settings=profile",
+            agentArgs = "start,wall=50ms,features=jnienv")
+    public void jnienvAgent(TestProcess p) throws Exception {
+        Thread.sleep(2000);
+        Output out = p.profile("stop -o collapsed");
+        assert out.contains("Alloc.allocate");
+    }
+}


### PR DESCRIPTION
### Description

Add `VMThread::isJavaThread()` function that is semantically equivalent to HotSpot's `Thread::is_Java_thread()`.

Implement `VMThread::jni()` without calling JNI GetEnv function which is [unsafe](https://github.com/async-profiler/async-profiler/issues/1162) insde a signal handler.

### Related issues

#1162, #1329

### Motivation and context

Differentiating between Java and non-Java threads is necessary to safely access JavaThread's fields through VMStructs. In particular, this is needed by VMStructs-based stack walker to discover the topmost Java frame using [`JavaThread::_anchor`](https://github.com/async-profiler/async-profiler/pull/1329/files#r2191214920).

Another use case is a cheap and signal-safe way to get `JNIEnv*` for the current thread. Previously used JNI GetEnv function could deadlock when called inside a signal hander.

### How has this been tested?

Proposed implementation uses heuristics which was verified on different JDK versions (from 8 to 25): release, fastdebug and slowdebug builds. However, this heuristics may break if new virtual methods are inserted in `Thread` class in future JDK versions. In order to detect such cases early, I introduced new developer-only option `jnienv` that validates proposed heuristics against reference implementation in HotSpot. Added new integration tests that make use of this option.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
