### PR TITLE
Do not use TSC on x86 if JFR fails to detect TSC frequency

### DIFF
--- a/src/tsc.cpp
+++ b/src/tsc.cpp
@@ -63,7 +63,7 @@ bool TSC::syncWithJvm() {
     }
     env->ExceptionClear();
 
-    if (frequency == 0) {
+    if (frequency == 0 || !JFR_ALLOWED_FREQUENCY(frequency)) {
         return false;
     }
 

--- a/src/tsc.h
+++ b/src/tsc.h
@@ -19,6 +19,9 @@ const u64 NANOTIME_FREQ = 1000000000;
 
 #define TSC_SUPPORTED true
 
+// JFR prefers TSC only if its frequency is higher than 1GHz
+#define JFR_ALLOWED_FREQUENCY(freq) ((freq) > NANOTIME_FREQ)
+
 static inline u64 rdtsc() {
 #if defined(__x86_64__)
     u32 lo, hi;
@@ -51,6 +54,7 @@ static bool cpuHasGoodTimestampCounter() {
 #elif defined(__aarch64__)
 
 #define TSC_SUPPORTED true
+#define JFR_ALLOWED_FREQUENCY(freq) true
 
 static inline u64 rdtsc() {
     u64 value;
@@ -66,6 +70,7 @@ static bool cpuHasGoodTimestampCounter() {
 #else
 
 #define TSC_SUPPORTED false
+#define JFR_ALLOWED_FREQUENCY(freq) false
 #define rdtsc() 0
 
 static bool cpuHasGoodTimestampCounter() {


### PR DESCRIPTION
### Description

This is a follow-up to #1760.

In some cases, when CPU supports invariant TSC, but JFR cannot reliably detect TSC frequency, JFR falls back to CLOCK_MONOTONIC. However, async-profiler keeps using TSC, resulting in inconsistent timestamps between jfrsync chunks.

As an additional check, async-profiler now verifies that JFR timestamp frequency is higher than 1 GHz. With lower frequencies, JFR never uses TSC:
```
if ((tsc_freq < 0) || (tsc_freq > 0 && tsc_freq <= os_freq) || (os_to_tsc_conv_factor <= 1)) {
    tsc_freq = .0;
}
```

### Related issues

#1760

### How has this been tested?

The following tests failed on JDK 27 on 12th Gen Intel(R) Core(TM) i7-1280P:
- JfrTests.clockSource/tsc
- JfrconverterTests.latencyFilter
- SpanTests.spans

After the fix, `make test` passes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
