### PR TITLE
Fix glibc TLS corruption

### DIFF
--- a/src/cpuEngine.cpp
+++ b/src/cpuEngine.cpp
@@ -32,6 +32,9 @@ static int pthread_setspecific_hook(pthread_key_t key, const void* value) {
     }
 
     if (value != NULL) {
+        // workaround for https://github.com/async-profiler/async-profiler/issues/1743
+        // having 2 different set functions guarantees the TLS will be correct after both are executed
+        pthread_setspecific(key, value);
         int result = pthread_setspecific(key, value);
         CpuEngine::onThreadStart();
         return result;
@@ -80,11 +83,17 @@ bool CpuEngine::setupThreadHook() {
 
 void CpuEngine::enableThreadHook() {
     *_pthread_entry = (void*)pthread_setspecific_hook;
+}
+
+void CpuEngine::enableEngine() {
     storeRelease(_current, this);
 }
 
 void CpuEngine::disableThreadHook() {
     *_pthread_entry = (void*)pthread_setspecific;
+}
+
+void CpuEngine::disableEngine() {
     storeRelease(_current, nullptr);
 }
 

--- a/src/cpuEngine.cpp
+++ b/src/cpuEngine.cpp
@@ -32,10 +32,9 @@ static int pthread_setspecific_hook(pthread_key_t key, const void* value) {
     }
 
     if (value != NULL) {
-        // workaround for https://github.com/async-profiler/async-profiler/issues/1743
-        // having 2 different set functions guarantees the TLS will be correct after both are executed
-        pthread_setspecific(key, value);
         int result = pthread_setspecific(key, value);
+        // Workaround for #1743: the second call repairs TLS if it was corrupted by the nested pthread_getspecific
+        pthread_setspecific(key, value);
         CpuEngine::onThreadStart();
         return result;
     } else {

--- a/src/cpuEngine.h
+++ b/src/cpuEngine.h
@@ -24,10 +24,8 @@ class CpuEngine : public Engine {
     static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext);
     static void signalHandlerJ9(int signo, siginfo_t* siginfo, void* ucontext);
 
-    static bool setupThreadHook();
-
-    void enableThreadHook();
-    void disableThreadHook();
+    void enableEngine();
+    void disableEngine();
 
     bool isResourceLimit(int err);
 
@@ -51,6 +49,10 @@ class CpuEngine : public Engine {
 
     static void onThreadStart();
     static void onThreadEnd();
+
+    static bool setupThreadHook();
+    static void enableThreadHook();
+    static void disableThreadHook();
 };
 
 #endif // _CPUENGINE_H

--- a/src/ctimer_linux.cpp
+++ b/src/ctimer_linux.cpp
@@ -74,10 +74,6 @@ void CTimer::destroyForThread(int tid) {
 }
 
 Error CTimer::start(Arguments& args) {
-    if (!setupThreadHook()) {
-        return Error("Could not set pthread hook");
-    }
-
     if (args._interval < 0) {
         return Error("interval must be positive");
     }
@@ -103,21 +99,20 @@ Error CTimer::start(Arguments& args) {
         OS::installSignalHandler(_signal, signalHandler);
     }
 
-    // Enable pthread hook before traversing currently running threads
-    enableThreadHook();
+    // allow pthread hook to create timers for new threads before traversing existing threads
+    enableEngine();
 
     // Create timers for all existing threads
     int err = createForAllThreads();
     if (err) {
-        disableThreadHook();
-        J9StackTraces::stop();
+        stop();
         return Error("Failed to create CPU timer");
     }
     return Error::OK;
 }
 
 void CTimer::stop() {
-    disableThreadHook();
+    disableEngine();
     for (int i = 0; i < _max_timers; i++) {
         destroyForThread(i);
     }

--- a/src/ctimer_linux.cpp
+++ b/src/ctimer_linux.cpp
@@ -99,7 +99,7 @@ Error CTimer::start(Arguments& args) {
         OS::installSignalHandler(_signal, signalHandler);
     }
 
-    // allow pthread hook to create timers for new threads before traversing existing threads
+    // Let pthread hook create timers for new threads before traversing existing threads
     enableEngine();
 
     // Create timers for all existing threads

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -817,10 +817,6 @@ Error PerfEvents::start(Arguments& args) {
         return Error("Only arguments 1-4 can be counted");
     }
 
-    if (!setupThreadHook()) {
-        return Error("Could not set pthread hook");
-    }
-
     _target_cpu = args._target_cpu;
     _record_cpu = args._record_cpu;
 
@@ -870,8 +866,8 @@ Error PerfEvents::start(Arguments& args) {
         OS::installSignalHandler(_signal, signalHandler);
     }
 
-    // Enable pthread hook before traversing currently running threads
-    enableThreadHook();
+    // allow pthread hook to create perf events for new threads before traversing existing threads
+    enableEngine();
 
     // Create perf_events for all existing threads
     int err = createForAllThreads();
@@ -889,7 +885,7 @@ Error PerfEvents::start(Arguments& args) {
 }
 
 void PerfEvents::stop() {
-    disableThreadHook();
+    disableEngine();
     for (int i = 0; i < _max_events; i++) {
         destroyForThread(i);
     }

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -866,7 +866,7 @@ Error PerfEvents::start(Arguments& args) {
         OS::installSignalHandler(_signal, signalHandler);
     }
 
-    // allow pthread hook to create perf events for new threads before traversing existing threads
+    // Let pthread hook create perf_events for new threads before traversing existing threads
     enableEngine();
 
     // Create perf_events for all existing threads

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -845,6 +845,10 @@ Error Profiler::start(Arguments& args, bool reset) {
         return Error("Profiling event is not supported with non-Java processes");
     }
 
+    if (!CpuEngine::setupThreadHook()) {
+        return Error("Could not set pthread hook");
+    }
+
     if (args._jfr_sync && !VM::loaded()) {
         return Error("jfrsync is not supported with non-Java processes");
     }
@@ -967,6 +971,7 @@ Error Profiler::start(Arguments& args, bool reset) {
         }
     }
 
+    CpuEngine::enableThreadHook();
     error = _engine->start(args);
     if (error) {
         goto error1;
@@ -1045,6 +1050,7 @@ error2:
     _engine->stop();
 
 error1:
+    CpuEngine::disableThreadHook();
     uninstallTraps();
     switchLibraryTrap(false);
 
@@ -1062,6 +1068,7 @@ Error Profiler::stop(bool restart) {
         return Error("Profiler is not active");
     }
 
+    CpuEngine::disableThreadHook();
     uninstallTraps();
 
     if (_event_mask & EM_WALL) wall_clock.stop();

--- a/src/threadLocalData.cpp
+++ b/src/threadLocalData.cpp
@@ -23,13 +23,17 @@ pthread_key_t ThreadLocalData::_profiler_data_key = init_profiler_data_key();
 // should be initialized beforehand.
 asprof_thread_local_data* ThreadLocalData::initThreadLocalData(pthread_key_t profiler_data_key) {
     // Initialize. Since this is a thread-local, it is not racy.
-    asprof_thread_local_data* val = (asprof_thread_local_data*) malloc(sizeof(asprof_thread_local_data));
+    asprof_thread_local_data* val = (asprof_thread_local_data*) calloc(1, sizeof(asprof_thread_local_data));
     if (val == NULL) {
         // would rather not insert random aborts into code. This
         // will make the code try again next time, which is fine.
         return NULL;
     }
-    val->sample_counter = 0;
+
+    // workaround for https://github.com/async-profiler/async-profiler/issues/1743
+    // No need to check output if first calls
+    // If "Insufficient memory exists" or if "key value is invalid" then both calls will fail
+    pthread_setspecific(profiler_data_key, (void*)val);
     if (pthread_setspecific(profiler_data_key, (void*)val) != 0) {
         free((void*)val);
         return NULL;

--- a/src/threadLocalData.cpp
+++ b/src/threadLocalData.cpp
@@ -30,13 +30,11 @@ asprof_thread_local_data* ThreadLocalData::initThreadLocalData(pthread_key_t pro
         return NULL;
     }
 
-    // workaround for https://github.com/async-profiler/async-profiler/issues/1743
-    // No need to check output if first calls
-    // If "Insufficient memory exists" or if "key value is invalid" then both calls will fail
-    pthread_setspecific(profiler_data_key, (void*)val);
     if (pthread_setspecific(profiler_data_key, (void*)val) != 0) {
         free((void*)val);
         return NULL;
     }
+    // Workaround for #1743: the second call repairs TLS if it was corrupted by the nested pthread_getspecific
+    pthread_setspecific(profiler_data_key, (void*)val);
     return val;
 }


### PR DESCRIPTION
### Description
In this change I'm addressing the glibc race that causes the tls entry to be unset, this is done by simply calling the pthread_setspecific two times back to back for the problematic keys

To achieve this with minimum changes the pthread_setspecific hook is now always enabled even if no CPU engine is selected, the CPU engine now only is responsible for setting itself to allow creation of timers/perf-events

Note: 
I did consider a more complex solution [here](https://github.com/async-profiler/async-profiler/compare/master...Baraa-Hasheesh:async-profiler:refs/heads/address-boundary-fix) that checks if `pthread_getspecific` is safe to call during the stackwalking, however after comparing the pros & cons of both, this solution wins for me

Pros:
- Less complex & lower change footprint
- Happens outside the of the StackWalking (hotpath), so will have a lower performance overhead overall 

Cons (minor):
- Problem is only glibc specific so we're calling pthread_setspecific twice for macOS & MUSL when it's not needed


### Related issues
#1743

### Motivation and context
Fix problem in glibc that causes the TLS entry to be unset

### How has this been tested?
I wasn't able to create a viable reproducer, but in theory the change should work

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
