### PR TITLE
Dragonwell JDK: SIGSEGV in isStaleMethodId() at JFR dump #1794

### DIFF
--- a/src/vmStructs.cpp
+++ b/src/vmStructs.cpp
@@ -62,6 +62,7 @@ int VMStructs::_nmethod_state_offset = -1;
 int VMStructs::_nmethod_level_offset = -1;
 int VMStructs::_nmethod_metadata_offset = -1;
 int VMStructs::_nmethod_immutable_offset = -1;
+int VMStructs::_nmethod_immutable_size_offset = -1;
 int VMStructs::_method_constmethod_offset = -1;
 int VMStructs::_method_code_offset = -1;
 int VMStructs::_constmethod_constants_offset = -1;
@@ -214,6 +215,8 @@ void VMStructs::initOffsets() {
                     _nmethod_metadata_offset = *(int*)(entry + offset_offset);
                 } else if (strcmp(field, "_immutable_data") == 0) {
                     _nmethod_immutable_offset = *(int*)(entry + offset_offset);
+                } else if (strcmp(field, "_immutable_data_size") == 0) {
+                    _nmethod_immutable_size_offset = *(int*)(entry + offset_offset);
                 } else if (strcmp(field, "_scopes_pcs_offset") == 0) {
                     _scopes_pcs_offset = *(int*)(entry + offset_offset);
                 } else if (strcmp(field, "_scopes_data_offset") == 0) {
@@ -520,8 +523,10 @@ void VMStructs::resolveOffsets() {
     }
 
     // Since JDK 23, _metadata_offset is relative to _data_offset. See metadata()
-    if (_nmethod_immutable_offset < 0) {
+    if (VM::hotspot_version() < 23) {
         _data_offset = 0;
+    } else {
+        _nmethod_immutable_size_offset = -1;
     }
 
     _has_stack_structs = _has_method_structs

--- a/src/vmStructs.h
+++ b/src/vmStructs.h
@@ -88,6 +88,7 @@ class VMStructs {
     static int _nmethod_level_offset;
     static int _nmethod_metadata_offset;
     static int _nmethod_immutable_offset;
+    static int _nmethod_immutable_size_offset;
     static int _method_constmethod_offset;
     static int _method_code_offset;
     static int _constmethod_constants_offset;
@@ -466,7 +467,10 @@ class NMethod : VMStructs {
     }
 
     const char* immutableDataAt(int offset) {
-        if (_nmethod_immutable_offset > 0) {
+        // _nmethod_immutable_size_offset is armed only for pre-23 layouts (Dragonwell 11) that may
+        // keep immutable data inline; size 0 then means _immutable_data is a mere placeholder.
+        if (_nmethod_immutable_offset > 0 &&
+            (_nmethod_immutable_size_offset < 0 || *(int*) at(_nmethod_immutable_size_offset) > 0)) {
             return *(const char**) at(_nmethod_immutable_offset) + offset;
         }
         return at(offset);


### PR DESCRIPTION
### Description

Detect the pre-23 nmethod layout by JVM version instead of by the presence of `nmethod::_immutable_data`, and gate the separate immutable region on `_immutable_data_size`.

### Related issues

#1794 

### Motivation and context

Dragonwell 11 has a product flag `ReduceNMethodSize` (default **off**). When enabled, an nmethod's immutable data is moved out into a separately allocated `_immutable_data` region instead of staying inline.

- `_immutable_data` — depends on a **JVM flag** (`ReduceNMethodSize`)
- `_metadata_offset` semantics, i.e. `_data_offset` — depends only on the **JVM version**; the flag does not change it

### How has this been tested?

Dragonwell 11.0.31 aarch64, master `6b34212`:

| | `ReduceNMethodSize` off | on |
|---|---|---|
| master | crash | crash |
| version gate only | crash | ok |
| both gates | ok | ok |

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0