### PR TITLE
Align sampling behaviour across output formats

### DIFF
--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -494,8 +494,9 @@ u64 Profiler::recordSample(void* ucontext, u64 counter, EventType event_type, Ev
 
 void Profiler::recordExternalSample(u64 counter, int tid, EventType event_type, Event* event, int num_frames, ASGCT_CallFrame* frames) {
     atomicInc(_total_samples);
+    int lock_index;
 
-    if (!RateLimit::allow(event_type)) {
+    if (!RateLimit::allow(event_type) || (lock_index = tryLock(tid)) < 0) {
         atomicInc(_failures[-ticks_skipped]);
         return;
     }
@@ -508,31 +509,23 @@ void Profiler::recordExternalSample(u64 counter, int tid, EventType event_type, 
     }
 
     u32 call_trace_id = _call_trace_storage.put(num_frames, frames, counter);
-
-    int lock_index = tryLock(tid);
-    if (lock_index < 0) {
-        // Too many concurrent signals already
-        atomicInc(_failures[-ticks_skipped]);
-        return;
-    }
-
     _jfr.recordEvent(lock_index, tid, call_trace_id, event_type, event);
 
     unlock(lock_index);
 }
 
 void Profiler::recordExternalSamples(u64 samples, u64 counter, int tid, u32 call_trace_id, EventType event_type, Event* event) {
-    if (!RateLimit::allow(event_type)) {
+    atomicInc(_total_samples, samples);
+
+    int lock_index;
+    if (!RateLimit::allow(event_type) || (lock_index = tryLock(tid)) < 0) {
+        atomicInc(_failures[-ticks_skipped], samples);
         return;
     }
 
     _call_trace_storage.add(call_trace_id, samples, counter);
-
-    int lock_index = tryLock(tid);
-    if (lock_index >= 0) {
-        _jfr.recordEvent(lock_index, tid, call_trace_id, event_type, event);
-        unlock(lock_index);
-    }
+    _jfr.recordEvent(lock_index, tid, call_trace_id, event_type, event);
+    unlock(lock_index);
 }
 
 void Profiler::recordEventOnly(EventType event_type, Event* event) {


### PR DESCRIPTION
### Description
I noticed that for the `recordExternalSample`  & `recordExternalSamples` we save the stack trace before a lock is acquired.

This means the output generated by the profiler might differ depending on the format selected by the user
- If JFR is selected then the events/samples will not be reported
- If Collapsed/Flamegraph is selected then the samples will be reported 

This change simply moves the lock check to be done first:
- The generated output will be the same no matter the output format
- Avoids recording unneeded traces when using JFR output formats

A secondary issue this change fixes, is the fact that `recordExternalSamples` did not update the `_total_samples` & the `_failures[-ticks_skipped]` counters

### Related issues
N/A

### Motivation and context
- Make the profiler output more consistent across the various output formats
- Account for `recordExternalSamples` in the sampling stats

### How has this been tested?
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
