### PR TITLE
Prevent fdtransfer connection from not closing in case of start failure

### DIFF
--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1198,7 +1198,7 @@ Error Profiler::start(Arguments& args, bool reset) {
     if (args._fdtransfer) {
         if (!FdTransferClient::connectToServer(args._fdtransfer_path)) {
             error = Error("Failed to initialize FdTransferClient");
-            if (error) goto error1;
+            goto error1;
         }
     }
 

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1197,7 +1197,8 @@ Error Profiler::start(Arguments& args, bool reset) {
 
     if (args._fdtransfer) {
         if (!FdTransferClient::connectToServer(args._fdtransfer_path)) {
-            return Error("Failed to initialize FdTransferClient");
+            error = Error("Failed to initialize FdTransferClient");
+            if (error) goto error1;
         }
     }
 

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1078,12 +1078,6 @@ Error Profiler::start(Arguments& args, bool reset) {
         return Error("jfrsync is not supported with non-Java processes");
     }
 
-    if (args._fdtransfer) {
-        if (!FdTransferClient::connectToServer(args._fdtransfer_path)) {
-            return Error("Failed to initialize FdTransferClient");
-        }
-    }
-
     if (args._proc > 0) {
         if (!OS::isLinux()) {
             return Error("Process sampling is not supported on the platform");
@@ -1198,6 +1192,12 @@ Error Profiler::start(Arguments& args, bool reset) {
             uninstallTraps();
             switchLibraryTrap(false);
             return error;
+        }
+    }
+
+    if (args._fdtransfer) {
+        if (!FdTransferClient::connectToServer(args._fdtransfer_path)) {
+            return Error("Failed to initialize FdTransferClient");
         }
     }
 

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -196,6 +196,7 @@ class Profiler {
     void shutdown(Arguments& args);
     Error check(Arguments& args);
     Error start(Arguments& args, bool reset);
+    Error startInternal(Arguments& args, bool reset);
     Error stop(bool restart = false);
     Error flushJfr();
     Error dump(Writer& out, Arguments& args);


### PR DESCRIPTION
### Description
Noticed while fixing #1651, in many locations after initial connection is created it's possible for `start` to return error without closing the connection

Moving the if condition to just before starting the CPU engine should work well enough

### Related issues
N/A

### Motivation and context
Prevent fdtransfer connection from not closing in case of start error

### How has this been tested?
`make test` & manual testing

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
