### PR TITLE
Fix stack walking edge cases on ARM64 and GraalVM

### DIFF
--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -257,6 +257,7 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
         if (details) {
             anchor = vm_thread->anchor();
         } else if (!vm_thread->anchor()->restoreFrame(pc, sp, fp)) {
+            crash_protection_ctx[lock_index] = NULL;
             return 0;
         }
     }
@@ -313,6 +314,11 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
                         fillFrame(frames[depth++], FRAME_INTERPRETED, bci, method_id);
 
                         sp = ((uintptr_t*)fp)[InterpreterFrame::sender_sp_offset];
+                        if (sp < fp + 2 * sizeof(void*)) {
+                            // Stored sender_sp is the "unextended" SP, which can be less than SP
+                            // on AArch64 and RISC-V. Raw sender_sp is two words below FP.
+                            sp = fp + 2 * sizeof(void*);
+                        }
                         pc = stripPointer(((void**)fp)[FRAME_PC_SLOT]);
                         fp = *(uintptr_t*)fp;
                         continue;
@@ -377,8 +383,8 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
                 fillFrame(frames[depth++], BCI_ERROR, "break_compiled");
                 break;
             } else if (nm->isEntryFrame(pc) && !features.mixed) {
-                JavaFrameAnchor* next_anchor = JavaFrameAnchor::fromEntryFrame(fp);
-                if (next_anchor == NULL) {
+                JavaFrameAnchor* next_anchor;
+                if (fp < sp || fp >= bottom || !aligned(fp) || (next_anchor = JavaFrameAnchor::fromEntryFrame(fp)) == NULL) {
                     fillFrame(frames[depth++], BCI_ERROR, "break_entry_frame");
                     break;
                 }

--- a/src/vmStructs.h
+++ b/src/vmStructs.h
@@ -360,9 +360,7 @@ class JavaFrameAnchor : VMStructs {
         }
 
         sp = lastJavaSP();
-        if ((fp = lastJavaFP()) == 0) {
-            fp = sp;
-        }
+        fp = lastJavaFP();
         if ((pc = lastJavaPC()) == NULL) {
             pc = ((const void**)sp)[-1];
         }


### PR DESCRIPTION
### Description

This PR fixes two problems with VMStructs stack walker:
1. `tlabAllocSampler` test failure with GraalVM.
2. `break_stack_range` errors with `tlab` allocation profiling on ARM64.

Additionally, it addresses two more issues found during code review:
1. Crash protection cleanup was missing on the path where `restoreFrame` fails.
2. `JavaFrameAnchor::fromEntryFrame` may potentially dereference garbage `fp`.

### Motivation and context

I found these issues while analyzing profiles collected with `alloc,tlab` options.

**On GraalVM/x86, most of stacks were broken.**

GraalVM's `Stub<new_instance_or_null(KlassPointer)Object>` frame, which has a normal prologue/epilogue, was unwound through the `frame.unwindStub()` path. That resulted in a wrong PC address, because `fp` was reconstructed incorrectly from the incomplete JavaFrameAnchor. If we keep `fp` zero as in the anchor, `unwindStub()` will return `false`, and the stub will be then correctly unwound through the `if (nm->frameSize() > 0)` path.

**On AArch64, some stacks were incomplete.**

A few stacks ended with an interpreter frame followed by `[break_stack_range]`.
That resulted from the failed `sp < prev_sp` condition. AArch64 interpreter frames may have sender_sp < sp. This is because sender_sp saved in a frame is "unextended" sp. Raw sender_sp is always 2 words away from the frame pointer.

### How has this been tested?

All tests pass with GraalVM 25 on x86 and ARM64.
Manually checked that `alloc,tlab` profiles have no more broken stacks.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
