### PR TITLE
disable wall-test for macOS

### DIFF
--- a/test/test/wall/WallTests.java
+++ b/test/test/wall/WallTests.java
@@ -5,6 +5,7 @@
 
 package test.wall;
 
+import one.profiler.test.Os;
 import one.profiler.test.Output;
 import one.profiler.test.Assert;
 import one.profiler.test.Test;
@@ -12,7 +13,7 @@ import one.profiler.test.TestProcess;
 
 public class WallTests {
 
-    @Test(mainClass = SocketTest.class)
+    @Test(mainClass = SocketTest.class, os = Os.LINUX)
     public void cpuWall(TestProcess p) throws Exception {
         Output out = p.profile("-e cpu -d 3 -o collapsed");
         Assert.isGreater(out.ratio("test/wall/SocketTest.main"), 0.25);


### PR DESCRIPTION
### Description
As discussed internally wall test is currently not stable on macOS GHA runners
One of the contributing reasons is that sleep functions aren't per say stable on macOS GHA runners which the wall engine depend on to have accurate profiling results

For now we will disable the test to prevent random failures on the pipeline
& in the background we will try to find a way to re-enable the test for macOS

### Related issues
#1332 

### Motivation and context
reduce noise of random failures on GHA runners

### How has this been tested?
N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
