### PR TITLE
Fix failing KernelTests

### DIFF
--- a/test/test/kernel/KernelTests.java
+++ b/test/test/kernel/KernelTests.java
@@ -19,12 +19,12 @@ public class KernelTests {
         Output out = p.profile("-e cpu-clock -d 3 -i 1ms -o collapsed");
         Output err = p.readFile(TestProcess.PROFERR);
         assert out.contains("test/kernel/ListFiles.listFiles;java/io/File");
-        assert err.contains("Kernel symbols are unavailable") || out.contains("sys_getdents");
+        assert err.contains("Kernel symbols are unavailable") || out.contains("(sys|SyS)_getdents");
 
         out = p.profile("stop -o flamegraph");
         out = out.convertFlameToCollapsed();
         assert out.contains("java/io/File.list");
-        assert err.contains("Kernel symbols are unavailable") || out.contains("sys_getdents");
+        assert err.contains("Kernel symbols are unavailable") || out.contains("(sys|SyS)_getdents");
     }
 
     @Test(mainClass = ListFiles.class, os = Os.LINUX)
@@ -32,7 +32,7 @@ public class KernelTests {
         p.profile("-e cpu -d 3 -i 1ms -o collapsed -f %f --fdtransfer", true);
         Output out = p.readFile("%f");
         assert out.contains("test/kernel/ListFiles.listFiles;java/io/File");
-        assert out.contains("sys_getdents");
+        assert out.contains("(sys|SyS)_getdents");
     }
 
     @Test(mainClass = ListFiles.class, os = Os.LINUX)


### PR DESCRIPTION
### Description
It was observed that when running async-profiler tests on some Alpine ARM instances that some of the integration tests can fail being:
* KernelTests.fdtransfer
* KernelTests.kernel

When checking the logs I noticed the following samples 

```
test/kernel/ListFiles.main;test/kernel/ListFiles.listFiles;java/io/File.list;java/io/File.normalizedList;java/io/UnixFileSystem.list;Java_java_io_UnixFileSystem_list;readdir_r;readdir;__sys_trace_return_[k];SyS_getdents64_[k];iterate_dir_[k];touch_atime_[k];__atime_needs_update_[k];current_time_[k];current_kernel_time64_[k] 4
```

The test checks if `sys_getdents` exists, but in this case the function is actually reported as `SyS_getdents`, which causes a failure

Comparing for either should be fine as in some Older Linux kernels we can see

```
#define __SYSCALL_DEFINEx(x, name, ...)					\
	asmlinkage long sys##name(__MAP(x,__SC_DECL,__VA_ARGS__));	\
	static inline long SYSC##name(__MAP(x,__SC_DECL,__VA_ARGS__));	\
	asmlinkage long SyS##name(__MAP(x,__SC_LONG,__VA_ARGS__))	\
	{								\
		long ret = SYSC##name(__MAP(x,__SC_CAST,__VA_ARGS__));	\
		__MAP(x,__SC_TEST,__VA_ARGS__);				\
		__PROTECT(x, ret,__MAP(x,__SC_ARGS,__VA_ARGS__));	\
		return ret;						\
	}								\
	SYSCALL_ALIAS(sys##name, SyS##name);				\
	static inline long SYSC##name(__MAP(x,__SC_DECL,__VA_ARGS__))
```


### Related issues
N/A

### Motivation and context
Fix tests for Alpine

### How has this been tested?
Manual testing

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
