### PR TITLE
Move pthread_setspecific hook to profiler space

### DIFF
--- a/src/cpuEngine.cpp
+++ b/src/cpuEngine.cpp
@@ -4,7 +4,6 @@
  */
 
 #include <errno.h>
-#include <pthread.h>
 #include "cpuEngine.h"
 #include "j9StackTraces.h"
 #include "profiler.h"
@@ -13,8 +12,7 @@
 #include "vmStructs.h"
 
 
-void** CpuEngine::_pthread_entry = NULL;
-CpuEngine* CpuEngine::_current = NULL;
+CpuEngine* CpuEngine::_current = nullptr;
 
 long CpuEngine::_interval;
 CStack CpuEngine::_cstack;
@@ -23,18 +21,17 @@ bool CpuEngine::_count_overrun;
 
 void CpuEngine::onThreadStart() {
     CpuEngine* current = loadAcquire(_current);
-    if (current != NULL) {
+    if (current != nullptr) {
         current->createForThread(OS::threadId());
     }
 }
 
 void CpuEngine::onThreadEnd() {
     CpuEngine* current = loadAcquire(_current);
-    if (current != NULL) {
+    if (current != nullptr) {
         current->destroyForThread(OS::threadId());
     }
 }
-
 
 void CpuEngine::enableEngine() {
     storeRelease(_current, this);

--- a/src/cpuEngine.cpp
+++ b/src/cpuEngine.cpp
@@ -21,28 +21,6 @@ CStack CpuEngine::_cstack;
 int CpuEngine::_signal;
 bool CpuEngine::_count_overrun;
 
-// Intercept thread creation/termination by patching libjvm's GOT entry for pthread_setspecific().
-// HotSpot puts VMThread into TLS on thread start, and resets on thread end.
-static int pthread_setspecific_hook(pthread_key_t key, const void* value) {
-    if (key != VMThread::key()) {
-        return pthread_setspecific(key, value);
-    }
-    if (pthread_getspecific(key) == value) {
-        return 0;
-    }
-
-    if (value != NULL) {
-        int result = pthread_setspecific(key, value);
-        // Workaround for #1743: the second call repairs TLS if it was corrupted by the nested pthread_getspecific
-        pthread_setspecific(key, value);
-        CpuEngine::onThreadStart();
-        return result;
-    } else {
-        CpuEngine::onThreadEnd();
-        return pthread_setspecific(key, value);
-    }
-}
-
 void CpuEngine::onThreadStart() {
     CpuEngine* current = loadAcquire(_current);
     if (current != NULL) {
@@ -57,39 +35,9 @@ void CpuEngine::onThreadEnd() {
     }
 }
 
-bool CpuEngine::setupThreadHook() {
-    if (_pthread_entry != NULL) {
-        return true;
-    }
-
-    if (!VM::loaded()) {
-        static void* dummy_pthread_entry;
-        _pthread_entry = &dummy_pthread_entry;
-        return true;
-    }
-
-    // Depending on Zing version, pthread_setspecific is called either from libazsys.so or from libjvm.so
-    if (VM::isZing()) {
-        CodeCache* libazsys = Profiler::instance()->findLibraryByName("libazsys");
-        if (libazsys != NULL && (_pthread_entry = libazsys->findImport(im_pthread_setspecific)) != NULL) {
-            return true;
-        }
-    }
-
-    CodeCache* lib = Profiler::instance()->findJvmLibrary("libj9thr");
-    return lib != NULL && (_pthread_entry = lib->findImport(im_pthread_setspecific)) != NULL;
-}
-
-void CpuEngine::enableThreadHook() {
-    *_pthread_entry = (void*)pthread_setspecific_hook;
-}
 
 void CpuEngine::enableEngine() {
     storeRelease(_current, this);
-}
-
-void CpuEngine::disableThreadHook() {
-    *_pthread_entry = (void*)pthread_setspecific;
 }
 
 void CpuEngine::disableEngine() {

--- a/src/cpuEngine.h
+++ b/src/cpuEngine.h
@@ -13,7 +13,6 @@
 // Base class for CPU sampling engines: PerfEvents, CTimer, ITimer
 class CpuEngine : public Engine {
   protected:
-    static void** _pthread_entry;
     static CpuEngine* _current;
 
     static long _interval;

--- a/src/cpuEngine.h
+++ b/src/cpuEngine.h
@@ -49,10 +49,6 @@ class CpuEngine : public Engine {
 
     static void onThreadStart();
     static void onThreadEnd();
-
-    static bool setupThreadHook();
-    static void enableThreadHook();
-    static void disableThreadHook();
 };
 
 #endif // _CPUENGINE_H

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -842,7 +842,6 @@ Error Profiler::checkJvmCapabilities() {
         }
 
         if (_pthread_setspecific_entry == NULL) {
-
             // Depending on Zing version, pthread_setspecific is called either from libazsys.so or from libjvm.so
             if (VM::isZing()) {
                 CodeCache* libazsys = findLibraryByName("libazsys");

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -567,10 +567,38 @@ void* Profiler::dlopen_hook(const char* filename, int flags) {
     return result;
 }
 
+// Intercept thread creation/termination by patching libjvm's GOT entry for pthread_setspecific().
+// HotSpot puts VMThread into TLS on thread start, and resets on thread end.
+int Profiler::pthread_setspecific_hook(pthread_key_t key, const void* value) {
+    if (key != VMThread::key()) {
+        return pthread_setspecific(key, value);
+    }
+    if (pthread_getspecific(key) == value) {
+        return 0;
+    }
+
+    if (value != NULL) {
+        int result = pthread_setspecific(key, value);
+        // Workaround for #1743: the second call repairs TLS if it was corrupted by the nested pthread_getspecific
+        pthread_setspecific(key, value);
+        CpuEngine::onThreadStart();
+        return result;
+    } else {
+        CpuEngine::onThreadEnd();
+        return pthread_setspecific(key, value);
+    }
+}
+
+
 void Profiler::switchLibraryTrap(bool enable) {
     if (_dlopen_entry != NULL) {
         void* impl = enable ? (void*)dlopen_hook : (void*)dlopen;
         storeRelease(*_dlopen_entry, impl);
+    }
+
+    if (_pthread_setspecific_entry != NULL) {
+        void* impl = enable ? (void*)pthread_setspecific_hook : (void*)pthread_setspecific;
+        storeRelease(*_pthread_setspecific_entry, impl);
     }
 }
 
@@ -813,6 +841,22 @@ Error Profiler::checkJvmCapabilities() {
             }
         }
 
+        if (_pthread_setspecific_entry == NULL) {
+
+            // Depending on Zing version, pthread_setspecific is called either from libazsys.so or from libjvm.so
+            if (VM::isZing()) {
+                CodeCache* libazsys = findLibraryByName("libazsys");
+                _pthread_setspecific_entry = libazsys ? libazsys->findImport(im_pthread_setspecific) : NULL;
+            }
+
+            if (_pthread_setspecific_entry == NULL) {
+                CodeCache* lib = findJvmLibrary("libj9thr");
+                if (lib == NULL || (_pthread_setspecific_entry = lib->findImport(im_pthread_setspecific)) == NULL) {
+                    return Error("Could not set pthread_setspecific hook. Unsupported JVM?");
+                }
+            }
+        }
+
         if (!VMStructs::libjvm()->hasDebugSymbols()) {
             Log::warn("Install JVM debug symbols to improve profile accuracy");
         }
@@ -845,10 +889,6 @@ Error Profiler::start(Arguments& args, bool reset) {
         return Error("Only JFR output supports multiple events");
     } else if (!VM::loaded() && (_event_mask & (1 << EC_ALLOC | 1 << EC_LOCK | 1 << EC_TRACE))) {
         return Error("Profiling event is not supported with non-Java processes");
-    }
-
-    if (!CpuEngine::setupThreadHook()) {
-        return Error("Could not set pthread hook");
     }
 
     if (args._jfr_sync && !VM::loaded()) {
@@ -973,7 +1013,6 @@ Error Profiler::start(Arguments& args, bool reset) {
         }
     }
 
-    CpuEngine::enableThreadHook();
     error = _engine->start(args);
     if (error) {
         goto error1;
@@ -1052,7 +1091,6 @@ error2:
     _engine->stop();
 
 error1:
-    CpuEngine::disableThreadHook();
     uninstallTraps();
     switchLibraryTrap(false);
 
@@ -1070,7 +1108,6 @@ Error Profiler::stop(bool restart) {
         return Error("Profiler is not active");
     }
 
-    CpuEngine::disableThreadHook();
     uninstallTraps();
 
     if (hasEvent(EC_WALL)) wall_clock.stop();

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -96,7 +96,10 @@ class Profiler {
 
     // dlopen() hook support
     void** _dlopen_entry;
+    // pthread_setspecific() hook support
+    void** _pthread_setspecific_entry;
     static void* dlopen_hook(const char* filename, int flags);
+    static int pthread_setspecific_hook(pthread_key_t key, const void* value);
     void switchLibraryTrap(bool enable);
 
     Error installTraps(const char* begin, const char* end, bool nostop);
@@ -173,7 +176,8 @@ class Profiler {
         _stubs_lock(),
         _runtime_stubs("[stubs]"),
         _native_libs(),
-        _dlopen_entry(NULL) {
+        _dlopen_entry(NULL),
+        _pthread_setspecific_entry(NULL) {
 
         for (int i = 0; i < CONCURRENCY_LEVEL; i++) {
             _calltrace_buffer[i] = NULL;


### PR DESCRIPTION
### Description
Follow up to #1771, after that change the `pthread_setspecific` hook is more generic & no longer fits under the CpuEngine class/file 

Moving the hooking function into the profiler class/file similar to what's already done for the dlopen hook

### Related issues
NA

### Motivation and context
Code & structure consistency 

### How has this been tested?
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
