### PR TITLE
Fix null vaddr_diff in ELF program header address resolution

### DIFF
--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -243,7 +243,10 @@ class ElfParser {
     }
 
     const char* at(ElfProgramHeader* pheader) {
-        return _header->e_type == ET_EXEC ? (const char*)pheader->p_vaddr : _vaddr_diff + pheader->p_vaddr;
+        if (_header->e_type == ET_EXEC) {
+            return (const char*)pheader->p_vaddr;
+        }
+        return _vaddr_diff == NULL ? (const char*)pheader->p_vaddr : _vaddr_diff + pheader->p_vaddr;
     }
 
     const char* base() {


### PR DESCRIPTION
### Description

Fix undefined behavior in `ElfParser::at(ElfProgramHeader*)` when `_vaddr_diff` is NULL.

For position-independent ELF binaries whose first `PT_LOAD` segment has `p_vaddr == 0` and the library is loaded at base address 0, `_vaddr_diff` computes as `NULL` (i.e. `0 - 0`). The existing code then performs `NULL + pheader->p_vaddr`, which is undefined behavior per the C++ standard (pointer arithmetic on null pointers).

The fix handles the `_vaddr_diff == NULL` case by falling back to treating `p_vaddr` as an absolute virtual address, matching the `ET_EXEC` code path.

### Related issues

None.

### Motivation and context

Discovered during AddressSanitizer testing in [DataDog/java-profiler](https://github.com/DataDog/java-profiler). While the UB is currently benign on most platforms (adding 0 to a null pointer), it is flagged by sanitizers and could theoretically be optimized away by a sufficiently aggressive compiler.

### How has this been tested?

- Builds successfully with `make` on macOS (arm64) and Linux (x86_64)
- Verified under AddressSanitizer — the UB warning on `_vaddr_diff + pheader->p_vaddr` is eliminated
- Existing async-profiler test suite passes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0