### PR TITLE
Fix integration test dependencies to build and cosmetic changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,8 @@ on:
         description: "Container image to use"
 
 env:
-  java_default_distribution: corretto
-  java_default_version: 11
+  build_java_distribution: corretto
+  build_java_version: 11
 
 jobs:
   build:
@@ -33,8 +33,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          distribution: ${{ env.java_default_distribution }}
-          java-version: ${{ env.java_default_version }}
+          distribution: ${{ env.build_java_distribution }}
+          java-version: ${{ env.build_java_version }}
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Build and unit test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,15 +6,12 @@ on:
       platform:
         type: string
         required: true
-        description: "Platform identifier (linux-x64, linux-arm64, macos)"
       runner:
         type: string
         required: true
-        description: "GitHub runner to use"
       container-image:
         type: string
         required: false
-        description: "Container image to use"
 
 env:
   build_java_distribution: corretto

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,83 @@
+name: build-template
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        type: string
+        required: true
+        description: "Platform identifier (linux-x64, linux-arm64, macos)"
+      runner:
+        type: string
+        required: true
+        description: "GitHub runner to use"
+      container-image:
+        type: string
+        required: false
+        description: "Container image to use"
+
+env:
+  java_default_distribution: corretto
+  java_default_version: 11
+
+jobs:
+  build:
+    runs-on: ${{ inputs.runner }}
+    container:
+      image: ${{ inputs.container-image }}
+    name: "build and unit test (${{ inputs.platform }})"
+    steps:
+      - name: Run container setup
+        if: inputs.container-image != ''
+        run: "[ ! -f /root/setup.sh ] || /root/setup.sh"
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: ${{ env.java_default_distribution }}
+          java-version: ${{ env.java_default_version }}
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Build and unit test
+        id: build
+        run: |
+          set -x
+          HASH=${GITHUB_SHA:0:7}
+          case "${{ inputs.platform }}" in
+            macos*)
+              brew install gcovr
+              make COMMIT_TAG=$HASH FAT_BINARY=true release coverage -j
+            ;;
+            *)
+              make COMMIT_TAG=$HASH CC=/usr/local/musl/bin/musl-gcc release coverage -j
+              echo "debug_archive=$(find . -type f -name "async-profiler-*-debug*" -exec basename {} \;)" >> $GITHUB_OUTPUT
+            ;;
+          esac
+          echo "archive=$(find . -type f -name "async-profiler-*" -not -name "*-debug*" -exec basename {} \;)" >> $GITHUB_OUTPUT
+        shell: bash
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+      - name: Set artifact name
+        id: set_artifact_name
+        run: echo "artifact_name=async-profiler-${{ inputs.platform }}-${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
+        shell: bash
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+      - name: Upload binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.set_artifact_name.outputs.artifact_name }}
+          path: ${{ steps.build.outputs.archive }}
+          if-no-files-found: error
+      - name: Upload debug info
+        uses: actions/upload-artifact@v4
+        if: inputs.platform != 'macos'
+        with:
+          name: ${{ steps.set_artifact_name.outputs.artifact_name }}-debug
+          path: ${{ steps.build.outputs.debug_archive }}
+          if-no-files-found: error
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-coverage-${{ inputs.platform }}
+          path: build/test/coverage/
+          if-no-files-found: error

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -1,0 +1,115 @@
+name: integration-test-template
+
+on:
+  workflow_call:
+    inputs:
+      test-platform:
+        type: string
+        required: true
+        description: "Platform identifier for the test environment"
+      platform:
+        type: string
+        required: true
+        description: "Platform identifier for the binary to test"
+      architecture:
+        type: string
+        required: false
+        description: "Architecture for Java setup"
+      java-version:
+        type: string
+        required: true
+        description: "Java version to test with"
+      java-distribution:
+        type: string
+        required: false
+        default: "corretto"
+        description: "Java distribution to use"
+      runner:
+        type: string
+        required: true
+        description: "GitHub runner to use"
+      container-image:
+        type: string
+        required: false
+        description: "Container image to use"
+      container-volumes:
+        type: string
+        required: false
+        description: "Container volumes JSON array"
+
+jobs:
+  integration-test:
+    runs-on: ${{ inputs.runner }}
+    container:
+      image: ${{ inputs.container-image }}
+      options: --privileged
+      volumes: ${{ fromJSON(inputs.container-volumes || '[]') }}
+    name: "${{ inputs.test-platform }}, ${{ inputs.java-distribution }} ${{ inputs.java-version }}"
+    steps:
+      - name: Run container setup
+        if: inputs.container-image != ''
+        run: "[ ! -f /root/setup.sh ] || /root/setup.sh"
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        if: ${{ !contains(inputs.test-platform, 'alpine') }}
+        with:
+          distribution: ${{ inputs.java-distribution }}
+          java-version: ${{ inputs.java-version }}
+          architecture: ${{ inputs.architecture }}
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Set variables
+        id: set_variables
+        run: |
+          echo "short_sha=${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
+          echo "artifact_name=async-profiler-${{ inputs.platform }}-${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
+        shell: bash
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+      - name: Download async-profiler release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.set_variables.outputs.artifact_name }}
+          path: async_profiler_release
+      - name: Download async-profiler JAR artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: async-profiler-jars
+          path: jar_artifacts
+      - name: Extract async-profiler artifact
+        id: extract_artifact
+        run: |
+          release_archive=$(basename $(find async_profiler_release -type f -iname "async-profiler-*" ))
+          case "${{ inputs.runner }}" in
+            macos*)
+              unzip async_profiler_release/$release_archive
+            ;;
+            *)
+              tar xvf async_profiler_release/$release_archive
+            ;;
+          esac
+          echo "jars_directory=jar_artifacts" >> $GITHUB_OUTPUT
+          echo "release_directory=$(basename $(find . -type d -iname "async-profiler-*" ))" >> $GITHUB_OUTPUT
+      - name: Download Protobuf Java runtime
+        run: |
+          mkdir -p test/deps
+          cd test/deps
+          curl -L -O "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/$PB_JAVA_VERSION/protobuf-java-$PB_JAVA_VERSION.jar"
+        env:
+          PB_JAVA_VERSION: "4.31.1"
+      - name: Run integration tests
+        run: |
+          mkdir -p build/jar
+          cp ${{ steps.extract_artifact.outputs.jars_directory }}/* build/jar
+          make build/test.jar
+          cp -r ${{ steps.extract_artifact.outputs.release_directory }}/bin build
+          cp -r ${{ steps.extract_artifact.outputs.release_directory }}/lib build
+          make test-java -j
+      - name: Upload integration test logs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: integration-test-logs-${{ inputs.test-platform }}-${{ inputs.java-version }}-${{ steps.set_variables.outputs.short_sha }}
+          path: |
+            build/test/logs/
+            hs_err*.log

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -51,6 +51,7 @@ jobs:
         run: "[ ! -f /root/setup.sh ] || /root/setup.sh"
       - name: Setup Java
         uses: actions/setup-java@v4
+        # https://github.com/actions/setup-java/issues/678#issuecomment-2446279753
         if: ${{ !contains(inputs.test-platform, 'alpine') }}
         with:
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -6,36 +6,28 @@ on:
       test-platform:
         type: string
         required: true
-        description: "Platform identifier for the test environment"
       platform:
         type: string
         required: true
-        description: "Platform identifier for the binary to test"
       architecture:
         type: string
         required: false
-        description: "Architecture for Java setup"
       java-version:
         type: string
         required: true
-        description: "Java version to test with"
       java-distribution:
         type: string
         required: false
         default: "corretto"
-        description: "Java distribution to use"
       runner:
         type: string
         required: true
-        description: "GitHub runner to use"
       container-image:
         type: string
         required: false
-        description: "Container image to use"
       container-volumes:
         type: string
         required: false
-        description: "Container volumes JSON array"
 
 jobs:
   integration-test:

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build-jars:
     runs-on: ubuntu-latest
-    name: Build JARs
+    name: build / jars
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -27,231 +27,107 @@ jobs:
           name: async-profiler-jars
           path: build/jar/*
           if-no-files-found: error
-  build-and-upload-binaries:
-    strategy:
-      matrix:
-        include:
-          - runson:
-              display: linux-arm64
-              name: ubuntu-24.04-arm
-            image: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"
-          - runson:
-              display: linux-x64
-              name: ubuntu-latest
-            image: public.ecr.aws/async-profiler/asprof-builder-x86:latest
-          - runson:
-              display: macos
-              name: macos-15
-    runs-on: ${{ matrix.runson.name }}
-    container:
-      image: ${{ matrix.image }}
-      volumes: ${{ fromJSON(matrix.volumes || '[]') }}
-    name: "Build and unit test (${{ matrix.runson.display }})"
-    steps:
-      - name: Run container setup
-        run: "[ ! -f /root/setup.sh ] || /root/setup.sh"
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: ${{ matrix.java-distribution || env.java_default_distribution }}
-          java-version: ${{ matrix.java-version || env.java_default_version }}
-      - name: Checkout sources
-        uses: actions/checkout@v4
-      - name: Build and unit test
-        id: build
-        run: |
-          set -x
-          HASH=${GITHUB_SHA:0:7}
-          case "${{ matrix.runson.display }}" in
-            macos*)
-              brew install gcovr
-              make COMMIT_TAG=$HASH FAT_BINARY=true release coverage -j
-            ;;
-            *)
-              make COMMIT_TAG=$HASH CC=/usr/local/musl/bin/musl-gcc release coverage -j
-              echo "debug_archive=$(find . -type f -name "async-profiler-*-debug*" -exec basename {} \;)" >> $GITHUB_OUTPUT
-            ;;
-          esac
-          echo "archive=$(find . -type f -name "async-profiler-*" -not -name "*-debug*" -exec basename {} \;)" >> $GITHUB_OUTPUT
-        shell: bash
-        env:
-          GITHUB_SHA: ${{ github.sha }}
-      - name: Set artifact name
-        id: set_artifact_name
-        run: echo "artifact_name=async-profiler-${{ matrix.runson.display }}-${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
-        shell: bash
-        env:
-          GITHUB_SHA: ${{ github.sha }}
-      - name: Upload binaries
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.set_artifact_name.outputs.artifact_name }}
-          path: ${{ steps.build.outputs.archive }}
-          if-no-files-found: error
-      - name: Upload debug info
-        uses: actions/upload-artifact@v4
-        if: matrix.runson.display != 'macos'
-        with:
-          name: ${{ steps.set_artifact_name.outputs.artifact_name }}-debug
-          path: ${{ steps.build.outputs.debug_archive }}
-          if-no-files-found: error
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-coverage-${{ matrix.runson.display }}
-          path: build/test/coverage/
-          if-no-files-found: error
-  integration-tests:
-    needs: build-and-upload-binaries
+  build-linux-arm64:
+    name: build / linux-arm64
+    uses: ./.github/workflows/build.yml
+    with:
+      platform: linux-arm64
+      runner: ubuntu-24.04-arm
+      container-image: "public.ecr.aws/async-profiler/asprof-builder-arm:latest"
+
+  build-linux-x64:
+    name: build / linux-x64
+    uses: ./.github/workflows/build.yml
+    with:
+      platform: linux-x64
+      runner: ubuntu-latest
+      container-image: public.ecr.aws/async-profiler/asprof-builder-x86:latest
+
+  build-macos:
+    name: build / macos
+    uses: ./.github/workflows/build.yml
+    with:
+      platform: macos
+      runner: macos-15
+  integ-linux-x64:
+    name: integration test / linux-x64
+    needs: [build-jars, build-linux-x64]
     strategy:
       fail-fast: false
       matrix:
-        runson:
-          - display: linux-x64
-            # Using "latest" here as the build and test will any ways run inside a container which we control
-            name: ubuntu-latest
         java-version: [8, 11, 17, 21, 24]
-        java-distribution: [corretto]
-        image: ["public.ecr.aws/async-profiler/asprof-builder-x86:latest"]
+    uses: ./.github/workflows/integ.yml
+    with:
+      platform: linux-x64
+      test-platform: linux-x64
+      runner: ubuntu-latest
+      container-image: public.ecr.aws/async-profiler/asprof-builder-x86:latest
+      java-version: ${{ matrix.java-version }}
+
+  integ-linux-arm64:
+    name: integration test / linux-arm64
+    needs: [build-jars, build-linux-arm64]
+    uses: ./.github/workflows/integ.yml
+    with:
+      platform: linux-arm64
+      test-platform: linux-arm64
+      runner: ubuntu-24.04-arm
+      container-image: public.ecr.aws/async-profiler/asprof-builder-arm:latest
+      java-version: "11"
+
+  integ-macos:
+    name: integration test / macos
+    needs: [build-jars, build-macos]
+    strategy:
+      fail-fast: false
+      matrix:
         include:
-          - runson:
-              display: macos-arm64
-              name: macos-15
-            java-version: 11
-            java-distribution: corretto
-            # Not using container for mac-os as we have images only for linux
-            image: ""
-            # ARM MacOS should take fat binaries built on ARM
-            asprof-binaries-job: macos
-          - runson:
-              display: macos-arm64
-              name: macos-15
-            java-version: 21
-            java-distribution: corretto
-            # Not using container for mac-os as we have images only for linux
-            image: ""
-            # ARM MacOS should take fat binaries built on ARM
-            asprof-binaries-job: macos
-          - runson:
-              display: macos-x64
-              name: macos-13
-            java-version: 17
-            java-distribution: corretto
+          - runner: macos-15
+            test-platform: macos-arm64
+            java-version: "11"
+          - runner: macos-15
+            test-platform: macos-arm64
+            java-version: "21"
+          - runner: macos-13
+            test-platform: macos-x64
+            java-version: "17"
             architecture: x64
-            image: ""
-            # x64 MacOS should take fat binaries built on ARM
-            asprof-binaries-job: macos
-          - runson:
-              display: linux-arm64
-              # There is no "latest" tag available (yet) as ARM runners are still in public preview
-              name: ubuntu-24.04-arm
-            java-version: 11
-            java-distribution: corretto
-            image: public.ecr.aws/async-profiler/asprof-builder-arm:latest
-          - runson:
-              display: alpine
-              name: ubuntu-latest
-            java-version: 11
-            java-distribution: corretto
-            asprof-binaries-job: linux-x64
-            image: public.ecr.aws/async-profiler/asprof-builder-alpine:corretto-11
-          - runson:
-              display: amazonlinux2
-              name: ubuntu-latest
-            java-version: 11
-            java-distribution: corretto
-            image: public.ecr.aws/async-profiler/asprof-builder-amazonlinux:2
-            # GHA provides Node.js by attaching a volume to the container. The container path is
-            # '/__e/node20', and it's not writable unless we override it via 'container.volumes'.
-            volumes: '["/tmp/node20:/__e/node20"]'
-            asprof-binaries-job: linux-x64
-          - runson:
-              display: amazonlinux2023
-              name: ubuntu-latest
-            java-version: 11
-            java-distribution: corretto
-            image: public.ecr.aws/async-profiler/asprof-builder-amazonlinux:2023
-            asprof-binaries-job: linux-x64
-    runs-on: ${{ matrix.runson.name }}
-    container:
-      image: ${{ matrix.image }}
-      options: --privileged
-      volumes: ${{ fromJSON(matrix.volumes || '[]') }}
-    name: "Integration test (${{ matrix.runson.display }}, ${{ matrix.java-distribution }} ${{ matrix.java-version }})"
-    steps:
-      - name: Run container setup
-        run: "[ ! -f /root/setup.sh ] || /root/setup.sh"
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        # https://github.com/actions/setup-java/issues/678#issuecomment-2446279753
-        if: matrix.runson.display != 'alpine'
-        with:
-          distribution: ${{ matrix.java-distribution }}
-          java-version: ${{ matrix.java-version }}
-          architecture: ${{ matrix.architecture }}
-      - name: Checkout sources
-        uses: actions/checkout@v4
-      - name: Set variables
-        id: set_variables
-        run: |
-          echo "short_sha=${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
-          echo "artifact_name=async-profiler-${{ matrix.asprof-binaries-job || matrix.runson.display }}-${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
-        shell: bash
-        env:
-          GITHUB_SHA: ${{ github.sha }}
-      - name: Download async-profiler release artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ steps.set_variables.outputs.artifact_name }}
-          path: async_profiler_release
-      - name: Download async-profiler JAR artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: async-profiler-jars
-          path: jar_artifacts
-      - name: Extract async-profiler artifact
-        id: extract_artifact
-        run: |
-          release_archive=$(basename $(find async_profiler_release -type f -iname "async-profiler-*" ))
-          case "${{ matrix.runson.name }}" in
-            macos*)
-              unzip async_profiler_release/$release_archive
-            ;;
-            *)
-              tar xvf async_profiler_release/$release_archive
-            ;;
-          esac
-          echo "jars_directory=jar_artifacts" >> $GITHUB_OUTPUT
-          echo "release_directory=$(basename $(find . -type d -iname "async-profiler-*" ))" >> $GITHUB_OUTPUT
-      - name: Download Protobuf Java runtime
-        run: |
-          mkdir -p test/deps
-          cd test/deps
-          curl -L -O "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/$PB_JAVA_VERSION/protobuf-java-$PB_JAVA_VERSION.jar"
-        env:
-          PB_JAVA_VERSION: "4.31.1"
-      - name: Run integration tests
-        run: |
-          mkdir -p build/jar
-          cp ${{ steps.extract_artifact.outputs.jars_directory }}/* build/jar
-          make build/test.jar
-          cp -r ${{ steps.extract_artifact.outputs.release_directory }}/bin build
-          cp -r ${{ steps.extract_artifact.outputs.release_directory }}/lib build
-          make test-java -j
-      - name: Upload integration test logs
-        uses: actions/upload-artifact@v4
-        # Always upload, especially after test failure
-        if: always()
-        with:
-          name: integration-test-logs-${{ matrix.runson.display }}-${{ matrix.java-version }}-${{ steps.set_variables.outputs.short_sha }}
-          path: |
-            build/test/logs/
-            hs_err*.log
+    uses: ./.github/workflows/integ.yml
+    with:
+      platform: macos
+      test-platform: ${{ matrix.test-platform }}
+      runner: ${{ matrix.runner }}
+      java-version: ${{ matrix.java-version }}
+      architecture: ${{ matrix.architecture || '' }}
+
+  integ-containers:
+    name: integration test / linux-x64
+    needs: [build-jars, build-linux-x64]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - test-platform: linux-x64-alpine
+            container-image: public.ecr.aws/async-profiler/asprof-builder-alpine:corretto-11
+          - test-platform: linux-x64-AL2
+            container-image: public.ecr.aws/async-profiler/asprof-builder-amazonlinux:2
+            container-volumes: '["/tmp/node20:/__e/node20"]'
+          - test-platform: linux-x64-AL2023
+            container-image: public.ecr.aws/async-profiler/asprof-builder-amazonlinux:2023
+    uses: ./.github/workflows/integ.yml
+    with:
+      platform: linux-x64
+      test-platform: ${{ matrix.test-platform }}
+      runner: ubuntu-latest
+      container-image: ${{ matrix.container-image }}
+      container-volumes: ${{ matrix.container-volumes || '' }}
+      java-version: "11"
+
   publish-only-on-push:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     name: publish (nightly)
     runs-on: ubuntu-latest
-    needs: [build-jars, integration-tests]
+    needs: [integ-linux-x64, integ-linux-arm64, integ-macos, integ-containers]
     steps:
       - name: Download async-profiler binaries and jars
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -27,6 +27,7 @@ jobs:
           name: async-profiler-jars
           path: build/jar/*
           if-no-files-found: error
+
   build-linux-arm64:
     name: build / linux-arm64
     uses: ./.github/workflows/build.yml
@@ -49,24 +50,38 @@ jobs:
     with:
       platform: macos
       runner: macos-15
+
   integ-linux-x64:
     name: integration test / linux-x64
-    needs: [build-jars, build-linux-x64]
+    needs: build-linux-x64
     strategy:
       fail-fast: false
       matrix:
+        test-platform: [linux-x64]
+        container-image: [public.ecr.aws/async-profiler/asprof-builder-x86:latest]
         java-version: [8, 11, 17, 21, 24]
+        include:
+          - test-platform: linux-x64-alpine
+            container-image: public.ecr.aws/async-profiler/asprof-builder-alpine:corretto-11
+          - test-platform: linux-x64-AL2
+            container-image: public.ecr.aws/async-profiler/asprof-builder-amazonlinux:2
+            # GHA provides Node.js by attaching a volume to the container. The container path is
+            # '/__e/node20', and it's not writable unless we override it via 'container.volumes'.
+            container-volumes: '["/tmp/node20:/__e/node20"]'
+          - test-platform: linux-x64-AL2023
+            container-image: public.ecr.aws/async-profiler/asprof-builder-amazonlinux:2023
     uses: ./.github/workflows/integ.yml
     with:
       platform: linux-x64
-      test-platform: linux-x64
+      test-platform: ${{ matrix.test-platform }}
       runner: ubuntu-latest
-      container-image: public.ecr.aws/async-profiler/asprof-builder-x86:latest
+      container-image: ${{ matrix.container-image }}
+      container-volumes: ${{ matrix.container-volumes || '' }}
       java-version: ${{ matrix.java-version }}
 
   integ-linux-arm64:
     name: integration test / linux-arm64
-    needs: [build-jars, build-linux-arm64]
+    needs: build-linux-arm64
     uses: ./.github/workflows/integ.yml
     with:
       platform: linux-arm64
@@ -77,7 +92,7 @@ jobs:
 
   integ-macos:
     name: integration test / macos
-    needs: [build-jars, build-macos]
+    needs: build-macos
     strategy:
       fail-fast: false
       matrix:
@@ -100,34 +115,11 @@ jobs:
       java-version: ${{ matrix.java-version }}
       architecture: ${{ matrix.architecture || '' }}
 
-  integ-containers:
-    name: integration test / linux-x64
-    needs: [build-jars, build-linux-x64]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - test-platform: linux-x64-alpine
-            container-image: public.ecr.aws/async-profiler/asprof-builder-alpine:corretto-11
-          - test-platform: linux-x64-AL2
-            container-image: public.ecr.aws/async-profiler/asprof-builder-amazonlinux:2
-            container-volumes: '["/tmp/node20:/__e/node20"]'
-          - test-platform: linux-x64-AL2023
-            container-image: public.ecr.aws/async-profiler/asprof-builder-amazonlinux:2023
-    uses: ./.github/workflows/integ.yml
-    with:
-      platform: linux-x64
-      test-platform: ${{ matrix.test-platform }}
-      runner: ubuntu-latest
-      container-image: ${{ matrix.container-image }}
-      container-volumes: ${{ matrix.container-volumes || '' }}
-      java-version: "11"
-
   publish-only-on-push:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     name: publish (nightly)
     runs-on: ubuntu-latest
-    needs: [integ-linux-x64, integ-linux-arm64, integ-macos, integ-containers]
+    needs: [build-jars, integ-linux-x64, integ-linux-arm64, integ-macos]
     steps:
       - name: Download async-profiler binaries and jars
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -8,10 +8,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  java_default_distribution: corretto
-  java_default_version: 11
-
 jobs:
   build-jars:
     runs-on: ubuntu-latest
@@ -60,6 +56,7 @@ jobs:
         test-platform: [linux-x64]
         container-image: [public.ecr.aws/async-profiler/asprof-builder-x86:latest]
         java-version: [8, 11, 17, 21, 24]
+        java-distribution: [corretto]
         include:
           - test-platform: linux-x64-alpine
             container-image: public.ecr.aws/async-profiler/asprof-builder-alpine:corretto-11
@@ -68,8 +65,12 @@ jobs:
             # GHA provides Node.js by attaching a volume to the container. The container path is
             # '/__e/node20', and it's not writable unless we override it via 'container.volumes'.
             container-volumes: '["/tmp/node20:/__e/node20"]'
+            java-version: 11
+            java-distribution: corretto
           - test-platform: linux-x64-AL2023
             container-image: public.ecr.aws/async-profiler/asprof-builder-amazonlinux:2023
+            java-version: 11
+            java-distribution: corretto
     uses: ./.github/workflows/integ.yml
     with:
       platform: linux-x64
@@ -78,6 +79,7 @@ jobs:
       container-image: ${{ matrix.container-image }}
       container-volumes: ${{ matrix.container-volumes || '' }}
       java-version: ${{ matrix.java-version }}
+      java-distribution: ${{ matrix.java-distribution }}
 
   integ-linux-arm64:
     name: integration test / linux-arm64


### PR DESCRIPTION
Before this PR, all integration tests depended on all builds, causing e.g. linux-x64 integration tests to wait for macos build.


This is now fixed with some cosmetic changes to make the UI look like attached:

<img width="1292" height="686" alt="image" src="https://github.com/user-attachments/assets/8d517b08-8009-4676-839b-8657708b2d6c" />

### Previous look and structure

<img width="1292" height="686" alt="image" src="https://github.com/user-attachments/assets/1febde30-623e-4ec3-9c5b-c45506c5420d" />


### Motivation and context
Integration tests should not wait for builds on unrelated OS/archs.

### How has this been tested?
By the current PR github action.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
