### PR TITLE
Fix vtable test failures on JDK 27

### DIFF
--- a/src/vmStructs.cpp
+++ b/src/vmStructs.cpp
@@ -23,6 +23,7 @@ bool VMStructs::_has_native_thread_id = false;
 bool VMStructs::_has_perm_gen = false;
 bool VMStructs::_can_dereference_jmethod_id = false;
 bool VMStructs::_compact_object_headers = false;
+bool VMStructs::_compressed_class_pointers = false;
 
 int VMStructs::_klass_name_offset = -1;
 int VMStructs::_symbol_length_offset = -1;
@@ -175,6 +176,10 @@ void VMStructs::initOffsets() {
             } else if (strcmp(type, "oopDesc") == 0) {
                 if (strcmp(field, "_metadata._klass") == 0) {
                     _oop_klass_offset = *(int*)(entry + offset_offset);
+                } else if (strcmp(field, "_compressed_klass") == 0) {
+                    // Since JDK 27, class pointers are always compressed
+                    _oop_klass_offset = *(int*)(entry + offset_offset);
+                    _compressed_class_pointers = true;
                 }
             } else if (strcmp(type, "Universe") == 0 || strcmp(type, "CompressedKlassPointers") == 0) {
                 if (strcmp(field, "_narrow_klass._base") == 0 || strcmp(field, "_base") == 0) {
@@ -448,8 +453,11 @@ void VMStructs::resolveOffsets() {
         _klass = (jfieldID)(uintptr_t)(*_klass_offset_addr << 2 | 2);
     }
 
-    JVMFlag* ccp = JVMFlag::find("UseCompressedClassPointers");
-    if (ccp != NULL && ccp->get() && _narrow_klass_base_addr != NULL && _narrow_klass_shift_addr != NULL) {
+    if (!_compressed_class_pointers) {
+        JVMFlag* ccp = JVMFlag::find("UseCompressedClassPointers");
+        _compressed_class_pointers = ccp != NULL && ccp->get();
+    }
+    if (_compressed_class_pointers && _narrow_klass_base_addr != NULL && _narrow_klass_shift_addr != NULL) {
         _narrow_klass_base = *_narrow_klass_base_addr;
         _narrow_klass_shift = *_narrow_klass_shift_addr;
     }

--- a/src/vmStructs.h
+++ b/src/vmStructs.h
@@ -49,6 +49,7 @@ class VMStructs {
     static bool _has_perm_gen;
     static bool _can_dereference_jmethod_id;
     static bool _compact_object_headers;
+    static bool _compressed_class_pointers;
 
     static int _klass_name_offset;
     static int _symbol_length_offset;


### PR DESCRIPTION
### Description

`VtableTests.vtableStubs` and `VtableTests.itableStubs` failed on JDK 27-ea.

JDK 27 removed the `UseCompressedClassPointers` flag in [JDK-8363996](https://bugs.openjdk.org/browse/JDK-8363996); class pointers are now always compressed, and oopDesc's `_metadata._klass` union was replaced with a `_compressed_klass` field.

Async-profiled failed to find `oopDesc::_metadata._klass` field, so `_oop_klass_offset` stayed -1. As a result, `VMKlass::fromOop()` dereferenced garbage at `oop - 1`.

### How has this been tested?

```
JAVA_HOME=/path/to/jdk-27 make test
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
