### PR TITLE
Support tracking allocations of JEP 401 value classes

### DIFF
--- a/src/objectSampler.cpp
+++ b/src/objectSampler.cpp
@@ -151,7 +151,7 @@ void ObjectSampler::recordAllocation(jvmtiEnv* jvmti, JNIEnv* jni, EventType eve
     event._class_id = lookupClassId(jvmti, object_klass);
 
     u64 trace = Profiler::instance()->recordSample(NULL, event._total_size, event_type, &event);
-    if (_live && trace != 0) {
+    if (_live && trace != 0 && object != NULL) {
         live_refs.add(jni, object, size, trace);
     }
 }

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -260,7 +260,7 @@ bool VM::init(JavaVM* vm, bool attach) {
     // this is just ignored and no harm is done.
     jvmtiCapabilities value_caps = {0};
     // can_support_value_objects is bit 45 (0-indexed) in jvmtiCapabilities
-    ((unsigned int*)&value_caps)[1] |= (1u << 13);
+    ((unsigned int*)&value_caps)[1] = (1u << 13);
     _jvmti->AddCapabilities(&value_caps);
 
     jvmtiEventCallbacks callbacks = {0};

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -250,6 +250,14 @@ bool VM::init(JavaVM* vm, bool attach) {
     capabilities.can_tag_objects = 1;
     _jvmti->AddCapabilities(&capabilities);
 
+    // Request value object support if available (JDK 28+ / Valhalla).
+    // This is needed so that SampledObjectAlloc events are fired for value class instances.
+    // AddCapabilities silently ignores unsupported capabilities on older JDKs.
+    jvmtiCapabilities value_caps = {0};
+    // can_support_value_objects is bit 45 (0-indexed) in jvmtiCapabilities
+    ((unsigned int*)&value_caps)[1] |= (1u << 13);
+    _jvmti->AddCapabilities(&value_caps);
+
     jvmtiEventCallbacks callbacks = {0};
     callbacks.VMInit = VMInit;
     callbacks.VMDeath = VMDeath;

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -252,15 +252,9 @@ bool VM::init(JavaVM* vm, bool attach) {
 
     // Request value object support if available (JDK 28+ / Valhalla).
     // This is needed so that SampledObjectAlloc events are fired for value class instances.
-    // AddCapabilities is deliberately called separately for value classes,
-    // because it returns JVMTI_ERROR_NOT_AVAILABLE on older versions.
-    // So, keeping a separate call only for value classes means that
-    // any errors reported here don't impact the rest of capabilities set above.
-    // The returned value of AddCapabilities below is ignored so if an error value is returned,
-    // this is just ignored and no harm is done.
+    // A separate call is to isolate unsupported capability on older JDKs.
     jvmtiCapabilities value_caps = {0};
-    // can_support_value_objects is bit 45 (0-indexed) in jvmtiCapabilities
-    ((unsigned int*)&value_caps)[1] = (1u << 13);
+    ((unsigned int*)&value_caps)[1] = 1u << 13;  // can_support_value_objects is bit 45
     _jvmti->AddCapabilities(&value_caps);
 
     jvmtiEventCallbacks callbacks = {0};

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -252,7 +252,12 @@ bool VM::init(JavaVM* vm, bool attach) {
 
     // Request value object support if available (JDK 28+ / Valhalla).
     // This is needed so that SampledObjectAlloc events are fired for value class instances.
-    // AddCapabilities silently ignores unsupported capabilities on older JDKs.
+    // AddCapabilities is deliberately called separately for value classes,
+    // because it returns JVMTI_ERROR_NOT_AVAILABLE on older versions.
+    // So, keeping a separate call only for value classes means that
+    // any errors reported here don't impact the rest of capabilities set above.
+    // The returned value of AddCapabilities below is ignored so if an error value is returned,
+    // this is just ignored and no harm is done.
     jvmtiCapabilities value_caps = {0};
     // can_support_value_objects is bit 45 (0-indexed) in jvmtiCapabilities
     ((unsigned int*)&value_caps)[1] |= (1u << 13);


### PR DESCRIPTION
### Description

Adds tracking of allocations for JEP 401 value classes.

### Related issues

It fixes issue #1786

### Motivation and context

Without the fix, no allocations of JEP 401 value classes are being tracked. You need to track this to understand how effective reference scalarization/flatterning is within the context of the given application.

### How has this been tested?

Verified that the reproducer in issue #1786 passes. Run `make test` successfully on darwin/aarch64.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
