### PR TITLE
Async-profiler should choose the same clock for timestamps as JFR

### DIFF
--- a/src/tsc.cpp
+++ b/src/tsc.cpp
@@ -35,7 +35,6 @@ void TSC::enable(Clock clock) {
 
 // Try to use the same clock source with the same offset/frequency as the JVM does
 bool TSC::syncWithJvm() {
-#if defined(__x86_64__) || defined(__i386__)
     JVMFlag* f = JVMFlag::find("UseFastUnorderedTimeStamps");
     if (f == nullptr || !f->get()) {
         return false;
@@ -74,8 +73,4 @@ bool TSC::syncWithJvm() {
 
     env->ExceptionClear();
     return true;
-#else
-    // HotSpot supports UseFastUnorderedTimeStamps on x86 only
-    return false;
-#endif
 }

--- a/src/tsc.cpp
+++ b/src/tsc.cpp
@@ -35,6 +35,7 @@ void TSC::enable(Clock clock) {
 
 // Try to use the same clock source with the same offset/frequency as the JVM does
 bool TSC::syncWithJvm() {
+#if defined(__x86_64__) || defined(__i386__)
     JVMFlag* f = JVMFlag::find("UseFastUnorderedTimeStamps");
     if (f == nullptr || !f->get()) {
         return false;
@@ -51,13 +52,15 @@ bool TSC::syncWithJvm() {
     }
 
     u64 frequency = 0;
+    // Method is static since JDK 22
     if ((getTicksFrequency = env->GetStaticMethodID(cls, "getTicksFrequency", "()J")) != nullptr) {
-        // Method is static in JDK 22+
         frequency = env->CallStaticLongMethod(cls, getTicksFrequency);
-    } else if ((getTicksFrequency = env->GetMethodID(cls, "getTicksFrequency", "()J")) != nullptr &&
-               (jvm = env->GetStaticFieldID(cls, "jvm", "Ljdk/jfr/internal/JVM;")) != nullptr) {
-        // Non-static method before JDK 22
-        frequency = env->CallLongMethod(env->GetStaticObjectField(cls, jvm), getTicksFrequency);
+    } else {
+        env->ExceptionClear();
+        if ((getTicksFrequency = env->GetMethodID(cls, "getTicksFrequency", "()J")) != nullptr &&
+                (jvm = env->GetStaticFieldID(cls, "jvm", "Ljdk/jfr/internal/JVM;")) != nullptr) {
+            frequency = env->CallLongMethod(env->GetStaticObjectField(cls, jvm), getTicksFrequency);
+        }
     }
     env->ExceptionClear();
 
@@ -71,4 +74,8 @@ bool TSC::syncWithJvm() {
 
     env->ExceptionClear();
     return true;
+#else
+    // HotSpot supports UseFastUnorderedTimeStamps on x86 only
+    return false;
+#endif
 }

--- a/src/tsc.cpp
+++ b/src/tsc.cpp
@@ -6,6 +6,7 @@
 #include <jvmti.h>
 #include "tsc.h"
 #include "vmEntry.h"
+#include "vmStructs.h"
 
 
 bool TSC::_initialized = false;
@@ -22,33 +23,52 @@ void TSC::enable(Clock clock) {
 
     if (!_initialized) {
         if (VM::loaded()) {
-            JNIEnv* env = VM::jni();
-
-            jfieldID jvm;
-            jmethodID getTicksFrequency, counterTime;
-            jclass cls = env->FindClass("jdk/jfr/internal/JVM");
-            if (cls != NULL
-                    && ((jvm = env->GetStaticFieldID(cls, "jvm", "Ljdk/jfr/internal/JVM;")) != NULL)
-                    && ((getTicksFrequency = env->GetMethodID(cls, "getTicksFrequency", "()J")) != NULL)
-                    && ((counterTime = env->GetStaticMethodID(cls, "counterTime", "()J")) != NULL)) {
-                u64 frequency = env->CallLongMethod(env->GetStaticObjectField(cls, jvm), getTicksFrequency);
-                if (frequency > NANOTIME_FREQ) {
-                    // Default 1GHz frequency might mean that rdtsc is not available
-                    u64 jvm_ticks = env->CallStaticLongMethod(cls, counterTime);
-                    _offset = rdtsc() - jvm_ticks;
-                    _frequency = frequency;
-                    _available = true;
-                }
-            }
-
-            env->ExceptionClear();
-        } else if (cpuHasGoodTimestampCounter()) {
-            _offset = 0;
-            _available = true;
+            _available = syncWithJvm();
+        } else {
+            _available = cpuHasGoodTimestampCounter();
         }
-
         _initialized = true;
     }
 
     _enabled = _available;
+}
+
+// Try to use the same clock source with the same offset/frequency as the JVM does
+bool TSC::syncWithJvm() {
+    JVMFlag* f = JVMFlag::find("UseFastUnorderedTimeStamps");
+    if (f == nullptr || !f->get()) {
+        return false;
+    }
+
+    JNIEnv* env = VM::jni();
+
+    jfieldID jvm;
+    jmethodID counterTime, getTicksFrequency;
+    jclass cls = env->FindClass("jdk/jfr/internal/JVM");
+    if (cls == nullptr || (counterTime = env->GetStaticMethodID(cls, "counterTime", "()J")) == nullptr) {
+        env->ExceptionClear();
+        return false;
+    }
+
+    u64 frequency = 0;
+    if ((getTicksFrequency = env->GetStaticMethodID(cls, "getTicksFrequency", "()J")) != nullptr) {
+        // Method is static in JDK 22+
+        frequency = env->CallStaticLongMethod(cls, getTicksFrequency);
+    } else if ((getTicksFrequency = env->GetMethodID(cls, "getTicksFrequency", "()J")) != nullptr &&
+               (jvm = env->GetStaticFieldID(cls, "jvm", "Ljdk/jfr/internal/JVM;")) != nullptr) {
+        // Non-static method before JDK 22
+        frequency = env->CallLongMethod(env->GetStaticObjectField(cls, jvm), getTicksFrequency);
+    }
+    env->ExceptionClear();
+
+    if (frequency == 0) {
+        return false;
+    }
+
+    u64 jvm_ticks = env->CallStaticLongMethod(cls, counterTime);
+    _offset = rdtsc() - jvm_ticks;
+    _frequency = frequency;
+
+    env->ExceptionClear();
+    return true;
 }

--- a/src/tsc.h
+++ b/src/tsc.h
@@ -83,6 +83,8 @@ class TSC {
     static u64 _offset;
     static u64 _frequency;
 
+    static bool syncWithJvm();
+
   public:
     static void enable(Clock clock);
 

--- a/test/test/jfr/JfrTests.java
+++ b/test/test/jfr/JfrTests.java
@@ -7,7 +7,9 @@ package test.jfr;
 
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordingFile;
+import one.profiler.test.Arch;
 import one.profiler.test.Assert;
+import one.profiler.test.Jvm;
 import one.profiler.test.Os;
 import one.profiler.test.Output;
 import one.profiler.test.Test;
@@ -237,6 +239,38 @@ public class JfrTests {
         assert p.exitCode() == 0;
 
         assert out.contains("begin and end symbols should not resolve to the same address");
+    }
+
+    /**
+     * Async-profiler should timestamp its events with the same clock the JVM uses for the JFR.
+     */
+    @Test(mainClass = Hello.class, arch = {Arch.X64, Arch.X86}, jvm = Jvm.HOTSPOT,
+            jvmArgs = "-XX:+UnlockExperimentalVMOptions -XX:+UseFastUnorderedTimeStamps",
+            agentArgs = "start,event=cpu,file=%f.jfr",
+            inputs = "tsc", nameSuffix = "tsc")
+    @Test(mainClass = Hello.class, arch = {Arch.X64, Arch.X86}, jvm = Jvm.HOTSPOT,
+            jvmArgs = "-XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps",
+            agentArgs = "start,event=cpu,file=%f.jfr",
+            inputs = "monotonic", nameSuffix = "monotonic")
+    public void clockSource(TestProcess p) throws Exception {
+        p.waitForExit();
+        assert p.exitCode() == 0;
+
+        String expectedClock = p.inputs()[0];
+        String actualClock = null;
+        try (RecordingFile recordingFile = new RecordingFile(p.getFile("%f").toPath())) {
+            while (recordingFile.hasMoreEvents()) {
+                RecordedEvent event = recordingFile.readEvent();
+                if (event.getEventType().getName().equals("jdk.ActiveSetting")
+                        && "clock".equals(event.getString("name"))) {
+                    actualClock = event.getString("value");
+                    break;
+                }
+            }
+        }
+
+        assert expectedClock.equals(actualClock)
+                : "Expected clock=" + expectedClock + " aligned with the JVM, but found clock=" + actualClock;
     }
 
     private boolean containsSamplesOutsideWindow(TestProcess p) throws Exception {

--- a/test/test/jfr/JfrTests.java
+++ b/test/test/jfr/JfrTests.java
@@ -7,9 +7,9 @@ package test.jfr;
 
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordingFile;
-import one.profiler.test.Arch;
+import one.jfr.JfrReader;
+import one.jfr.event.ExecutionSample;
 import one.profiler.test.Assert;
-import one.profiler.test.Jvm;
 import one.profiler.test.Os;
 import one.profiler.test.Output;
 import one.profiler.test.Test;
@@ -35,11 +35,11 @@ public class JfrTests {
         assert !out.contains(spikePattern);
         assert out.contains(normalLoadPattern);
 
-        out = Output.convertJfrToCollapsed(jfrOutPath,"--from", "1500", "--to", "3500");
+        out = Output.convertJfrToCollapsed(jfrOutPath, "--from", "1500", "--to", "3500");
         assert out.contains(spikePattern);
         assert out.contains(normalLoadPattern);
 
-        out = Output.convertJfrToCollapsed(jfrOutPath,"--from", "3500");
+        out = Output.convertJfrToCollapsed(jfrOutPath, "--from", "3500");
         assert !out.contains(spikePattern);
         assert out.contains(normalLoadPattern);
     }
@@ -244,33 +244,39 @@ public class JfrTests {
     /**
      * Async-profiler should timestamp its events with the same clock the JVM uses for the JFR.
      */
-    @Test(mainClass = Hello.class, arch = {Arch.X64, Arch.X86}, jvm = Jvm.HOTSPOT,
-            jvmArgs = "-XX:+UnlockExperimentalVMOptions -XX:+UseFastUnorderedTimeStamps",
-            agentArgs = "start,event=cpu,file=%f.jfr",
-            inputs = "tsc", nameSuffix = "tsc")
-    @Test(mainClass = Hello.class, arch = {Arch.X64, Arch.X86}, jvm = Jvm.HOTSPOT,
+    @Test(mainClass = Hello.class, nameSuffix = "tsc",
+            agentArgs = "start,event=cpu,file=%f.jfr,jfrsync")
+    @Test(mainClass = Hello.class, nameSuffix = "monotonic",
             jvmArgs = "-XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps",
-            agentArgs = "start,event=cpu,file=%f.jfr",
-            inputs = "monotonic", nameSuffix = "monotonic")
+            agentArgs = "start,event=cpu,file=%f.jfr,jfrsync")
     public void clockSource(TestProcess p) throws Exception {
         p.waitForExit();
         assert p.exitCode() == 0;
 
-        String expectedClock = p.inputs()[0];
-        String actualClock = null;
-        try (RecordingFile recordingFile = new RecordingFile(p.getFile("%f").toPath())) {
-            while (recordingFile.hasMoreEvents()) {
-                RecordedEvent event = recordingFile.readEvent();
-                if (event.getEventType().getName().equals("jdk.ActiveSetting")
-                        && "clock".equals(event.getString("name"))) {
-                    actualClock = event.getString("value");
-                    break;
-                }
-            }
-        }
+        try (JfrReader jfr = new JfrReader(p.getFilePath("%f"))) {
+            jfr.stopAtNewChunk = true;
+            // Read JDK chunk
+            jfr.readAllEvents(ExecutionSample.class);
+            long ticksPerSec1 = jfr.ticksPerSec;
+            // Read Async-profiler chunk
+            jfr.readAllEvents(ExecutionSample.class);
+            long ticksPerSec2 = jfr.ticksPerSec;
 
-        assert expectedClock.equals(actualClock)
-                : "Expected clock=" + expectedClock + " aligned with the JVM, but found clock=" + actualClock;
+            String clock = jfr.settings.get("clock");
+            if (clock.equals("monotonic")) {
+                // Monotonic clock has fixed 1GHz frequency
+                Assert.isEqual(ticksPerSec1, 1_000_000_000);
+                Assert.isEqual(ticksPerSec2, 1_000_000_000);
+            }
+
+            if (p.test().jvmArgs().contains("-UseFastUnorderedTimeStamps")) {
+                assert clock.equals("monotonic") : clock;
+            }
+
+            // Clock frequency must be aligned
+            Assert.isGreater(ticksPerSec1, ticksPerSec2 * 0.95);
+            Assert.isLess(ticksPerSec1, ticksPerSec2 * 1.05);
+        }
     }
 
     private boolean containsSamplesOutsideWindow(TestProcess p) throws Exception {


### PR DESCRIPTION
### Description

Fix the issue where async-profiler generated timestamps that are not aligned with the JDK Flight Recorder, even in the `jfrsync` mode.

### Related issues

https://bugs.openjdk.org/browse/JDK-8310661

### Motivation and context

Since JDK 22, `jdk.jfr.internal.JVM.getTicksFrequency` method became static.
Async-profiler failed to find an instance method and silently fell back to using CLOCK_MONOTONIC (System.nanoTime).
It should try both static and non-static versions.

### How has this been tested?

Added new `clockSource` test that runs with the default clock and with `-XX:-UseFastUnorderedTimeStamps`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
