### PR TITLE
More accurate stack walking limit

### DIFF
--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -39,6 +39,14 @@ static inline uintptr_t defaultSenderSP(uintptr_t sp, uintptr_t fp) {
 #endif
 }
 
+static inline uintptr_t stackBottom() {
+    // For threads created with pthread_create(), control block is usually placed at the stack bottom.
+    // Exceptions are the main thread, threads with a user-provided stack, and threads made via raw clone().
+    uintptr_t tcb = (uintptr_t)pthread_self();
+    uintptr_t current_frame = (uintptr_t)&tcb;
+    return tcb - current_frame <= MAX_WALK_SIZE ? tcb : current_frame + MAX_WALK_SIZE;
+}
+
 static inline void fillFrame(ASGCT_CallFrame& frame, ASGCT_CallFrameType type, const char* name) {
     frame.bci = type;
     frame.method_id = (jmethodID)name;
@@ -66,7 +74,7 @@ int StackWalker::walkFP(void* ucontext, const void** callchain, int max_depth) {
     const void* pc;
     uintptr_t fp;
     uintptr_t sp;
-    uintptr_t bottom = (uintptr_t)&sp + MAX_WALK_SIZE;
+    uintptr_t bottom = stackBottom();
 
     StackFrame frame(ucontext);
     if (ucontext == NULL) {
@@ -115,7 +123,7 @@ int StackWalker::walkDwarf(void* ucontext, const void** callchain, int max_depth
     const void* pc;
     uintptr_t fp;
     uintptr_t sp;
-    uintptr_t bottom = (uintptr_t)&sp + MAX_WALK_SIZE;
+    uintptr_t bottom = stackBottom();
 
     StackFrame frame(ucontext);
     if (ucontext == NULL) {
@@ -208,7 +216,7 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
     const void* pc;
     uintptr_t fp;
     uintptr_t sp;
-    uintptr_t bottom = (uintptr_t)&sp + MAX_WALK_SIZE;
+    uintptr_t bottom = stackBottom();
 
     StackFrame frame(ucontext ? ucontext : &empty_ucontext);
     if (ucontext == NULL) {

--- a/src/stackWalker.h
+++ b/src/stackWalker.h
@@ -6,7 +6,6 @@
 #ifndef _STACKWALKER_H
 #define _STACKWALKER_H
 
-#include <stdint.h>
 #include "arguments.h"
 #include "event.h"
 #include "vmEntry.h"


### PR DESCRIPTION
### Description

Instead of relying on MAX_WALK_SIZE (1 MB) to rule out pointers oustide the stack, use the thread control block address pointed by `pthread_self()` as the stack end. For threads created with `pthread_create()`, all supported libc implementations place the control block at the highest addresses of the stack mapping. When the TCB address is not usable (main thread, raw `clone()` threads), fall back to the previous heuristic.

`pthread_self()` is a very cheap, mostly accurate, and async-signal-safe estimation for the end-of-stack. Other alternatives are either unsafe inside a signal handler (e.g. `pthread_getattr_np`) or too expensive (e.g. parsing `/proc/self/maps`).

### Related issues

#1778

### Motivation and context

Previous heuristic `bottom = &sp + MAX_WALK_SIZE` was inaccurate. It successfully rejected obviously invalid pointers, but in rare cases, since `bottom` exceeded the real end of stack, it could allow access to unreadable memory via a plausible-looking pointer. On HotSpot such accesses are recovered by the profiler's SIGSEGV handler, but on JVMs where async-profiler does not interpose signal handlers (e.g. Zing), they crash the process.

### How has this been tested?

- `make test`
- manually verified that `cpu` and `wall` flame graphs of spring-petclinic look fine on Linux x86 and on macOS.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
