### PR TITLE
Fix the pixel jump on hovering the flamegraph, on Firefox and Chrome

### DIFF
--- a/.assets/html/flamegraph.html
+++ b/.assets/html/flamegraph.html
@@ -215,9 +215,9 @@
 			if (f) {
 				if (f !== root) getSelection().removeAllRanges();
 				const border = 1;
-				hl.style.left = (Math.max(f.left - root.left, 0) * px + canvas.offsetLeft) + "px";
-				hl.style.top = ((inverted ? h * 16 - border + jankOffset : canvasHeight - (h + 1) * 16 - border + jankOffset) + canvas.offsetTop) + "px";
+				hl.style.left = (Math.max(f.left - root.left, 0) * px + canvas.offsetLeft) + 'px';
 				hl.style.width = (Math.min(f.width, root.width) * px) + 'px';
+				hl.style.top = ((inverted ? h * 16 - border + jankOffset : canvasHeight - (h + 1) * 16 - border + jankOffset) + canvas.offsetTop) + 'px';
 				hl.firstChild.textContent = f.title;
 				hl.style.display = 'block';
 				canvas.title = f.title + '\n(' + samples(f.width) + f.details + ', ' + pct(f.width, levels[0][0].width) + '%)';

--- a/.assets/html/flamegraph.html
+++ b/.assets/html/flamegraph.html
@@ -9,8 +9,8 @@
 	button {font: 12px sans-serif; cursor: pointer}
 	p {position: fixed; bottom: 0; margin: 0; padding: 2px 3px 2px 3px; outline: 1px solid #ffc000; display: none; overflow: hidden; white-space: nowrap; background-color: #ffffe0}
 	a {color: #0366d6}
-	#hl {position: absolute; display: none; overflow: hidden; white-space: nowrap; pointer-events: none; background-color: #ffffe0; outline: 1px solid #ffc000; height: 15px}
-	#hl span {padding: 0 3px 0 3px}
+	#hl {position: absolute; display: none; overflow: hidden; white-space: nowrap; pointer-events: none; background-color: #ffffe0; border: 1px solid #ffc000; box-sizing: border-box; height: 17px; line-height: 14px;}
+	#hl span {padding: 0 3px 0 2px}
 	#status {left: 0}
 	#match {right: 0}
 	#reset {cursor: pointer}
@@ -207,15 +207,17 @@
 		}
 	}
 
+	const jankOffset = navigator.userAgentData?.brands.filter((elem)=> elem.brand === 'Google Chrome')?.length > 0 ? 1 : 0;
 	canvas.onmousemove = function() {
 		const h = Math.floor((inverted ? event.offsetY : (canvasHeight - event.offsetY)) / 16);
 		if (h >= 0 && h < levels.length) {
 			const f = findFrame(levels[h], event.offsetX / px + root.left);
 			if (f) {
 				if (f !== root) getSelection().removeAllRanges();
-				hl.style.left = (Math.max(f.left - root.left, 0) * px + canvas.offsetLeft) + 'px';
+				const border = 1;
+				hl.style.left = (Math.max(f.left - root.left, 0) * px + canvas.offsetLeft) + "px";
+				hl.style.top = ((inverted ? h * 16 - border + jankOffset : canvasHeight - (h + 1) * 16 - border + jankOffset) + canvas.offsetTop) + "px";
 				hl.style.width = (Math.min(f.width, root.width) * px) + 'px';
-				hl.style.top = ((inverted ? h * 16 : canvasHeight - (h + 1) * 16) + canvas.offsetTop) + 'px';
 				hl.firstChild.textContent = f.title;
 				hl.style.display = 'block';
 				canvas.title = f.title + '\n(' + samples(f.width) + f.details + ', ' + pct(f.width, levels[0][0].width) + '%)';

--- a/src/res/flame.html
+++ b/src/res/flame.html
@@ -215,9 +215,9 @@
 			if (f) {
 				if (f !== root) getSelection().removeAllRanges();
 				const border = 1;
-				hl.style.left = (Math.max(f.left - root.left, 0) * px + canvas.offsetLeft) + "px";
-				hl.style.top = ((inverted ? h * 16 - border + jankOffset : canvasHeight - (h + 1) * 16 - border + jankOffset) + canvas.offsetTop) + "px";
+				hl.style.left = (Math.max(f.left - root.left, 0) * px + canvas.offsetLeft) + 'px';
 				hl.style.width = (Math.min(f.width, root.width) * px) + 'px';
+				hl.style.top = ((inverted ? h * 16 - border + jankOffset : canvasHeight - (h + 1) * 16 - border + jankOffset) + canvas.offsetTop) + 'px';
 				hl.firstChild.textContent = f.title;
 				hl.style.display = 'block';
 				canvas.title = f.title + '\n(' + samples(f.width) + f.details + ', ' + pct(f.width, levels[0][0].width) + '%)';

--- a/src/res/flame.html
+++ b/src/res/flame.html
@@ -9,8 +9,8 @@
 	button {font: 12px sans-serif; cursor: pointer}
 	p {position: fixed; bottom: 0; margin: 0; padding: 2px 3px 2px 3px; outline: 1px solid #ffc000; display: none; overflow: hidden; white-space: nowrap; background-color: #ffffe0}
 	a {color: #0366d6}
-	#hl {position: absolute; display: none; overflow: hidden; white-space: nowrap; pointer-events: none; background-color: #ffffe0; outline: 1px solid #ffc000; height: 15px}
-	#hl span {padding: 0 3px 0 3px}
+	#hl {position: absolute; display: none; overflow: hidden; white-space: nowrap; pointer-events: none; background-color: #ffffe0; border: 1px solid #ffc000; box-sizing: border-box; height: 17px; line-height: 14px;}
+	#hl span {padding: 0 3px 0 2px}
 	#status {left: 0}
 	#match {right: 0}
 	#reset {cursor: pointer}
@@ -207,15 +207,17 @@
 		}
 	}
 
+	const jankOffset = navigator.userAgentData?.brands.filter((elem)=> elem.brand === 'Google Chrome')?.length > 0 ? 1 : 0;
 	canvas.onmousemove = function() {
 		const h = Math.floor((inverted ? event.offsetY : (canvasHeight - event.offsetY)) / 16);
 		if (h >= 0 && h < levels.length) {
 			const f = findFrame(levels[h], event.offsetX / px + root.left);
 			if (f) {
 				if (f !== root) getSelection().removeAllRanges();
-				hl.style.left = (Math.max(f.left - root.left, 0) * px + canvas.offsetLeft) + 'px';
+				const border = 1;
+				hl.style.left = (Math.max(f.left - root.left, 0) * px + canvas.offsetLeft) + "px";
+				hl.style.top = ((inverted ? h * 16 - border + jankOffset : canvasHeight - (h + 1) * 16 - border + jankOffset) + canvas.offsetTop) + "px";
 				hl.style.width = (Math.min(f.width, root.width) * px) + 'px';
-				hl.style.top = ((inverted ? h * 16 : canvasHeight - (h + 1) * 16) + canvas.offsetTop) + 'px';
 				hl.firstChild.textContent = f.title;
 				hl.style.display = 'block';
 				canvas.title = f.title + '\n(' + samples(f.width) + f.details + ', ' + pct(f.width, levels[0][0].width) + '%)';


### PR DESCRIPTION
### Description
This fixes the one pixel jump on hovering frames in the flamegraph, which was foreshadowed in https://github.com/async-profiler/async-profiler/pull/1140#discussion_r2197332570.

Chrome needed an extra adjustment which is done by the `jankOffset` variable.

First 4 seconds from master, and fixed after that:

https://github.com/user-attachments/assets/150132a7-12ef-4b28-90eb-f8e5a78abb4b

### Motivation and context

When a frame is hovered, text should not be offset, only the highlighting rectangle should be drawn.

### How has this been tested?




Tested in Chrome and Firefox.





---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
