### PR TITLE
Reduce flakiness in parseMultiModeRecording on JDK 8

### DIFF
--- a/test/test/jfr/JfrTests.java
+++ b/test/test/jfr/JfrTests.java
@@ -84,7 +84,8 @@ public class JfrTests {
      * @param p The test process to profile with.
      * @throws Exception Any exception thrown during profiling JFR output parsing.
      */
-    @Test(mainClass = JfrMultiModeProfiling.class, agentArgs = "start,event=cpu,alloc,lock=0,quiet,jfr,file=%f", output = true)
+    @Test(mainClass = JfrMultiModeProfiling.class, agentArgs = "start,event=cpu,alloc,lock=0,quiet,jfr,file=%f", output = true, jvmVer = {9, Integer.MAX_VALUE})
+    @Test(mainClass = JfrMultiModeProfiling.class, agentArgs = "start,event=cpu,alloc,lock=0,quiet,jfr,file=%f", output = true, jvmVer = {8, 8}, jvmArgs = "-XX:+UseG1GC -XX:+UseCountedLoopSafepoints")
     public void parseMultiModeRecording(TestProcess p) throws Exception {
         Output output = p.waitForExit(TestProcess.STDOUT);
         assert p.exitCode() == 0;

--- a/test/test/jfr/JfrTests.java
+++ b/test/test/jfr/JfrTests.java
@@ -85,7 +85,7 @@ public class JfrTests {
      * @throws Exception Any exception thrown during profiling JFR output parsing.
      */
     @Test(mainClass = JfrMultiModeProfiling.class, agentArgs = "start,event=cpu,alloc,lock=0,quiet,jfr,file=%f", output = true, jvmVer = {9, Integer.MAX_VALUE})
-    @Test(mainClass = JfrMultiModeProfiling.class, agentArgs = "start,event=cpu,alloc,lock=0,quiet,jfr,file=%f", output = true, jvmVer = {8, 8}, jvmArgs = "-XX:+UseG1GC -XX:+UseCountedLoopSafepoints")
+    @Test(mainClass = JfrMultiModeProfiling.class, agentArgs = "start,event=cpu,alloc,lock=0,quiet,jfr,file=%f", output = true, jvmVer = 8, jvmArgs = "-XX:+UseG1GC -XX:+UseCountedLoopSafepoints")
     public void parseMultiModeRecording(TestProcess p) throws Exception {
         Output output = p.waitForExit(TestProcess.STDOUT);
         assert p.exitCode() == 0;


### PR DESCRIPTION
### Description
The JVM starts a thread's blocked-time clock before it posts the JVMTI contended-enter event that async-profiler timestamps. Posting that event transitions the thread to native, which blocks if a safepoint is pending. Time spent waiting there counts toward ThreadMXBean blocked time but falls outside the profiler's window, lowering the ratio the test asserts. Enabling UseCountedLoopSafepoints brings behavior in line with newer versions.

### Related issues


### Motivation and context
`parseMultiModeRecording` is flaky on JDK 8 on highly-contended GHA runners

### How has this been tested?
Local repro in a docker container based on the GHA runner
The additional flag IgnoreUnrecognizedVMOptions is set because LoopStripMiningIter is not available on JDK 8. It is set on other versions to keep the value the [same as default](https://github.com/openjdk/jdk25u-dev/blob/63176eeac932d12cee18461f7dd84474359e3c5e/src/hotspot/share/gc/g1/g1Arguments.cpp#L234) on newer JDKs

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
