### PR TITLE
Fix full-match branch in instrument.cpp

### DIFF
--- a/src/instrument.cpp
+++ b/src/instrument.cpp
@@ -41,7 +41,7 @@ static inline u16 alignUp4(u16 i) {
 
 static bool matchesPattern(const char* value, size_t len, const std::string& pattern) {
     if (len == 0 || pattern.empty()) return false;
-    return (
+    return
         // wildcard match
         (
             pattern[pattern.length() - 1] == '*' &&
@@ -49,8 +49,7 @@ static bool matchesPattern(const char* value, size_t len, const std::string& pat
             memcmp(pattern.c_str(), value, pattern.length() - 1) == 0
         ) ||
         // full match
-        memcmp(pattern.c_str(), value, len) == 0
-    );
+        (len == pattern.length() && memcmp(pattern.c_str(), value, len) == 0);
 }
 
 static const MethodTargets* findMethodTargets(const Targets* targets, const char* class_name, size_t len) {


### PR DESCRIPTION
### Description

The "full match" branch in `matchesPattern` was broken: it compared `len` bytes regardless of pattern length.
So, for example, `java/lang/StringBuilder` would match `java/lang/String` pattern.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
