### PR TITLE
Span API: added Recording.clockFrequency() method

### DIFF
--- a/src/api/one/profiler/Recording.java
+++ b/src/api/one/profiler/Recording.java
@@ -25,6 +25,8 @@ public class Recording {
     /** A JFR session is running. */
     public static final int RUNNING = 2;
 
+    static volatile long clockFrequency = 1_000_000_000;  // 1 GHz
+
     static volatile int state;
 
     static {
@@ -46,6 +48,19 @@ public class Recording {
     }
 
     /**
+     * Returns the tick rate of the {@link #timestamp()} clock. The frequency is not a constant:
+     * it may change when a recording starts, since async-profiler can switch the clock source
+     * between recordings.
+     * <p>
+     * The frequency alone is enough to convert durations to profiler ticks.
+     *
+     * @return the number of ticks per second of the profiler clock
+     */
+    public static long clockFrequency() {
+        return clockFrequency;
+    }
+
+    /**
      * @return the current time in the same clock async-profiler uses for its events,
      *         so span and sample timestamps are comparable
      */
@@ -53,20 +68,16 @@ public class Recording {
         try {
             return (long) TIMESTAMP_INVOKER.invokeExact();
         } catch (Throwable e) {
-            throw new RuntimeException(e);
+            return 0;
         }
     }
 
     private static MethodHandle getTimestampMH(MethodHandles.Lookup privateLookup) {
-        if (privateLookup != null) {
-            try {
+        try {
+            if (privateLookup != null) {
                 Class<?> jvmClass = Class.forName("jdk.jfr.internal.JVM");
                 return privateLookup.findStatic(jvmClass, "counterTime", MethodType.methodType(long.class));
-            } catch (Exception e) {
-                // Fallback to System.nanoTime
             }
-        }
-        try {
             return MethodHandles.publicLookup().findStatic(System.class, "nanoTime", MethodType.methodType(long.class));
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -74,8 +85,9 @@ public class Recording {
     }
 
     // Called from JNI to replace the MethodHandle for timestamps
-    private static void updateClock(MethodHandles.Lookup privateLookup) {
+    private static void updateClock(MethodHandles.Lookup privateLookup, long frequency) {
         TIMESTAMP_CS.setTarget(getTimestampMH(privateLookup));
+        clockFrequency = frequency;
         MutableCallSite.syncAll(new MutableCallSite[]{TIMESTAMP_CS});
     }
 

--- a/src/api/one/profiler/Span.java
+++ b/src/api/one/profiler/Span.java
@@ -97,7 +97,8 @@ public class Span {
 
     /**
      * Records a span with explicit start and end timestamps obtained from
-     * {@link Recording#timestamp()}.
+     * {@link Recording#timestamp()} or converted from another clock
+     * using {@link Recording#clockFrequency()}.
      *
      * @param tag an arbitrary label, or {@code null}
      */

--- a/src/javaApi.cpp
+++ b/src/javaApi.cpp
@@ -270,7 +270,7 @@ void RecordingAPI::updateClock(JNIEnv* env) {
 
             lookup = env->GetStaticObjectField(lookup_class, impl_field);
         }
-        env->CallStaticVoidMethod(_recording_class, _update_clock_method, lookup);
+        env->CallStaticVoidMethod(_recording_class, _update_clock_method, lookup, TSC::frequency());
     } while (false);
 
     env->ExceptionClear();
@@ -286,7 +286,7 @@ RecordingAPI::State RecordingAPI::registerNatives(JNIEnv* env, jclass recording_
         return UNAVAILABLE;
     }
 
-    _update_clock_method = env->GetStaticMethodID(recording_class, "updateClock", "(Ljava/lang/invoke/MethodHandles$Lookup;)V");
+    _update_clock_method = env->GetStaticMethodID(recording_class, "updateClock", "(Ljava/lang/invoke/MethodHandles$Lookup;J)V");
     if (_update_clock_method == nullptr) {
         return UNAVAILABLE;
     }

--- a/test/test/span/SpanApiApp.java
+++ b/test/test/span/SpanApiApp.java
@@ -36,9 +36,17 @@ public class SpanApiApp {
         profiler.execute("start,event=cpu,interval=1ms,file=" + args[0]);
         assert Recording.state() == Recording.RUNNING;
 
+        long frequency = Recording.clockFrequency();
+        assert frequency > 0 : frequency;
+
+        long start = Recording.timestamp();
         long span = Span.start();
         busy(300);
         Span.end(span, "duringSession");
+
+        // Check that clockFrequency() matches the timestamp() clock.
+        long elapsedMillis = (Recording.timestamp() - start) * 1000 / frequency;
+        assert elapsedMillis >= 250 && elapsedMillis <= 500 : elapsedMillis;
 
         profiler.execute("stop");
         assert Recording.state() == Recording.STOPPED;


### PR DESCRIPTION
### Description

Extend Span API with a new `Recording.clockFrequency()` method.

### Related issues

https://github.com/async-profiler/async-profiler/pull/1755#issuecomment-4852373902

### Motivation and context

Often, developers already trace timing of latency-sensitive events, e.g. with `System.nanoTime`. Span API has methods to record spans with user-provided timestamps, but there is no guarantee that these timestamps are aligned with the async-profiler's internal clock source, which can be either `tsc` or `monotonic`.

I'm adding the minimal API that should be enough to do all kinds of timestamp/duration conversion. This will shift the burden of dealing with timestamps to the user, but on the other hand, this will keep the API clean and flexible.

### How has this been tested?

Added assertions in the SpanApiApp to verify that `Recording.clockFrequency()` value is sane.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
