### PR TITLE
Fix `--tlab` mode on ARM64

### DIFF
--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -406,10 +406,13 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
                     continue;
                 }
 
-                if (depth > 1 && nm->frameSize() > 0) {
+                if (nm->frameSize() > 0) {
                     sp += nm->frameSize() * sizeof(void*);
                     fp = ((uintptr_t*)sp)[-FRAME_PC_SLOT - 1];
                     pc = ((const void**)sp)[-FRAME_PC_SLOT];
+                    if (inDeadZone(pc)) {
+                        fillFrame(frames[depth++], BCI_ERROR, "break_stub");
+                    }
                     continue;
                 }
             }

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -412,6 +412,7 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
                     pc = ((const void**)sp)[-FRAME_PC_SLOT];
                     if (inDeadZone(pc)) {
                         fillFrame(frames[depth++], BCI_ERROR, "break_stub");
+                        break;
                     }
                     continue;
                 }

--- a/test/test/alloc/AllocTests.java
+++ b/test/test/alloc/AllocTests.java
@@ -80,6 +80,16 @@ public class AllocTests {
         }
 
         assert tlabEvent : "No jdk.ObjectAllocationOutsideTLAB event was found";
+
+        // Verify that the allocation profile is sane
+        Output out = Output.convertJfrToCollapsed(p.getFilePath("%profile"), "--alloc");
+        assert out.containsExact(";java.lang.String") : "Strings are obviously allocated";
+        assert out.containsExact("_[k] ") : "Some allocations are outside TLAB";
+
+        Assert.isLess(out.ratio("break_"), 0.01, "No more than 1% of broken stacks");
+        Assert.isGreater(out.ratio("test/alloc/MapReaderOpt.main_...;" +
+                "test/alloc/MapReader.benchmark_...;" +
+                "test/alloc/MapReaderOpt.readMap_...;"), 0.7);
     }
 
     @Test(mainClass = MapReaderOpt.class, jvmVer = {11, Integer.MAX_VALUE})


### PR DESCRIPTION
### Description

AllocTracer engine (legacy allocation profiling mode) did not work correctly on ARM64, because the stub `C2 Runtime new_instance` was not unwound due to the bogus `depth > 1` check.
On x86, the stub was accidentally unwound through a different code path.

### How has this been tested?

Extended `AllocTests.tlabAllocSampler` test with more checks to ensure the output allocation profile is sane.
Previously, the test only verified presence of `ObjectAllocationOutsideTLAB` events without checking actual stack traces.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
