### PR TITLE
Fingerprint-based detection of idle threads during wall clock profiling

### DIFF
--- a/src/os.h
+++ b/src/os.h
@@ -114,6 +114,7 @@ class OS {
     static const char* schedPolicy(int thread_id);
     static bool threadName(int thread_id, char* name_buf, size_t name_len);
     static ThreadState threadState(int thread_id);
+    static u64 threadFingerprint(int thread_id);
     static u64 threadCpuTime(int thread_id);
     static ThreadList* listThreads();
 

--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -11,6 +11,7 @@
 #include <dlfcn.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <link.h>
 #include <sched.h>
 #include <stdio.h>
@@ -185,10 +186,17 @@ const char* OS::schedPolicy(int thread_id) {
     return "SCHED_OTHER";
 }
 
+static int openTaskFile(const char* file, int flags) {
+    // Opening a file under a directory tree is ~25% faster when accessing via a pre-resolved dir_fd
+    static const int task_dir_fd = open("/proc/self/task", O_RDONLY | O_CLOEXEC);
+
+    return openat(task_dir_fd, file, flags);
+}
+
 bool OS::threadName(int thread_id, char* name_buf, size_t name_len) {
     char buf[64];
-    snprintf(buf, sizeof(buf), "/proc/self/task/%d/comm", thread_id);
-    int fd = open(buf, O_RDONLY);
+    snprintf(buf, sizeof(buf), "%d/comm", thread_id);
+    int fd = openTaskFile(buf, O_RDONLY);
     if (fd == -1) {
         return false;
     }
@@ -205,8 +213,8 @@ bool OS::threadName(int thread_id, char* name_buf, size_t name_len) {
 
 ThreadState OS::threadState(int thread_id) {
     char buf[512];
-    snprintf(buf, sizeof(buf), "/proc/self/task/%d/stat", thread_id);
-    int fd = open(buf, O_RDONLY);
+    snprintf(buf, sizeof(buf), "%d/stat", thread_id);
+    int fd = openTaskFile(buf, O_RDONLY);
     if (fd == -1) {
         return THREAD_UNKNOWN;
     }
@@ -219,6 +227,39 @@ ThreadState OS::threadState(int thread_id) {
 
     close(fd);
     return state;
+}
+
+// Returns fingerprint (mix of PC and SP) of a thread's blocked state or 0 if a thread is not blocked.
+// Fingerprint allows checking if a thread is blocked on the same syscall as before without signaling.
+u64 OS::threadFingerprint(int thread_id) {
+    char buf[512];
+    snprintf(buf, sizeof(buf), "%d/syscall", thread_id);
+    int fd = openTaskFile(buf, O_RDONLY);
+    if (fd == -1) {
+        return 0;
+    }
+
+    ssize_t r = read(fd, buf, sizeof(buf) - 1);
+    close(fd);
+    buf[r > 0 ? r : 0] = 0;
+
+    // 3 possible patterns (we are interested only in the first one):
+    //   blocked on a syscall:    <nr> <arg1> .. <arg6> <sp> <pc>
+    //   blocked outside syscall: -1 <sp> <pc>
+    //   not blocked:             running
+    char* s = buf;
+    for (int i = 0; i < 7; i++) {
+        if ((s = strchr(s, ' ')) == NULL) return 0;
+        s++;
+    }
+
+    u64 sp = strtoull(s, &s, 16);
+    if (sp == 0 || sp == ULLONG_MAX || *s == 0) return 0;
+
+    u64 pc = strtoull(s + 1, NULL, 16);
+    if (pc == 0 || pc == ULLONG_MAX) return 0;
+
+    return sp << 32 ^ pc;
 }
 
 u64 OS::threadCpuTime(int thread_id) {

--- a/src/os_macos.cpp
+++ b/src/os_macos.cpp
@@ -192,6 +192,29 @@ ThreadState OS::threadState(int thread_id) {
     return info.run_state == TH_STATE_RUNNING ? THREAD_RUNNING : THREAD_SLEEPING;
 }
 
+u64 OS::threadFingerprint(int thread_id) {
+    // Avoid thread_get_state() for running threads
+    // as it forcibly stops the thread for reading its state.
+    if (threadState(thread_id) == THREAD_RUNNING) {
+        return 0;
+    }
+
+#if defined(__x86_64__)
+    x86_thread_state64_t state;
+    mach_msg_type_number_t count = x86_THREAD_STATE64_COUNT;
+    if (thread_get_state((thread_act_t)thread_id, x86_THREAD_STATE64, (thread_state_t)&state, &count) == 0) {
+        return state.__rsp << 32 ^ state.__rip;
+    }
+#elif defined(__aarch64__)
+    arm_thread_state64_t state;
+    mach_msg_type_number_t count = ARM_THREAD_STATE64_COUNT;
+    if (thread_get_state((thread_act_t)thread_id, ARM_THREAD_STATE64, (thread_state_t)&state, &count) == 0) {
+        return state.__sp << 32 ^ state.__pc;
+    }
+#endif
+    return 0;
+}
+
 u64 OS::threadCpuTime(int thread_id) {
     if (thread_id == 0) thread_id = threadId();
 

--- a/src/wallClock.cpp
+++ b/src/wallClock.cpp
@@ -24,9 +24,11 @@ const int THREADS_PER_TICK = 8;
 // Smaller intervals are practically unusable due to large overhead.
 const long long MIN_INTERVAL = 100000;
 
-// How much CPU time a thread can spend after being sampled as idle
-// until it is considered runnable.
-const u64 RUNNABLE_THRESHOLD_NS = 10000;
+// A thread that ran for less than IDLE_THRESHOLD_NS since last iteration is considered idle.
+const u64 IDLE_THRESHOLD_NS = 10000;
+
+// Maximum amount of CPU time a thread may spend to be eligible for wall clock event batching.
+const u64 BATCH_CPU_THRESHOLD_NS = 200000;
 
 // How many skipped idle samples can be recorded in a single WallClock event.
 const u32 MAX_IDLE_BATCH = 1000;
@@ -36,6 +38,7 @@ struct ThreadSleepState {
     u64 start_time;
     u64 last_time;
     u64 last_cpu_time;
+    u64 fingerprint;
     u32 call_trace_id;
     u32 counter;
 };
@@ -44,6 +47,7 @@ typedef std::map<int, ThreadSleepState> ThreadSleepMap;
 
 struct ThreadCpuTime {
     u64 cpu_time;
+    u64 fingerprint;
     u64 trace;
 };
 
@@ -72,8 +76,9 @@ class ThreadCpuTimeBuffer {
         storeRelease(_write_ptr, 0);
     }
 
-    void add(u64 trace) {
+    void add(u64 fingerprint, u64 trace) {
         ThreadCpuTime& t = _ringbuf[atomicInc(_write_ptr) & (RINGBUF_SIZE - 1)];
+        t.fingerprint = fingerprint;
         t.trace = trace;
         storeRelease(t.cpu_time, OS::threadCpuTime(0));
     }
@@ -87,11 +92,13 @@ class ThreadCpuTimeBuffer {
                 break;
             }
 
+            u64 fingerprint = t.fingerprint;
             u64 trace = t.trace;
             if (__sync_bool_compare_and_swap(&t.cpu_time, cpu_time, 0)) {
                 int thread_id = trace >> 32;
                 ThreadSleepState& tss = thread_sleep_state[thread_id];
                 tss.last_cpu_time = cpu_time;
+                tss.fingerprint = fingerprint;
                 tss.call_trace_id = (u32)trace;
                 tss.counter = 0;
                 _read_ptr++;
@@ -109,41 +116,47 @@ long WallClock::_interval;
 int WallClock::_signal;
 WallClock::Mode WallClock::_mode;
 
-ThreadState WallClock::getThreadState(void* ucontext) {
+// Gets fingerprint (as in OS::threadFingerprint) from the signal context of the current thread.
+// Fingerprint is zero for running threads and non-zero for threads blocked on a syscall.
+u64 WallClock::getThreadFingerprint(void* ucontext) {
     StackFrame frame(ucontext);
     uintptr_t pc = frame.pc();
 
     // Consider a thread sleeping, if it has been interrupted in the middle of syscall execution,
     // either when PC points to the syscall instruction, or if syscall has just returned with EINTR
     if (StackFrame::isSyscall((instruction_t*)pc)) {
-        return THREAD_SLEEPING;
+        return ((u64)frame.sp() << 32) ^ (pc + SYSCALL_SIZE);
     }
 
     // Make sure the previous instruction address is readable
     uintptr_t prev_pc = pc - SYSCALL_SIZE;
     if ((pc & 0xfff) >= SYSCALL_SIZE || Profiler::instance()->findLibraryByAddress((instruction_t*)prev_pc) != NULL) {
         if (StackFrame::isSyscall((instruction_t*)prev_pc) && frame.checkInterruptedSyscall()) {
-            return THREAD_SLEEPING;
+            return ((u64)frame.sp() << 32) ^ pc;
         }
     }
 
-    return THREAD_RUNNING;
+    return 0;
 }
 
 void WallClock::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
+    u64 start_time = TSC::ticks();
     if (_mode == WALL_BATCH) {
+        u64 fingerprint = getThreadFingerprint(ucontext);
         WallClockEvent event;
-        event._start_time = TSC::ticks();
+        event._start_time = start_time;
         event._time_span = 0;
-        event._thread_state = getThreadState(ucontext);
+        event._thread_state = fingerprint == 0 ? THREAD_RUNNING : THREAD_SLEEPING;
         event._samples = 1;
         u64 trace = Profiler::instance()->recordSample(ucontext, _interval, WALL_CLOCK_SAMPLE, &event);
-        if (event._thread_state == THREAD_SLEEPING && trace != 0) {
-            _thread_cpu_time_buf.add(trace);
+        if (fingerprint != 0 && trace != 0) {
+            _thread_cpu_time_buf.add(fingerprint, trace);
         }
     } else {
-        ExecutionEvent event(TSC::ticks());
-        event._thread_state = _mode == CPU_ONLY ? THREAD_UNKNOWN : getThreadState(ucontext);
+        ExecutionEvent event(start_time);
+        if (_mode != CPU_ONLY) {
+            event._thread_state = getThreadFingerprint(ucontext) == 0 ? THREAD_RUNNING : THREAD_SLEEPING;
+        }
         Profiler::instance()->recordSample(ucontext, _interval, EXECUTION_SAMPLE, &event);
     }
 }
@@ -231,14 +244,26 @@ void WallClock::timerLoop() {
             } else if (mode == WALL_BATCH) {
                 MutexLocker ml(_thread_sleep_state_lock);
                 ThreadSleepState& tss = _thread_sleep_state[thread_id];
-                u64 new_thread_cpu_time = enabled ? OS::threadCpuTime(thread_id) : 0;
-                if (new_thread_cpu_time != 0 && new_thread_cpu_time - tss.last_cpu_time <= RUNNABLE_THRESHOLD_NS) {
-                    tss.last_time = TSC::ticks();
-                    if (++tss.counter < MAX_IDLE_BATCH) {
-                        if (tss.counter == 1) {
-                            tss.start_time = tss.last_time;
+                if (enabled && tss.last_cpu_time != 0) {
+                    u64 new_thread_cpu_time = OS::threadCpuTime(thread_id);
+                    // Fast check: thread has not spent enough CPU time since last sampling
+                    bool idle = new_thread_cpu_time - tss.last_cpu_time <= IDLE_THRESHOLD_NS;
+                    // 2nd level check: thread spent some CPU time, but is now blocked on the same syscall
+                    if (!idle && new_thread_cpu_time - tss.last_cpu_time <= BATCH_CPU_THRESHOLD_NS &&
+                            OS::threadFingerprint(thread_id) == tss.fingerprint) {
+                        tss.last_cpu_time = new_thread_cpu_time;
+                        idle = true;
+                    }
+                    if (idle) {
+                        tss.last_time = TSC::ticks();
+                        if (++tss.counter < MAX_IDLE_BATCH) {
+                            if (tss.counter == 1) {
+                                tss.start_time = tss.last_time;
+                            }
+                            continue;
                         }
-                        continue;
+                    } else {
+                        tss.last_cpu_time = 0;
                     }
                 }
                 if (tss.counter != 0) {

--- a/src/wallClock.cpp
+++ b/src/wallClock.cpp
@@ -28,7 +28,7 @@ const long long MIN_INTERVAL = 100000;
 const u64 IDLE_THRESHOLD_NS = 10000;
 
 // Maximum amount of CPU time a thread may spend to be eligible for wall clock event batching.
-const u64 BATCH_CPU_THRESHOLD_NS = 200000;
+const u64 BATCH_CPU_THRESHOLD_NS = 500000;
 
 // How many skipped idle samples can be recorded in a single WallClock event.
 const u32 MAX_IDLE_BATCH = 1000;
@@ -245,15 +245,19 @@ void WallClock::timerLoop() {
                 MutexLocker ml(_thread_sleep_state_lock);
                 ThreadSleepState& tss = _thread_sleep_state[thread_id];
                 if (enabled && tss.last_cpu_time != 0) {
-                    u64 new_thread_cpu_time = OS::threadCpuTime(thread_id);
+                    u64 cpu_time_delta = OS::threadCpuTime(thread_id) - tss.last_cpu_time;
                     // Fast check: thread has not spent enough CPU time since last sampling
-                    bool idle = new_thread_cpu_time - tss.last_cpu_time <= IDLE_THRESHOLD_NS;
+                    bool idle = cpu_time_delta <= IDLE_THRESHOLD_NS;
                     // 2nd level check: thread spent some CPU time, but is now blocked on the same syscall
-                    if (!idle && new_thread_cpu_time - tss.last_cpu_time <= BATCH_CPU_THRESHOLD_NS &&
-                            OS::threadFingerprint(thread_id) == tss.fingerprint) {
-                        tss.last_cpu_time = new_thread_cpu_time;
+                    if (!idle && cpu_time_delta <= BATCH_CPU_THRESHOLD_NS &&
+                            tss.fingerprint != 0 && OS::threadFingerprint(thread_id) == tss.fingerprint) {
+                        tss.last_cpu_time += cpu_time_delta;
                         idle = true;
                     }
+                    // Fingerprint check is one-shot protection from EINTR wakeup.
+                    // We still need to detect genuine wakeups.
+                    tss.fingerprint = 0;
+
                     if (idle) {
                         tss.last_time = TSC::ticks();
                         if (++tss.counter < MAX_IDLE_BATCH) {

--- a/src/wallClock.h
+++ b/src/wallClock.h
@@ -6,7 +6,6 @@
 #ifndef _WALLCLOCK_H
 #define _WALLCLOCK_H
 
-#include <jvmti.h>
 #include <signal.h>
 #include <pthread.h>
 #include "engine.h"
@@ -36,7 +35,7 @@ class WallClock : public Engine {
         return NULL;
     }
 
-    static ThreadState getThreadState(void* ucontext);
+    static u64 getThreadFingerprint(void* ucontext);
 
     static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext);
 


### PR DESCRIPTION
### Description

In wall clock mode, do not send a profiling signal to a thread that is still blocked on the same syscall where the previous sample was taken.

When a sample is taken, the signal handler computes a *fingerprint* of the blocking site - a mix of PC and SP of the interrupted syscall. On subsequent iterations, the timer thread obtains a fingerprint without waking up the thread: on Linux from `/proc/self/task/<tid>/syscall`, on macOS via `thread_get_state()`. If the fingerprint matches and the thread has spent less than 0.5 ms of CPU time since the last sample, the thread is considered blocked inside the same syscall.

### Motivation and context

Delivering a profiling signal to a sleeping thread wakes it up. If the thread was blocked in `epoll_wait`, `poll` or `select` (every NIO event loop uses one of these), the interrupted syscall is not restarted by the kernel; the JDK recomputes the timeout and re-executes the syscall in userspace.

This creates a vicious cycle: the profiling signal makes an idle thread burn CPU, and this CPU usage makes the profiler treat the thread as active and signal it again. As a result:

- wall clock recordings are bloated with identical events having `samples=1` and the same "sleeping" stack;
- idle event-loop threads (Netty, Tomcat, etc.) show 10-100x higher CPU usage under profiling.

### How has this been tested?

A demo application with idle NIO selector, event-loop and `Object.wait()` threads plus one busy thread per core, profiled with `-e wall -i 10ms`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
