### PR TITLE
#1406, #1756: Parse only essential libraries at load time

### DIFF
--- a/src/symbols.h
+++ b/src/symbols.h
@@ -18,7 +18,7 @@ class Symbols {
 
   public:
     static void parseKernelSymbols(CodeCache* cc);
-    static void parseLibraries(CodeCacheArray* array, bool kernel_symbols);
+    static void parseLibraries(CodeCacheArray* array, bool kernel_symbols, bool essential_only = false);
 
     static bool haveKernelSymbols() {
         return _have_kernel_symbols;

--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -740,7 +740,17 @@ void Symbols::parseKernelSymbols(CodeCache* cc) {
     fclose(f);
 }
 
-static void collectSharedLibraries(std::unordered_map<u64, SharedLibrary>& libs, int max_count) {
+static bool isEssentialLibrary(const char* file, const char* map_start, const char* map_end) {
+    const void* this_lib = (const void*)isEssentialLibrary;
+    if (this_lib >= map_start && this_lib < map_end) {
+        return true;  // async-profiler's own library
+    }
+
+    const char* base_name = strrchr(file, '/');
+    return base_name != NULL && (strncmp(base_name + 1, "libjvm.", 7) == 0 || strncmp(base_name + 1, "libj9", 5) == 0);
+}
+
+static void collectSharedLibraries(std::unordered_map<u64, SharedLibrary>& libs, int max_count, bool essential_only) {
     FILE* f = fopen("/proc/self/maps", "r");
     if (f == NULL) {
         return;
@@ -776,6 +786,9 @@ static void collectSharedLibraries(std::unordered_map<u64, SharedLibrary>& libs,
         }
 
         if (map.isExecutable()) {
+            if (essential_only && !isEssentialLibrary(map.file(), map_start, map_end)) {
+                continue;
+            }
             SharedLibrary& lib = libs[inode];
             if (lib.file == nullptr) {
                 lib.file = strdup(map.file());
@@ -794,7 +807,7 @@ static void collectSharedLibraries(std::unordered_map<u64, SharedLibrary>& libs,
     fclose(f);
 }
 
-void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
+void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols, bool essential_only) {
     MutexLocker ml(_parse_lock);
 
     if (_in_parse_libraries || array->count() >= MAX_NATIVE_LIBS) {
@@ -815,7 +828,7 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
     }
 
     std::unordered_map<u64, SharedLibrary> libs;
-    collectSharedLibraries(libs, MAX_NATIVE_LIBS - array->count());
+    collectSharedLibraries(libs, MAX_NATIVE_LIBS - array->count(), essential_only);
 
     for (auto& it : libs) {
         u64 inode = it.first;

--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -747,7 +747,11 @@ static bool isEssentialLibrary(const char* file, const char* map_start, const ch
     }
 
     const char* base_name = strrchr(file, '/');
-    return base_name != NULL && (strncmp(base_name + 1, "libjvm.", 7) == 0 || strncmp(base_name + 1, "libj9", 5) == 0);
+    return base_name != NULL && (
+               strncmp(base_name + 1, "libjvm.", 7) == 0 ||
+               strncmp(base_name + 1, "libj9", 5) == 0 ||
+               strncmp(base_name + 1, "libazsys", 8) == 0
+           );
 }
 
 static void collectSharedLibraries(std::unordered_map<u64, SharedLibrary>& libs, int max_count, bool essential_only) {

--- a/src/symbols_macos.cpp
+++ b/src/symbols_macos.cpp
@@ -191,7 +191,11 @@ static bool isEssentialLibrary(const char* path, const mach_header* image_base) 
     }
 
     const char* base_name = path != NULL ? strrchr(path, '/') : NULL;
-    return base_name != NULL && (strncmp(base_name + 1, "libjvm.", 7) == 0 || strncmp(base_name + 1, "libj9", 5) == 0);
+    return base_name != NULL && (
+               strncmp(base_name + 1, "libjvm.", 7) == 0 ||
+               strncmp(base_name + 1, "libj9", 5) == 0 ||
+               strncmp(base_name + 1, "libazsys", 8) == 0
+           );
 }
 
 

--- a/src/symbols_macos.cpp
+++ b/src/symbols_macos.cpp
@@ -178,16 +178,36 @@ bool Symbols::_have_kernel_symbols = false;
 bool Symbols::_libs_limit_reported = false;
 static std::unordered_set<const void*> _parsed_libraries;
 
+static const void* getProfilerImageBase() {
+    Dl_info dl_info;
+    return dladdr((const void*)getProfilerImageBase, &dl_info) != 0 ? dl_info.dli_fbase : NULL;
+}
+
+static const void* _profiler_image_base = getProfilerImageBase();
+
+static bool isEssentialLibrary(const char* path, const mach_header* image_base) {
+    if (image_base == _profiler_image_base) {
+        return true;  // async-profiler's own library
+    }
+
+    const char* base_name = path != NULL ? strrchr(path, '/') : NULL;
+    return base_name != NULL && (strncmp(base_name + 1, "libjvm.", 7) == 0 || strncmp(base_name + 1, "libj9", 5) == 0);
+}
+
+
 void Symbols::parseKernelSymbols(CodeCache* cc) {
 }
 
-void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
+void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols, bool essential_only) {
     MutexLocker ml(_parse_lock);
     uint32_t images = _dyld_image_count();
 
     for (uint32_t i = 0; i < images; i++) {
         const mach_header* image_base = _dyld_get_image_header(i);
-        if (image_base == NULL || !_parsed_libraries.insert(image_base).second) {
+        if (image_base == NULL || (essential_only && !isEssentialLibrary(_dyld_get_image_name(i), image_base))) {
+            continue;
+        }
+        if (!_parsed_libraries.insert(image_base).second) {
             continue;  // the library was already parsed
         }
 

--- a/src/zInit.cpp
+++ b/src/zInit.cpp
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include "hooks.h"
 #include "profiler.h"
+#include "symbols.h"
 #include "vmStructs.h"
 
 
@@ -33,8 +34,10 @@ class LateInitializer {
 
   private:
     bool checkJvmLoaded() {
+        // Parsing all libraries in the constructor may cause a long time-to-safepoint pause.
+        // Parse only libraries needed at load time: libjvm, libj9*, and the async-profiler library itself.
         Profiler* profiler = Profiler::instance();
-        profiler->updateSymbols(false);
+        Symbols::parseLibraries(profiler->nativeLibs(), false, true);
 
         CodeCache* libjvm = profiler->findLibraryByName(OS::isLinux() ? "libjvm.so" : "libjvm.dylib");
         if (libjvm != NULL && libjvm->findSymbol("AsyncGetCallTrace") != NULL) {

--- a/src/zInit.cpp
+++ b/src/zInit.cpp
@@ -35,7 +35,7 @@ class LateInitializer {
   private:
     bool checkJvmLoaded() {
         // Parsing all libraries in the constructor may cause a long time-to-safepoint pause.
-        // Parse only libraries needed at load time: libjvm, libj9*, and the async-profiler library itself.
+        // Parse only essential libraries: libjvm, libj9*, libazsys, and the async-profiler library itself.
         Profiler* profiler = Profiler::instance();
         Symbols::parseLibraries(profiler->nativeLibs(), false, true);
 


### PR DESCRIPTION
### Description

`Symbols::parseLibraries()` gets a new `essential_only` mode that parses only the libraries required at agent load time: `libjvm`, `libj9*`, and async-profiler itself.

### Related issues

- Fixes #1406
- Fixes #1756

### Motivation and context

`LateInitializer` runs as part of `dlopen()` when the agent is loaded. Parsing all shared libraries there has two problems:

- In a process with many/large libraries, `dlopen()` runs too long on a thread that cannot reach a safepoint, causing a long time-to-safepoint pause (#1406).
- When more than `MAX_NATIVE_LIBS` (2048) libraries are loaded, the scan may exhaust the limit before reaching `libjvm`, so the agent fails to attach with "JVM does not support Tool Interface" (#1756).

Parsing only the essential libraries makes agent load fast and guarantees `libjvm` is always parsed. Libraries parsed at load time are remembered, so `Profiler::start()` does not parse them again. `libj9*` is included so that OpenJ9 symbols remain available in `VM::init()` as before.

### How has this been tested?

- CI
- Manual: dynamic attach and `-agentpath` at startup; no dynamic-agent warning on JDK 21+
- Reproduced #1756 with a test app that loads 2100 extra libraries: the old build fails to attach, the new build attaches instantly and profiles correctly

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
