### PR TITLE
Add service.name resource attribute to OTLP output

### DIFF
--- a/src/converter/one/convert/JfrToOtlp.java
+++ b/src/converter/one/convert/JfrToOtlp.java
@@ -101,6 +101,8 @@ public class JfrToOtlp extends JfrConverter {
     @Override
     public void convert() throws IOException {
         long rpMark = proto.startField(PROFILES_DATA_resource_profiles, MSG_LARGE);
+        writeResource();
+
         long spMark = proto.startField(RESOURCE_PROFILES_scope_profiles, MSG_LARGE);
         super.convert();
         proto.commitField(spMark);
@@ -134,6 +136,22 @@ public class JfrToOtlp extends JfrConverter {
         });
 
         proto.commitField(pMark);
+    }
+
+    private void writeResource() {
+        String serviceName = System.getProperty("otel.service.name");
+        if (serviceName == null || serviceName.isEmpty()) {
+            return;
+        }
+
+        long rMark = proto.startField(RESOURCE_PROFILES_resource, MSG_LARGE);
+        long aMark = proto.startField(RESOURCE_attributes, MSG_LARGE);
+        proto.field(KEY_VALUE_key, OTLP_SERVICE_NAME);
+        long vMark = proto.startField(KEY_VALUE_value, MSG_LARGE);
+        proto.field(ANY_VALUE_string_value, serviceName);
+        proto.commitField(vMark);
+        proto.commitField(aMark);
+        proto.commitField(rMark);
     }
 
     private long getPeriod() {

--- a/src/converter/one/convert/OtlpConstants.java
+++ b/src/converter/one/convert/OtlpConstants.java
@@ -8,6 +8,7 @@ package one.convert;
 final class OtlpConstants {
 
     static final String OTLP_THREAD_NAME = "thread.name";
+    static final String OTLP_SERVICE_NAME = "service.name";
 
     static final int
             PROFILES_DICTIONARY_mapping_table = 1,
@@ -22,7 +23,11 @@ final class OtlpConstants {
             PROFILES_DATA_resource_profiles = 1,
             PROFILES_DATA_dictionary = 2;
 
-    static final int RESOURCE_PROFILES_scope_profiles = 2;
+    static final int
+            RESOURCE_PROFILES_resource = 1,
+            RESOURCE_PROFILES_scope_profiles = 2;
+
+    static final int RESOURCE_attributes = 1;
 
     static final int SCOPE_PROFILES_profiles = 2;
 
@@ -64,6 +69,10 @@ final class OtlpConstants {
     static final int
             KEY_VALUE_AND_UNIT_key_strindex = 1,
             KEY_VALUE_AND_UNIT_value = 2;
+
+    static final int
+            KEY_VALUE_key = 1,
+            KEY_VALUE_value = 2;
 
     static final int ANY_VALUE_string_value = 1;
 }

--- a/src/otlp.cpp
+++ b/src/otlp.cpp
@@ -3,10 +3,118 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdlib.h>
+#include <string.h>
 #include "callTraceStorage.h"
 #include "otlp.h"
+#include "vmEntry.h"
 
 namespace Otlp {
+
+class ResourceAttributes {
+  private:
+    JNIEnv* _jni;
+    jclass _system_class;
+    jmethodID _get_property;
+    jstring _jstr;
+    const char* _chars;
+    char _buf[256];
+
+    // Invalid input produces garbage, which is acceptable here
+    static int hexDigit(char c) {
+        return c <= '9' ? c - '0' : (c & ~0x20) - ('A' - 10);
+    }
+
+    // Copy the value until the next ',' or whitespace, decoding %XX on the way
+    const char* unescape(const char* s) {
+        size_t len = 0;
+        while (*s > ' ' && *s != ',' && len < sizeof(_buf) - 1) {
+            char c = *s++;
+            if (c == '%' && s[0] && s[1]) {
+                c = (char)(hexDigit(s[0]) << 4 | hexDigit(s[1]));
+                s += 2;
+            }
+            _buf[len++] = c;
+        }
+        _buf[len] = 0;
+        return _buf;
+    }
+
+    const char* getSystemProperty(const char* key) {
+        if (_get_property == nullptr) return nullptr;
+        releaseString();
+
+        jstring jkey = _jni->NewStringUTF(key);
+        _jstr = jkey == nullptr ? nullptr : (jstring)_jni->CallStaticObjectMethod(_system_class, _get_property, jkey);
+        _chars = _jstr == nullptr ? nullptr : _jni->GetStringUTFChars(_jstr, nullptr);
+        _jni->ExceptionClear();
+        return _chars;
+    }
+
+    void releaseString() {
+        if (_chars != nullptr) {
+            _jni->ReleaseStringUTFChars(_jstr, _chars);
+        }
+    }
+
+    // Extract attribute from a comma-separated list of key=value pairs (W3C Baggage format)
+    const char* getAttribute(const char* list, const char* attr) {
+        for (const char* s = strstr(list, attr); s != nullptr; s = strstr(s + 1, attr)) {
+            if (s > list && s[-1] != ',' && s[-1] > ' ') {
+                continue;  // not at the start of a list entry
+            }
+
+            const char* p = s + strlen(attr);
+            while (*p == ' ' || *p == '\t') p++;
+            if (*p++ != '=') continue;
+            while (*p == ' ' || *p == '\t') p++;
+
+            return unescape(p);
+        }
+        return nullptr;
+    }
+
+  public:
+    ResourceAttributes() : _jni(VM::jni()), _system_class(nullptr), _get_property(nullptr), _chars(nullptr) {
+        if (_jni != nullptr) {
+            _jni->PushLocalFrame(16);
+            if ((_system_class = _jni->FindClass("java/lang/System")) == nullptr ||
+                (_get_property = _jni->GetStaticMethodID(_system_class, "getProperty", "(Ljava/lang/String;)Ljava/lang/String;")) == nullptr) {
+                _jni->ExceptionClear();
+            }
+        }
+    }
+
+    ~ResourceAttributes() {
+        if (_jni != nullptr) {
+            releaseString();
+            _jni->PopLocalFrame(nullptr);
+        }
+    }
+
+    const char* getServiceName() {
+        const char* s = getSystemProperty("otel.service.name");
+        if (s != nullptr && s[0]) {
+            return s;
+        }
+
+        s = getenv("OTEL_SERVICE_NAME");
+        if (s != nullptr && s[0]) {
+            return s;
+        }
+
+        const char* attrs = getSystemProperty("otel.resource.attributes");
+        if (attrs != nullptr && (s = getAttribute(attrs, OTLP_SERVICE_NAME)) != nullptr && s[0]) {
+            return s;
+        }
+
+        attrs = getenv("OTEL_RESOURCE_ATTRIBUTES");
+        if (attrs != nullptr && (s = getAttribute(attrs, OTLP_SERVICE_NAME)) != nullptr && s[0]) {
+            return s;
+        }
+        return nullptr;
+    }
+};
 
 void Recorder::recordProfilesDictionary(const std::vector<CallTraceSample*>& call_trace_samples) {
     protobuf_mark_t dictionary_mark = _otlp_buffer.startMessage(ProfilesData::dictionary);
@@ -78,7 +186,7 @@ void Recorder::recordStacks(const std::vector<CallTraceSample*>& call_trace_samp
 
     for (const auto& cts : call_trace_samples) {
         CallTrace* trace = cts->acquireTrace();
-        if (trace == NULL || _fn.excludeTrace(trace) || cts->samples == 0) continue;
+        if (trace == nullptr || _fn.excludeTrace(trace) || cts->samples == 0) continue;
 
         protobuf_mark_t stack_mark = _otlp_buffer.startMessage(ProfilesDictionary::stack_table);
         protobuf_mark_t location_indices_mark = _otlp_buffer.startMessage(Stack::location_indices);
@@ -131,16 +239,34 @@ void Recorder::recordOtlpProfile(size_t type_strindex, size_t unit_strindex, boo
     _otlp_buffer.commitMessage(profile_mark);
 }
 
+void Recorder::recordResource() {
+    ResourceAttributes attributes;
+    const char* service_name = attributes.getServiceName();
+    if (service_name == nullptr) {
+        return;
+    }
+
+    protobuf_mark_t resource_mark = _otlp_buffer.startMessage(ResourceProfiles::resource);
+    protobuf_mark_t attribute_mark = _otlp_buffer.startMessage(Resource::attributes);
+    _otlp_buffer.field(KeyValue::key, OTLP_SERVICE_NAME);
+    protobuf_mark_t value_mark = _otlp_buffer.startMessage(KeyValue::value);
+    _otlp_buffer.field(AnyValue::string_value, service_name);
+    _otlp_buffer.commitMessage(value_mark);
+    _otlp_buffer.commitMessage(attribute_mark);
+    _otlp_buffer.commitMessage(resource_mark);
+}
+
 void Recorder::record(const std::vector<CallTraceSample*>& call_trace_samples, bool samples) {
     recordProfilesDictionary(call_trace_samples);
 
     protobuf_mark_t resource_profiles_mark = _otlp_buffer.startMessage(ProfilesData::resource_profiles);
-    protobuf_mark_t scope_profiles_mark = _otlp_buffer.startMessage(ResourceProfiles::scope_profiles);
+    recordResource();
 
+    protobuf_mark_t scope_profiles_mark = _otlp_buffer.startMessage(ResourceProfiles::scope_profiles);
     size_t unit_strindex = samples ? _count_strindex : _engine_unit_strindex;
     recordOtlpProfile(_engine_type_strindex, unit_strindex, samples);
-
     _otlp_buffer.commitMessage(scope_profiles_mark);
+
     _otlp_buffer.commitMessage(resource_profiles_mark);
 }
 

--- a/src/otlp.h
+++ b/src/otlp.h
@@ -20,6 +20,8 @@ namespace Otlp {
 const u32 OTLP_BUFFER_INITIAL_SIZE = 5120;
 // https://opentelemetry.io/docs/specs/semconv/registry/attributes/thread/#thread-name
 const char* const OTLP_THREAD_NAME = "thread.name";
+// https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-name
+const char* const OTLP_SERVICE_NAME = "service.name";
 
 namespace ProfilesDictionary {
     const protobuf_index_t mapping_table = 1;
@@ -37,7 +39,12 @@ namespace ProfilesData {
 }
 
 namespace ResourceProfiles {
+    const protobuf_index_t resource = 1;
     const protobuf_index_t scope_profiles = 2;
+}
+
+namespace Resource {
+    const protobuf_index_t attributes = 1;
 }
 
 namespace ScopeProfiles {
@@ -87,6 +94,11 @@ namespace Line {
     const protobuf_index_t function_index = 1;
 }
 
+namespace KeyValue {
+    const protobuf_index_t key = 1;
+    const protobuf_index_t value = 2;
+}
+
 namespace KeyValueAndUnit {
     const protobuf_index_t key_strindex = 1;
     const protobuf_index_t value = 2;
@@ -119,6 +131,7 @@ class Recorder {
 
     // Record a profile with a specified sample type
     void recordOtlpProfile(size_t type_strindex, size_t unit_strindex, bool samples);
+    void recordResource();
     void recordValueType(protobuf_index_t field_index, size_t type_strindex, size_t unit_strindex);
     void recordStacks(const std::vector<CallTraceSample*>& call_trace_samples);
     void recordProfilesDictionary(const std::vector<CallTraceSample*>& call_trace_samples);

--- a/test/test/otlp/OtlpTests.java
+++ b/test/test/otlp/OtlpTests.java
@@ -17,7 +17,9 @@ import one.jfr.JfrReader;
 import one.profiler.test.*;
 
 import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.profiles.v1development.*;
+import io.opentelemetry.proto.resource.v1.Resource;
 
 public class OtlpTests {
     @Test(mainClass = CpuBurner.class, agentArgs = "start,otlp,event=itimer,file=%f.pb")
@@ -125,6 +127,37 @@ public class OtlpTests {
             found = found || sample.getTimestampsUnixNanoList().size() > 1;
         }
         assert found : "No sample contains more than one timestamp";
+    }
+
+    @Test(mainClass = CpuBurner.class, agentArgs = "start,otlp,file=%f.pb",
+          jvmArgs = "-Dotel.service.name=sysprop-service",
+          env = {"OTEL_SERVICE_NAME=env-service"})
+    public void serviceNameFromSystemProperty(TestProcess p) throws Exception {
+        assertServiceName(waitAndGetProfilesData(p), "sysprop-service");
+    }
+
+    @Test(mainClass = CpuBurner.class, agentArgs = "start,otlp,file=%f.pb",
+          jvmArgs = "-Dotel.resource.attributes=service.namespace=shop,service.name=attr%20service",
+          env = {"OTEL_RESOURCE_ATTRIBUTES=service.name=env-attr-service"})
+    public void serviceNameFromResourceAttributes(TestProcess p) throws Exception {
+        assertServiceName(waitAndGetProfilesData(p), "attr service");
+    }
+
+    @Test(mainClass = CpuBurner.class, agentArgs = "start,otlp,file=%f.pb",
+          env = {"OTEL_RESOURCE_ATTRIBUTES=deployment.environment=prod, service.name=env-attr-service"})
+    public void serviceNameFromResourceAttributesEnv(TestProcess p) throws Exception {
+        assertServiceName(waitAndGetProfilesData(p), "env-attr-service");
+    }
+
+    private static void assertServiceName(ProfilesData profilesData, String expected) {
+        Resource resource = profilesData.getResourceProfiles(0).getResource();
+        for (KeyValue kv : resource.getAttributesList()) {
+            if (kv.getKey().equals("service.name")) {
+                assertString(kv.getValue().getStringValue(), expected);
+                return;
+            }
+        }
+        assert false : "service.name attribute not found: " + resource;
     }
 
     @Test(mainClass = OtlpProfileTimeTest.class)


### PR DESCRIPTION
### Description

OTLP profiles now include the `service.name` resource attribute, resolved according to OpenTelemetry SDK conventions, in the following lookup order:

1. `otel.service.name` system property
2. `OTEL_SERVICE_NAME` environment variable
3. `service.name` key in `otel.resource.attributes` system property
4. `service.name` key in `OTEL_RESOURCE_ATTRIBUTES` environment variable

When no service name is configured, the attribute is omitted.

### Motivation and context

Profiling backends (e.g. Grafana Pyroscope) use `service.name` to attribute profiles to a service.
Without it, all profiles will be displayed under `unknown`.

### How has this been tested?

+3 new integration tests

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
