### PR TITLE
Expose dictionary that maps event id to javaThreadId

### DIFF
--- a/src/converter/one/jfr/JfrReader.java
+++ b/src/converter/one/jfr/JfrReader.java
@@ -60,6 +60,7 @@ public class JfrReader implements Closeable {
     public final Dictionary<StackTrace> stackTraces = new Dictionary<>();
     public final Map<String, String> settings = new HashMap<>();
     public final Map<String, Map<Integer, String>> enums = new HashMap<>();
+    public final Dictionary<Long> javaThreads = new Dictionary<>();
 
     private final Dictionary<Constructor<? extends Event>> customEvents = new Dictionary<>();
 
@@ -460,6 +461,7 @@ public class JfrReader implements Closeable {
             long javaThreadId = getVarlong();
             readFields(fieldCount - 4);
             threads.put(id, javaName != null ? javaName : osName);
+            javaThreads.put(id, javaThreadId);
         }
     }
 


### PR DESCRIPTION
### Description
Adds a dictionary `javaThreads` that maps eventIds to javaThreadIds.

### Related issues
#1525 

### Motivation and context
For the [sentry-java sdk](https://github.com/getsentry/sentry-java?rgh-link-date=2025-10-03T13%3A38%3A47.000Z) we recently implemented continuous profiling with async-profiler. We had to vendor in parts of the converter in order to get to the `Java Thread Id` that we need to map between profiles and transactions. This PR exposes that mapping and would allow us to simply use the `jfr-converter` as a dependency. 
Hopefully this will be useful for others too.

### How has this been tested?
We implemented this change in sentry-java sdk and have tested it in that context.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
