### PR TITLE
Fix JfrConverter.excludeStack() NullPointerException

### DIFF
--- a/src/converter/one/convert/JfrConverter.java
+++ b/src/converter/one/convert/JfrConverter.java
@@ -155,14 +155,16 @@ public abstract class JfrConverter extends Classifier {
         }
 
         StackTrace stackTrace = jfr.stackTraces.get(stackId);
-        for (int i = 0; i < stackTrace.methods.length; i++) {
-            String name = getMethodName(stackTrace.methods[i], stackTrace.types[i]);
-            if (exclude != null && exclude.matcher(name).matches()) {
-                return true;
-            }
-            if (include != null && include.matcher(name).matches()) {
-                if (exclude == null) return false;
-                include = null;
+        if (stackTrace != null) {
+            for (int i = 0; i < stackTrace.methods.length; i++) {
+                String name = getMethodName(stackTrace.methods[i], stackTrace.types[i]);
+                if (exclude != null && exclude.matcher(name).matches()) {
+                    return true;
+                }
+                if (include != null && include.matcher(name).matches()) {
+                    if (exclude == null) return false;
+                    include = null;
+                }
             }
         }
         return include != null;


### PR DESCRIPTION
### Description

This PR fixes a `NullPointerException` in `JfrConverter.excludeStack()` by adding a `null` check.

### Related issues

None

### Motivation and context

Sometimes an event `stackTraceId` may not have a corresponding stack trace, and various parts of the converter (for example `JfrToPprof` and `JfrToFlame`) already perform `null` checks when accessing `jfr.stackTraces`. But `JfrConverter.excludeStack()` does not have such a `null` check, which sometimes causes `NullPointerException` during conversion with exclusions (from async-profiler 4.5):

```
java.lang.NullPointerException: Cannot read field "methods" because "<local7>" is null
	at one.convert.JfrConverter.excludeStack(JfrConverter.java:158)
	at one.convert.JfrToPprof$1.visit(JfrToPprof.java:41)
	at one.convert.JfrConverter$AggregatedEventVisitor.visit(JfrConverter.java:368)
	at one.jfr.event.EventAggregator.forEach(EventAggregator.java:86)
	at one.convert.JfrToPprof.convertChunk(JfrToPprof.java:36)
	at one.convert.JfrConverter.convert(JfrConverter.java:47)
	at one.convert.JfrToPprof.convert(JfrToPprof.java:150)
	at one.convert.Main.convert(Main.java:87)
	at one.convert.Main.main(Main.java:75)
```

### How has this been tested?

The fixed `jfrconv` successfully converts a JFR file that causes the aforementioned crash with async-profiler 4.5 and also on `master`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
