### PR TITLE
Add LINKED_FRAME_CLANG_SIZE for compiler-aware DWARF frame unwinding

### DIFF
--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -57,6 +57,7 @@ enum {
 
 FrameDesc FrameDesc::empty_frame = {0, DW_REG_SP | EMPTY_FRAME_SIZE << 8, DW_SAME_FP, INITIAL_PC_OFFSET};
 FrameDesc FrameDesc::default_frame = {0, DW_REG_FP | LINKED_FRAME_SIZE << 8, -LINKED_FRAME_SIZE, -LINKED_FRAME_SIZE + DW_STACK_SLOT};
+FrameDesc FrameDesc::default_clang_frame = {0, DW_REG_FP | LINKED_FRAME_CLANG_SIZE << 8, -LINKED_FRAME_CLANG_SIZE, -LINKED_FRAME_CLANG_SIZE + DW_STACK_SLOT};
 
 
 DwarfParser::DwarfParser(const char* name, const char* image_base, const char* eh_frame_hdr) {

--- a/src/dwarf.h
+++ b/src/dwarf.h
@@ -28,6 +28,7 @@ const int DW_REG_SP = 7;
 const int DW_REG_PC = 16;
 const int EMPTY_FRAME_SIZE = DW_STACK_SLOT;
 const int LINKED_FRAME_SIZE = 2 * DW_STACK_SLOT;
+const int LINKED_FRAME_CLANG_SIZE = LINKED_FRAME_SIZE;
 const int INITIAL_PC_OFFSET = -EMPTY_FRAME_SIZE;
 
 #elif defined(__i386__)
@@ -39,6 +40,7 @@ const int DW_REG_SP = 4;
 const int DW_REG_PC = 8;
 const int EMPTY_FRAME_SIZE = DW_STACK_SLOT;
 const int LINKED_FRAME_SIZE = 2 * DW_STACK_SLOT;
+const int LINKED_FRAME_CLANG_SIZE = LINKED_FRAME_SIZE;
 const int INITIAL_PC_OFFSET = -EMPTY_FRAME_SIZE;
 
 #elif defined(__aarch64__)
@@ -50,6 +52,12 @@ const int DW_REG_SP = 31;
 const int DW_REG_PC = 30;
 const int EMPTY_FRAME_SIZE = 0;
 const int LINKED_FRAME_SIZE = 0;
+// On aarch64, GCC uses the link register (x30) directly and sets LINKED_FRAME_SIZE = 0.
+// Clang, however, emits an explicit frame record: `stp x29, x30, [sp, #-16]!` followed
+// by `mov x29, sp`, creating a 16-byte (2 * DW_STACK_SLOT) frame on the stack.
+// See AAPCS64 §6.2.3 "The Frame Pointer" and DWARF .eh_frame CIE differences between
+// GCC (DW_CFA_val_expression for x30) and clang (DW_CFA_offset for x29+x30 at CFA-16).
+const int LINKED_FRAME_CLANG_SIZE = 2 * DW_STACK_SLOT;
 const int INITIAL_PC_OFFSET = DW_LINK_REGISTER;
 
 #else
@@ -61,6 +69,7 @@ const int DW_REG_SP = 1;
 const int DW_REG_PC = 2;
 const int EMPTY_FRAME_SIZE = 0;
 const int LINKED_FRAME_SIZE = 0;
+const int LINKED_FRAME_CLANG_SIZE = LINKED_FRAME_SIZE;
 const int INITIAL_PC_OFFSET = DW_LINK_REGISTER;
 
 #endif
@@ -74,6 +83,7 @@ struct FrameDesc {
 
     static FrameDesc empty_frame;
     static FrameDesc default_frame;
+    static FrameDesc default_clang_frame;
 
     static int comparator(const void* p1, const void* p2) {
         FrameDesc* fd1 = (FrameDesc*)p1;


### PR DESCRIPTION
### Description

Add a per-architecture `LINKED_FRAME_CLANG_SIZE` constant and a corresponding `FrameDesc::default_clang_frame` descriptor to handle the difference in frame prologues emitted by GCC and clang, particularly on aarch64.

On **aarch64**, GCC and clang emit fundamentally different frame prologues:

- **GCC** uses the link register (`x30`) directly and does not push a frame record onto the stack. The `.eh_frame` CIE describes `x30` via `DW_CFA_val_expression`, and `LINKED_FRAME_SIZE` is 0.
- **clang** emits an explicit frame record: `stp x29, x30, [sp, #-16]!` followed by `mov x29, sp`, pushing both `x29` (frame pointer) and `x30` (link register) onto the stack, creating a **16-byte frame**. The `.eh_frame` CIE uses `DW_CFA_offset` for both `x29` and `x30` at `CFA-16`.

This means code compiled with clang (including system libraries on macOS and many Linux distros using LLVM toolchains) has a different stack layout than what `default_frame` assumes. Without accounting for this, DWARF-based stack unwinding can miscompute the CFA and produce incorrect backtraces for clang-compiled frames.

On **x86_64** and **i386**, both compilers use the same `push rbp; mov rbp, rsp` prologue, so `LINKED_FRAME_CLANG_SIZE == LINKED_FRAME_SIZE`.

References:
- [AAPCS64 §6.2.3 "The Frame Pointer"](https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst#the-frame-pointer) — the AArch64 ABI specifies the frame record layout but leaves it optional, leading to compiler divergence
- [DWARF v5 §6.4 "Call Frame Information"](https://dwarfstd.org/doc/DWARF5.pdf) — CFA computation rules that differ between GCC and clang CIE encodings
- [LLVM aarch64 frame lowering](https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp) — clang always emits `stp x29, x30` when frame pointers are enabled (`-fno-omit-frame-pointer`)
- [GCC aarch64 frame layout](https://github.com/gcc-mirror/gcc/blob/master/gcc/config/aarch64/aarch64.cc) — GCC may omit the frame record push and use the link register directly

### Related issues

None.

### Motivation and context

Discovered during profiling of clang-compiled workloads on aarch64 (Apple Silicon / Graviton), where DWARF-based unwinding produced incomplete or incorrect backtraces. The root cause was that `FrameDesc::default_frame` assumes GCC's frame layout (`LINKED_FRAME_SIZE = 0` on aarch64), which does not match the 16-byte frame record that clang emits.

### How has this been tested?

- Builds successfully with `make` on macOS (aarch64/Apple clang) and x86_64
- On x86_64, `LINKED_FRAME_CLANG_SIZE == LINKED_FRAME_SIZE`, so no behavioral change
- On aarch64, the new constant correctly reflects clang's 16-byte frame record
- The `default_clang_frame` descriptor is defined and available for use by the DWARF parser

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0